### PR TITLE
Added a check option to allow the testing of a Puppetfile

### DIFF
--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -49,7 +49,33 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
       end
     end
     self.command.add_command(Install.command)
-
+    module Check
+      def self.command
+        @cmd ||= Cri::Command.define do
+          name  'check'
+          usage 'check'
+          summary 'Try and load the Puppetfile to verify the syntax is correct.'
+          run do |opts,args,cmd|
+            puppetfile_root = Dir.getwd
+            puppetfile_path = ENV['PUPPETFILE_DIR']
+            puppetfile      = ENV['PUPPETFILE']
+            
+            puppetfile = R10K::Puppetfile.new(puppetfile_root, puppetfile_path, puppetfile)
+            begin
+              puppetfile.load
+            rescue Exception => ex
+              puts "ERROR: Puppetfile bad syntax"
+              ex.backtrace.each do |line|
+                  puts line
+              end
+              exit 1
+            end
+            exit 0
+          end
+        end
+      end
+    end
+    self.command.add_command(Check.command)
     module Purge
       def self.command
         @cmd ||= Cri::Command.define do

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -63,8 +63,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
             puppetfile = R10K::Puppetfile.new(puppetfile_root, puppetfile_path, puppetfile)
             begin
               puppetfile.load
-            rescue Exception => ex
-              puts "ERROR: Puppetfile bad syntax"
+            rescue LoadError => ex
+              $stderr.puts "ERROR: Puppetfile bad syntax"
               ex.backtrace.each do |line|
                   puts line
               end


### PR DESCRIPTION
``` bash
=>> r10k puppetfile check
{alevy@toodles-galore r10k} [11:45:44] |ruby-1.9.3@puppet-3.x| (lindenle_check %)
 =>> echo $?
0
{alevy@toodles-galore r10k} [11:45:47] |ruby-1.9.3@puppet-3.x| (lindenle_check %)
 =>> emacs Puppetfile
{alevy@toodles-galore r10k} [11:45:51] |ruby-1.9.3@puppet-3.x| (lindenle_check %)
 =>> r10k puppetfile check
ERROR: Puppetfile bad syntax
/Users/alevy/vcsworking/r10k/lib/r10k/puppetfile.rb:52:in `instance_eval'
/Users/alevy/vcsworking/r10k/lib/r10k/puppetfile.rb:52:in `load!'
/Users/alevy/vcsworking/r10k/lib/r10k/puppetfile.rb:44:in `load'
/Users/alevy/vcsworking/r10k/lib/r10k/cli/puppetfile.rb:65:in `block (2 levels) in command'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/gems/cri-2.3.0/lib/cri/command.rb:296:in `call'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/gems/cri-2.3.0/lib/cri/command.rb:296:in `run_this'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/gems/cri-2.3.0/lib/cri/command.rb:249:in `run'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/gems/cri-2.3.0/lib/cri/command.rb:262:in `run'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/gems/cri-2.3.0/lib/cri/command.rb:262:in `run'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/gems/r10k-1.0.0/bin/r10k:7:in `<top (required)>'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/bin/r10k:19:in `load'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/bin/r10k:19:in `<main>'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/bin/ruby_noexec_wrapper:14:in `eval'
/Users/alevy/.rvm/gems/ruby-1.9.3-p448@puppet-3.x/bin/ruby_noexec_wrapper:14:in `<main>'
```
