### PR TITLE
Request for Comment: Support multiple moduledirs in a Puppetfile

### DIFF
--- a/lib/r10k/deployment/source.rb
+++ b/lib/r10k/deployment/source.rb
@@ -60,7 +60,7 @@ class Source
   # @note This implements a required method for the Purgeable mixin
   # @return [Array<String>]
   def desired_contents
-    @environments.map {|env| env.dirname }
+    @environments.map {|env| [ env.basedir , env.dirname].join('/') }
   end
 
   private

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -57,6 +57,11 @@ class Puppetfile
     @forge = forge
   end
 
+  # @param [String] moduledir
+  def set_moduledir(moduledir)
+    @moduledir = moduledir
+  end
+
   # @param [String] name
   # @param [*Object] args
   def add_module(name, args)
@@ -97,6 +102,10 @@ class Puppetfile
 
     def forge(location)
       @librarian.set_forge(location)
+    end
+
+    def moduledir(location)
+      @librarian.set_moduledir(location)
     end
 
     def method_missing(method, *args)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -20,6 +20,10 @@ class Puppetfile
   #   @return [String] The base directory that contains the Puppetfile
   attr_reader :basedir
 
+  # @!attribute [r] modbasedir
+  #   @return [String] The module base directory if set in Puppetfile 
+  attr_reader :modbasedir
+
   # @!attribute [r] moduledir
   #   @return [String] The directory to install the modules #{basedir}/modules
   attr_reader :moduledir
@@ -57,28 +61,50 @@ class Puppetfile
     @forge = forge
   end
 
+  # @param [String] modbasedir
+  def set_modbasedir(modbasedir)
+    @modbasedir = modbasedir
+  end
+
   # @param [String] moduledir
   def set_moduledir(moduledir)
-    @moduledir = moduledir
+    if ! @modbasedir
+     @moduledir = moduledir
+    else
+     @moduledir = File.join(@modbasedir, moduledir)
+    end
+    @moduledir
   end
 
   # @param [String] name
   # @param [*Object] args
   def add_module(name, args)
-    @modules << R10K::Module.new(name, @moduledir, args)
+    if ! args[:moduledir]
+      mod_dir = @moduledir
+    else
+      if @modbasedir.nil?
+        mod_dir = File.join(basedir, args[:moduledir])
+      else
+        mod_dir = File.join(@modbasedir, args[:moduledir])
+      end
+    end
+    @modules << R10K::Module.new(name, mod_dir, args)
   end
 
   include R10K::Util::Purgeable
 
   def managed_directory
-    @moduledir
+    @dirs = @modules.map { |mod| mod.basedir }.uniq
+    @dirs
   end
 
   # List all modules that should exist in the module directory
   # @note This implements a required method for the Purgeable mixin
   # @return [Array<String>]
   def desired_contents
-    @modules.map { |mod| mod.name }
+    @desired_dirs = @modules.map { |mod| [mod.basedir , mod.name].join("/") }
+    @desired_dirs << @modules.map { |mod| [mod.basedir] }.uniq
+    @desired_dirs.flatten.uniq
   end
 
   private
@@ -106,6 +132,10 @@ class Puppetfile
 
     def moduledir(location)
       @librarian.set_moduledir(location)
+    end
+
+    def basedir(location)
+      @librarian.set_modbasedir(location)
     end
 
     def method_missing(method, *args)

--- a/lib/r10k/task/puppetfile.rb
+++ b/lib/r10k/task/puppetfile.rb
@@ -79,7 +79,7 @@ module Puppetfile
     end
 
     def call
-      moduledir = @puppetfile.moduledir
+      moduledir = @puppetfile.managed_directory.uniq.join(', ')
 
       @puppetfile.load
 

--- a/lib/r10k/util/purgeable.rb
+++ b/lib/r10k/util/purgeable.rb
@@ -19,12 +19,17 @@ module Purgeable
 
   # @return [Array<String>] The present directory entries in `self.managed_directory`
   def current_contents
-    dir = self.managed_directory
-    glob_exp = File.join(dir, '*')
+    @dirs = []
+    @dirs <<  self.managed_directory
+    @fnames = []
 
-    Dir.glob(glob_exp).map do |fname|
-      File.basename fname
+    @dirs.flatten.each do |dir|
+      glob_exp = File.join(dir, '*')
+      @fnames << Dir.glob(glob_exp)
     end
+
+    @fnames.flatten
+
   end
 
   # @return [Array<String>] Directory contents that are expected but not present
@@ -40,8 +45,7 @@ module Purgeable
   # Forcibly remove all unmanaged content in `self.managed_directory`
   def purge!
     stale_contents.each do |fname|
-      fpath = File.join(self.managed_directory, fname)
-      FileUtils.rm_rf fpath, :secure => true
+      FileUtils.rm_rf fname, :secure => true
     end
   end
 


### PR DESCRIPTION
This is for discussion purposes.

Here is one possible way of doing multiple `moduledirs` in a Puppetfile.  I coded this to work with `r10k deploy environment -p`

Example Puppetfile:

```
moduledir 'my_modules'

mod 'lvm',
  :git => 'https://github.com/puppetlabs/puppetlabs-lvm.git',
  :moduledir => 'puppetlabs'

mod 'r10k',
  :git => 'https://github.com/adrienthebo/r10k.git'
```
