### PR TITLE
Feature: Implement locking an environment to a ref

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -261,6 +261,21 @@ without being able to accidentally impact other groups.
         remote: 'git@github.com:my-org/app2-environments'
         basedir: '/etc/puppet/environments'
 
+### Locking an environment to a ref
+
+You may want to lock an environment to a specific git ref (such as a 'tested' tag). This can be specified in the
+yaml configuration file.
+
+        :cachedir: '/var/cache/r10k'
+        :sources:
+          # branch in /etc/puppet/environments
+          :plops:
+            remote: 'git@github.com:my-org/org-shared-modules'
+            basedir: '/etc/puppet/environments'
+            environment:
+              master:
+                ref: 'tested'
+
 More information
 ----------------
 

--- a/lib/r10k/deployment/environment.rb
+++ b/lib/r10k/deployment/environment.rb
@@ -28,12 +28,12 @@ class Environment
   # @param [String] basedir
   # @param [String] dirname The directory to clone the root into, defaults to ref
   # @param [String] source_name An additional string which may be used with ref to build dirname
-  def initialize(ref, remote, basedir, dirname = nil, source_name = "")
+  def initialize(ref, remote, basedir, source_name = "")
     @ref     = ref
     @remote  = remote
     @basedir = basedir
     alternate_name =  source_name.empty? ? ref : source_name + "_" + ref
-    @dirname = sanitize_dirname(dirname || alternate_name)
+    @dirname = sanitize_dirname(alternate_name)
 
     @working_dir = R10K::Git::WorkingDir.new(@ref, @remote, @basedir, @dirname)
 

--- a/lib/r10k/deployment/environment.rb
+++ b/lib/r10k/deployment/environment.rb
@@ -7,9 +7,9 @@ class Environment
 
   include R10K::Logging
 
-  # @!attribute [r] ref
-  #   The git ref to instantiate into the basedir
-  attr_reader :ref
+  # @!attribute [r] name
+  #   The git name to instantiate into the basedir
+  attr_reader :name
 
   # @!attribute [r] remote
   #   The location of the remote git repository
@@ -23,19 +23,19 @@ class Environment
   #   @return [String] The directory name to use for the environment
   attr_reader :dirname
 
-  # @param [String] ref
+  # @param [String] name
   # @param [String] remote
   # @param [String] basedir
-  # @param [String] dirname The directory to clone the root into, defaults to ref
-  # @param [String] source_name An additional string which may be used with ref to build dirname
-  def initialize(ref, remote, basedir, source_name = "")
-    @ref     = ref
+  # @param [String] dirname The directory to clone the root into, defaults to name
+  # @param [String] source_name An additional string which may be used with name to build dirname
+  def initialize(name, remote, basedir, source_name = "")
+    @name     = name
     @remote  = remote
     @basedir = basedir
-    alternate_name =  source_name.empty? ? ref : source_name + "_" + ref
+    alternate_name =  source_name.empty? ? name : source_name + "_" + name
     @dirname = sanitize_dirname(alternate_name)
 
-    @working_dir = R10K::Git::WorkingDir.new(@ref, @remote, @basedir, @dirname)
+    @working_dir = R10K::Git::WorkingDir.new(@name, @remote, @basedir, @dirname)
 
     @full_path = File.join(@basedir, @dirname)
   end

--- a/lib/r10k/deployment/environment.rb
+++ b/lib/r10k/deployment/environment.rb
@@ -23,19 +23,24 @@ class Environment
   #   @return [String] The directory name to use for the environment
   attr_reader :dirname
 
+  # @!attribute [r] ref
+  #   @return [String] Git ref that this environment is based on
+  attr_reader :ref
+
   # @param [String] name
   # @param [String] remote
   # @param [String] basedir
-  # @param [String] dirname The directory to clone the root into, defaults to name
   # @param [String] source_name An additional string which may be used with name to build dirname
-  def initialize(name, remote, basedir, source_name = "")
+  # @param [String] ref Optional git ref to use
+  def initialize(name, remote, basedir, source_name = nil, ref = nil)
     @name     = name
     @remote  = remote
     @basedir = basedir
-    alternate_name =  source_name.empty? ? name : source_name + "_" + name
+    alternate_name =  source_name.nil? ? name : source_name + "_" + name
     @dirname = sanitize_dirname(alternate_name)
+    @ref = ref.nil? ? name : ref
 
-    @working_dir = R10K::Git::WorkingDir.new(@name, @remote, @basedir, @dirname)
+    @working_dir = R10K::Git::WorkingDir.new(@ref, @remote, @basedir, @dirname)
 
     @full_path = File.join(@basedir, @dirname)
   end

