### PR TITLE
Add $basedir to $moduledir if not absolute path (solves #44)

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -59,7 +59,11 @@ class Puppetfile
 
   # @param [String] moduledir
   def set_moduledir(moduledir)
-    @moduledir = moduledir
+    if moduledir[0] != 47   # ASCII for '/' (adds $basedir if not absolute path)
+      @moduledir = File.join(@basedir, moduledir)
+    else
+      @moduledir = moduledir
+    end
   end
 
   # @param [String] name


### PR DESCRIPTION
Having new directories created to $CMD does not seem to have any practical use... so this should not break backwards compatibility.
It solves #44 very simply.
