### PR TITLE
When moduledir is relative, prepend the basedir

### DIFF
--- a/lib/r10k/module.rb
+++ b/lib/r10k/module.rb
@@ -2,7 +2,6 @@ require 'r10k'
 require 'r10k/util/path'
 
 module R10K::Module
-  include R10K::Util::Path
 
   # Register an inheriting  class for later generation
   def self.included(klass)
@@ -30,7 +29,7 @@ module R10K::Module
     @basedir = basedir
 
     if args.is_a? Hash and args.has_key?(:moduledir)
-      raise "Setting an absolute :moduledir path is not supported in this place!" if is_absolute?(args[:moduledir])
+      raise "Setting an absolute :moduledir path is not supported in this place!" if R10K::Util::Path.is_absolute?(args[:moduledir])
       @moduledir = File.join(@basedir, args[:moduledir])
     end
 

--- a/lib/r10k/module.rb
+++ b/lib/r10k/module.rb
@@ -17,24 +17,33 @@ module R10K::Module
   # with `name, args`, and generates an object of that class.
   #
   # @param [String] name The unique name of the module
-  # @param [String] basedir The root to install the module in
+  # @param [String] basedir The root of the module installations, in case we have to modify moduledir
+  # @param [String] moduledir The root to install the module in
   # @param [Object] args An arbitary value or set of values that specifies the implementation
   #
   # @return [Object < R10K::Module] A member of the implementing subclass
-  def self.new(name, basedir, args)
+  def self.new(name, basedir, moduledir, args)
+
+    @moduledir = moduledir
+    @basedir = basedir
+
+    if args.is_a? Hash and args.has_key?(:moduledir)
+      @moduledir = File.join(@basedir, args[:moduledir])
+    end
+
     if implementation = @klasses.find { |klass| klass.implement?(name, args) }
-      obj = implementation.new(name, basedir, args)
+      obj = implementation.new(name, @moduledir, args)
       obj
     else
       raise "Module #{name} with args #{args.inspect} doesn't have an implementation. (Are you using the right arguments?)"
     end
   end
 
-  attr_accessor :name, :basedir
+  attr_accessor :name, :basedir, :moduledir
 
   # @return [String] The full filesystem path to the module.
   def full_path
-    File.join(@basedir, @name)
+    File.join(@moduledir, @name)
   end
 end
 

--- a/lib/r10k/module.rb
+++ b/lib/r10k/module.rb
@@ -1,6 +1,8 @@
 require 'r10k'
+require 'r10k/util/path'
 
 module R10K::Module
+  include R10K::Util::Path
 
   # Register an inheriting  class for later generation
   def self.included(klass)
@@ -28,6 +30,7 @@ module R10K::Module
     @basedir = basedir
 
     if args.is_a? Hash and args.has_key?(:moduledir)
+      raise "Setting an absolute :moduledir path is not supported in this place!" if is_absolute?(args[:moduledir])
       @moduledir = File.join(@basedir, args[:moduledir])
     end
 

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -22,9 +22,9 @@ class Forge
 
   attr_accessor :owner, :full_name
 
-  def initialize(name, basedir, args)
+  def initialize(name, moduledir, args)
     @full_name = name
-    @basedir   = basedir
+    @moduledir   = moduledir
 
     @owner, @name = name.split('/')
 
@@ -47,7 +47,7 @@ class Forge
       cmd << @full_name
       pmt cmd
     else
-      FileUtils.mkdir @basedir unless File.directory? @basedir
+      FileUtils.mkdir @moduledir unless File.directory? @moduledir
       #logger.debug "Module #{@full_name} is not installed"
       cmd = []
       cmd << 'install'
@@ -82,8 +82,8 @@ class Forge
   private
 
   def pmt(args)
-    cmd = "puppet module --modulepath '#{@basedir}' #{args.join(' ')}"
-    log_event = "puppet module #{args.join(' ')}, modulepath: #{@basedir.inspect}"
+    cmd = "puppet module --modulepath '#{@moduledir}' #{args.join(' ')}"
+    log_event = "puppet module #{args.join(' ')}, modulepath: #{@moduledir.inspect}"
     logger.debug1 "Execute: #{cmd}"
 
     status, stdout, stderr = systemu(cmd)

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -17,13 +17,13 @@ class Git
   extend Forwardable
   def_delegator :@working_dir, :sync
 