--- a/lib/r10k/deployment/source.rb
+++ b/lib/r10k/deployment/source.rb
@@ -97,7 +97,7 @@ class Source
     if @cache.cached?
       @environments = @cache.branches.map do |branch|
         if @prefix
-          R10K::Deployment::Environment.new(branch, @remote, @basedir, nil, @name.to_s())
+          R10K::Deployment::Environment.new(branch, @remote, @basedir, @name.to_s())
         else
           R10K::Deployment::Environment.new(branch, @remote, @basedir)
         end

--- a/lib/r10k/deployment/source.rb
+++ b/lib/r10k/deployment/source.rb
@@ -53,12 +53,12 @@ class Source
     new(name, remote, basedir, prefix_outcome, environment_refs)
   end
 
-  def initialize(name, remote, basedir, prefix = nil, environment_refs = {})
+  def initialize(name, remote, basedir, prefix = nil, environment_refs = nil)
     @name    = name
     @remote  = remote
     @basedir = basedir
     @prefix = prefix.nil? ? false : prefix
-    @environment_refs = environment_refs
+    @environment_refs = environment_refs.nil? ? {} : environment_refs
 
     @cache   = R10K::Git::Cache.generate(@remote)
 

--- a/lib/r10k/deployment/source.rb
+++ b/lib/r10k/deployment/source.rb
@@ -46,17 +46,19 @@ class Source
     remote  = (attrs.delete(:remote) || attrs.delete('remote'))
     basedir = (attrs.delete(:basedir) || attrs.delete('basedir'))
     prefix_config = (attrs.delete(:prefix) || attrs.delete('prefix'))
+    environment_refs = (attrs.delete(:environment) || attrs.delete('environment'))
     prefix_outcome = prefix_config.nil? ? prefix : prefix_config
 
     raise ArgumentError, "Unrecognized attributes for #{self.name}: #{attrs.inspect}" unless attrs.empty?
-    new(name, remote, basedir, prefix_outcome)
+    new(name, remote, basedir, prefix_outcome, environment_refs)
   end
 
-  def initialize(name, remote, basedir, prefix = nil)
+  def initialize(name, remote, basedir, prefix = nil, environment_refs = {})
     @name    = name
     @remote  = remote
     @basedir = basedir
     @prefix = prefix.nil? ? false : prefix
+    @environment_refs = environment_refs
 
     @cache   = R10K::Git::Cache.generate(@remote)
 
@@ -97,15 +99,24 @@ class Source
     if @cache.cached?
       @environments = @cache.branches.map do |branch|
         if @prefix
-          R10K::Deployment::Environment.new(branch, @remote, @basedir, @name.to_s())
+          R10K::Deployment::Environment.new(branch, @remote, @basedir, @name.to_s(), branch_ref(branch))
         else
-          R10K::Deployment::Environment.new(branch, @remote, @basedir)
+          R10K::Deployment::Environment.new(branch, @remote, @basedir, nil, branch_ref(branch))
         end
       end
     else
       @environments = []
     end
   end
+
+  def branch_ref(branch)
+    begin
+      @environment_refs.fetch(branch).fetch('ref')
+    rescue IndexError
+      branch
+    end
+  end
+
 end
 end
 end

--- a/spec/unit/deployment/environment_spec.rb
+++ b/spec/unit/deployment/environment_spec.rb
@@ -4,6 +4,7 @@ require 'r10k/deployment/environment'
 describe R10K::Deployment::Environment do
   let(:remote) { 'git://github.com/adrienthebo/r10k-fixture-repo' }
   let(:name)    { 'master' }
+  let(:ref)     { 'v1.0' }
 
   describe 'dirname' do
     it 'uses the environment name as the default dirname' do
@@ -16,5 +17,28 @@ describe R10K::Deployment::Environment do
       subject.dirname.should == 'the_master'
     end
 
+    it 'is not affected by the ref passed in when using the default dirname' do
+      subject = described_class.new(name, remote, '/tmp', nil, ref)
+      subject.dirname.should == 'master'
+    end
+
+    it 'is not affected by the ref passed in when using a provided source name' do
+      subject = described_class.new(name, remote, '/tmp', "the", ref)
+      subject.dirname.should == 'the_master'
+    end
+
   end
+
+  describe 'ref' do
+    it 'is the ref passed as a constructor arg' do
+      subject = described_class.new(name, remote, '/tmp', nil, ref)
+      subject.ref.should == 'v1.0'
+    end
+
+    it 'is the name of the environment if no ref constructor arg is given' do
+      subject = described_class.new(name, remote, '/tmp')
+      subject.ref.should == 'master'
+    end
+  end
+
 end

