### PR TITLE
Fix Issue #15

### DIFF
--- a/lib/r10k/git/working_dir.rb
+++ b/lib/r10k/git/working_dir.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require 'r10k/logging'
 require 'r10k/execution'
 require 'r10k/git/command'


### PR DESCRIPTION
`extend Forwardable` causes an error on Ubuntu 12.04 LTS. Explicitly requiring 'forwardable' resolves this issue.

```
/var/lib/gems/1.8/gems/r10k-0.0.10/lib/r10k/git/working_dir.rb:19: uninitialized constant R10K::Git::WorkingDir::Forwardable (NameError)
    from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
    from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `require'
    from /var/lib/gems/1.8/gems/r10k-0.0.10/lib/r10k/module/git.rb:3
```
