### PR TITLE
Also checkout the environment's branch after cloning the environment.

### DIFF
--- a/lib/r10k/git/working_dir.rb
+++ b/lib/r10k/git/working_dir.rb
@@ -78,6 +78,7 @@ class WorkingDir < R10K::Git::Repository
     # that doing a normal `git pull` on a directory will work.
     git "clone --reference #{@cache.path} #{@remote} #{@full_path}"
     git "remote add cache #{@cache.path}", :path => @full_path
+    git "checkout #{@ref}", :path => @full_path
   end
 
   def fetch


### PR DESCRIPTION
When doing a

```
r10k deploy environment
```

The result will be a directory tree like:

```
etc
+-- puppet
    +-- environments
        +-- development
        +-- integration
        +-- production
        +-- test-feature-foo
        +-- test-feature-bar
```

Whereas each environment represents a branch of the source repository.

The problem is with the respective environment's directory: instead of containing the respective branch, it'll always contain a checkout of the `production` branch (I wasn't able yet to find out what causes here the default to `production` instead of something else like the first branch name in alpha-numerical order like `development`).

This PR ensures, the corresponding environment's branch is checked out from the cloned repository.

It would be also possible to clone a specific branch right away (`git clone --branch --single-branch …`), but this would break functionality for < git 1.7.10.