--- a/spec/unit/deployment/environment_spec.rb
+++ b/spec/unit/deployment/environment_spec.rb
@@ -12,13 +12,9 @@ describe R10K::Deployment::Environment do
     end
 
     it 'uses the ref and a provided source name in the default dirname' do
-      subject = described_class.new(ref, remote, '/tmp', nil, "the")
+      subject = described_class.new(ref, remote, '/tmp', "the")
       subject.dirname.should == 'the_master'
     end
 
-    it 'allows a specific dirname to be set' do
-      subject = described_class.new(ref, remote, '/tmp', 'sourcename_master')
-      subject.dirname.should == 'sourcename_master'
-    end
   end
 end

--- a/spec/unit/deployment/environment_spec.rb
+++ b/spec/unit/deployment/environment_spec.rb
@@ -3,16 +3,16 @@ require 'r10k/deployment/environment'
 
 describe R10K::Deployment::Environment do
   let(:remote) { 'git://github.com/adrienthebo/r10k-fixture-repo' }
-  let(:ref)    { 'master' }
+  let(:name)    { 'master' }
 
   describe 'dirname' do
-    it 'uses the ref as the default dirname' do
-      subject = described_class.new(ref, remote, '/tmp')
+    it 'uses the environment name as the default dirname' do
+      subject = described_class.new(name, remote, '/tmp')
       subject.dirname.should == 'master'
     end
 
-    it 'uses the ref and a provided source name in the default dirname' do
-      subject = described_class.new(ref, remote, '/tmp', "the")
+    it 'uses the environment name and a provided source name in the default dirname' do
+      subject = described_class.new(name, remote, '/tmp', "the")
       subject.dirname.should == 'the_master'
     end
 

--- a/spec/unit/deployment/source_spec.rb
+++ b/spec/unit/deployment/source_spec.rb
@@ -21,4 +21,38 @@ describe R10K::Deployment::Source do
       subject.environments.first.dirname.should_not start_with name
     end
   end
+
+  describe 'environments' do
+
+    let(:branch1) { double(:ref => "branch1") }
+    let(:environment1) { double(:ref => "environment1") }
+    let(:branch2) { double(:ref => "branch2") }
+    let(:environment2) { double(:ref => "environment2") }
+    let(:cache)   { double(:sync => nil, :cached? => true, :branches =>  [branch1, branch2] ) }
+
+    before :each do
+      R10K::Git::Cache.stub(:generate).and_return(cache)
+    end
+
+    context 'when prefix is not set' do
+      it 'creates an environment for each git branch' do
+        R10K::Deployment::Environment.should_receive(:new).with(branch1, remote, basedir).and_return environment1
+        R10K::Deployment::Environment.should_receive(:new).with(branch2, remote, basedir).and_return environment2
+        subject = described_class.new(name, remote, basedir, false)
+        subject.environments.should  match_array [environment1, environment2]
+      end
+    end
+
+    context 'when prefix is set' do
+      it 'creates an environment for each git branch with source name set' do
+        R10K::Deployment::Environment.should_receive(:new).with(branch1, remote, basedir, nil, name).and_return environment1
+        R10K::Deployment::Environment.should_receive(:new).with(branch2, remote, basedir, nil, name).and_return environment2
+        subject = described_class.new(name, remote, basedir, true)
+        subject.environments.should  match_array [environment1, environment2]
+      end
+    end
+
+
+  end
+
 end

--- a/spec/unit/deployment/source_spec.rb
+++ b/spec/unit/deployment/source_spec.rb
@@ -45,8 +45,8 @@ describe R10K::Deployment::Source do
 
     context 'when prefix is set' do
       it 'creates an environment for each git branch with source name set' do
-        R10K::Deployment::Environment.should_receive(:new).with(branch1, remote, basedir, nil, name).and_return environment1
-        R10K::Deployment::Environment.should_receive(:new).with(branch2, remote, basedir, nil, name).and_return environment2
+        R10K::Deployment::Environment.should_receive(:new).with(branch1, remote, basedir, name).and_return environment1
+        R10K::Deployment::Environment.should_receive(:new).with(branch2, remote, basedir, name).and_return environment2
         subject = described_class.new(name, remote, basedir, true)
         subject.environments.should  match_array [environment1, environment2]
       end


### PR DESCRIPTION
Heya

I've added a feature that allows a user to configure locking a git ref (our use case: a git tag) to an environment. I've added some extra test coverage and cleaned up some unused constructor args while I was digging in the area.

rspec tests all pass, although I did have some trouble running `rake spec:system` (although the failures are in a different area).

Cheers!
