### PR TITLE
Purge each basedir separately

### DIFF
--- a/lib/r10k/deployment/basedir.rb
+++ b/lib/r10k/deployment/basedir.rb
@@ -1,0 +1,38 @@
+require 'r10k/git/cache'
+require 'r10k/deployment/environment'
+require 'r10k/util/purgeable'
+
+module R10K
+class Deployment
+class Basedir
+  # Represents a directory containing environments
+
+  def initialize(path,deployment)
+    @path       = path
+    @deployment = deployment
+  end
+
+  include R10K::Util::Purgeable
+
+  # Return the path of the basedir
+  # @note This implements a required method for the Purgeable mixin
+  # @return [String]
+  def managed_directory
+    @path
+  end
+
+  # List all environments that should exist in this basedir
+  # @note This implements a required method for the Purgeable mixin
+  # @return [Array<String>]
+  def desired_contents
+    @keepers = []
+    @deployment.sources.each do |source|
+      next unless source.managed_directory == @path
+      @keepers += source.desired_contents
+    end
+    @keepers
+  end
+
+end
+end
+end

--- a/lib/r10k/deployment/source.rb
+++ b/lib/r10k/deployment/source.rb
@@ -1,5 +1,6 @@
 require 'r10k/git/cache'
 require 'r10k/deployment/environment'
+require 'r10k/deployment/basedir'
 require 'r10k/util/purgeable'
 
 module R10K

--- a/lib/r10k/task/deployment.rb
+++ b/lib/r10k/task/deployment.rb
@@ -102,21 +102,14 @@ module Deployment
 
     def initialize(deployment)
       @deployment = deployment
+      @basedirs   = @deployment.sources.map { |x| x.basedir }.uniq
     end
 
     def call
-      @deployment.sources.each do |source|
-        stale_envs = source.stale_contents
-
-        dir = source.managed_directory
-
-        if stale_envs.empty?
-          logger.debug "No stale environments in #{dir}"
-        else
-          logger.info "Purging stale environments from #{dir}"
-          logger.debug "Stale modules in #{dir}: #{stale_envs.join(', ')}"
-          source.purge!
-        end
+      @basedirs.each do |path|
+        basedir = R10K::Deployment::Basedir.new(path,@deployment)
+        logger.info "Purging stale environments from #{path}"
+        basedir.purge!
       end
     end
   end


### PR DESCRIPTION
This should close #64

Given a configuration like this:

```
cachedir: '/srv/puppet/cache'
sources:
  one:
    remote: '/srv/puppet/puppet.git/'
    basedir: '/srv/puppet/env_test'
    prefix: false
  two:
    remote: '/srv/puppet/puppet.git/'
    basedir: '/srv/puppet/env_test'
  three:
    remote: '/srv/puppet/puppet.git/'
    basedir: '/srv/puppet/env_test_more'
```

Output from "r10k deploy environment --verbose" is:

```
[R10K::Task::Deployment::DeployEnvironments - INFO] Loading environments from all sources
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment three_testing
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment three_production
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment three_master
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment two_testing
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment two_production
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment two_master
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment testing
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment production
[R10K::Task::Environment::Deploy - NOTICE] Deploying environment master
[R10K::Task::Deployment::PurgeEnvironments - INFO] Purging stale environments from /srv/puppet/env_test
[R10K::Task::Deployment::PurgeEnvironments - INFO] Purging stale environments from /srv/puppet/env_test_more
```

Result is:

```
# ls /srv/puppet/env_test*
/srv/puppet/env_test:
master  production  testing  two_master  two_production  two_testing

/srv/puppet/env_test_more:
three_master  three_production  three_testing
```
