### PR TITLE
Add support for setting moduledir in the Puppetfile

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -57,6 +57,11 @@ class Puppetfile
     @forge = forge
   end
 
+  # @param [String] moduledir
+  def set_moduledir(moduledir)
+    @moduledir = moduledir
+  end
+
   # @param [String] name
   # @param [*Object] args
   def add_module(name, args)
@@ -97,6 +102,10 @@ class Puppetfile
 
     def forge(location)
       @librarian.set_forge(location)
+    end
+
+    def moduledir(location)
+      @librarian.set_moduledir(location)
     end
 
     def method_missing(method, *args)


### PR DESCRIPTION
Add support to allow the module to be set in the Puppetfile

Example:

```
moduledir '/etc/puppet/modules/production/puppetlabs/'

mod 'lvm',
  :git => 'https://github.com/puppetlabs/puppetlabs-lvm.git'
```
