### PR TITLE
Fix module install from forge fails install when modules directory is not yet created

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -3,6 +3,7 @@ require 'r10k/module'
 require 'r10k/errors'
 require 'r10k/logging'
 
+require 'fileutils'
 require 'systemu'
 require 'semver'
 require 'json'
@@ -46,6 +47,7 @@ class Forge
       cmd << @full_name
       pmt cmd
     else
+      FileUtils.mkdir @basedir unless File.directory? @basedir
       #logger.debug "Module #{@full_name} is not installed"
       cmd = []
       cmd << 'install'


### PR DESCRIPTION
r10k version: 1.0.0rc3 d7fc40007713c1b7a8bd4df8eac6030a01a50212

Running "r10k deploy environment -p" on a new environment fails for forge modules.

Steps to reproduce
1. Create new environment
2. Create Puppetfile with both forge modules and git modules.
3. Run "r10k deploy environment -p".

What happens:

Forge modules fail to install. Git modules are installed. A second run of r10k installs the forge modules without error. The "git clone" command automatically creates parent directories.

Using some extra debug output, "puppet module install" prints

```
"Error: Could not install module 'adrien-pe_upgrade' (latest)\n  Directory /etc/puppetlabs/puppet/environments/master/modules does not exist"
```

What's expected:

r10k will create the modules directory prior to installing the forge modules.