-  def initialize(name, basedir, args)
-    @name, @basedir, @args = name, basedir, args
+  def initialize(name, moduledir, args)
+    @name, @moduledir, @args = name, moduledir, args
 
     @remote = @args[:git]
     @ref    = (@args[:ref] || 'master')
 
-    @working_dir = R10K::Git::WorkingDir.new(@ref, @remote, @basedir, @name)
+    @working_dir = R10K::Git::WorkingDir.new(@ref, @remote, @moduledir, @name)
   end
 
   def version

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -59,11 +59,9 @@ class Puppetfile
   end
 
 
-  include R10K::Util::Path
-
   # @param [String] moduledir
   def set_moduledir(moduledir)
-    if is_relative?(moduledir)
+    if R10K::Util::Path.is_relative?(moduledir)
       moduledir = File.join(@basedir, moduledir)
     end
     @moduledir = moduledir

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -59,6 +59,8 @@ class Puppetfile
 
   # @param [String] moduledir
   def set_moduledir(moduledir)
+    # If moduledir is relative, prepend basedir
+    moduledir = if File.expand_path(moduledir) != moduledir then  File.join(@basedir, moduledir) end
     @moduledir = moduledir
   end
 

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -72,7 +72,7 @@ class Puppetfile
   # @param [String] name
   # @param [*Object] args
   def add_module(name, args)
-    @modules << R10K::Module.new(name, @moduledir, args)
+    @modules << R10K::Module.new(name, @basedir, @moduledir, args)
   end
 
   include R10K::Util::Purgeable

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -1,6 +1,7 @@
 require 'r10k/module'
 require 'r10k/logging'
 require 'r10k/util/purgeable'
+require 'r10k/util/path'
 
 module R10K
 class Puppetfile
@@ -57,10 +58,14 @@ class Puppetfile
     @forge = forge
   end
 
+
+  include R10K::Util::Path
+
   # @param [String] moduledir
   def set_moduledir(moduledir)
-    # If moduledir is relative, prepend basedir
-    moduledir = if File.expand_path(moduledir) != moduledir then  File.join(@basedir, moduledir) end
+    if is_relative?(moduledir)
+      moduledir = File.join(@basedir, moduledir)
+    end
     @moduledir = moduledir
   end
 

--- a/lib/r10k/task/module.rb
+++ b/lib/r10k/task/module.rb
@@ -9,7 +9,7 @@ module Module
     end
 
     def call
-      logger.info "Deploying #{@mod.name} into #{@mod.basedir}"
+      logger.info "Deploying #{@mod.name} into #{@mod.moduledir}"
       @mod.sync
     end
   end

--- a/lib/r10k/util/path.rb
+++ b/lib/r10k/util/path.rb
@@ -1,0 +1,24 @@
+
+module R10K; end
+module R10K::Util; end
+
+module R10K::Util::Path
+
+  # Check if path is absolute
+  #
+  # @param [String] path
+  #
+  # @return [Boolean]
+  def is_absolute?(path)
+    File.expand_path(path) == path
+  end
+
+  # Check if path is relative
+  #
+  # @param [String] path
+  #
+  # @return [Boolean]
+  def is_relative?(path)
+    File.expand_path(path) != path
+  end
+end

--- a/lib/r10k/util/path.rb
+++ b/lib/r10k/util/path.rb
@@ -4,6 +4,9 @@ module R10K::Util; end
 
 module R10K::Util::Path
 
+  # Make all functions here module functions, not instance functions.
+  module_function
+
   # Check if path is absolute
   #
   # @param [String] path


### PR DESCRIPTION
The basic premise works, however right now we're appending the moduledir
again at the end. That shouldn't happen (imo), but maybe I'm
misunderstanding some core-concept of r10k here.

In general, this fixes #43  and when used with `moduledir ''` it also accommodates for different use-cases, such as managing more than just modules with r10k.
