### PR TITLE
Feature/extra parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -265,6 +265,36 @@ without being able to accidentally impact other groups.
         remote: 'git@github.com:my-org/app2-environments'
         basedir: '/etc/puppet/environments'
 
+
+### Single Environment Repository with multiple Puppetfiles
+
+It is also possible to extend the use of environments beyond the modules themselves, by creating multiple sources that point to the same remote, each pulling from a different `Puppetfile` and deploying to a different subdirectory, by using the `puppetfile:` and the `subdir:` parameters. This is specially interesting for those cases when you need to sync groups of repositories like site manifests, hieradata, roles or profiles.
+
+For example:
+
+    :sources:
+      # This will clone the git repository and instantiate an environment per
+      # branch in /etc/puppet/environments
+      :modules:
+        remote: 'git@github.com:my-org/site-environments'
+        basedir: '/etc/puppet/environments'
+      :manifests:
+        remote: 'git@github.com:my-org/site-environments'
+        basedir: '/etc/puppet/environments'
+        puppetfile: 'Puppetfile.manifests'
+        subdir: 'manifests'
+      :hieradata:
+        remote: 'git@github.com:my-org/site-environments'
+        basedir: '/etc/puppet/environments'
+        puppetfile: 'Puppetfile.hiera'
+        subdir: 'hieradata'
+
+The Environment Repository (site-environments) would need to have at least three files: Puppetfile (default), Puppetfile.manifests and Puppetfile.hieradata. All those three $puppetfile files would have the same format, but each would be deployed in a different subdirectory below the environment name, with the shape $basedir/<env_branch>/$subdir:
+- git repositories defined in Puppetfile (branch X) would be deployed in /etc/puppet/environments/X/modules (default)
+- git repositories defined in Puppetfile.manifests (branch X) would be deployed in /etc/puppet/environments/X/manifests
+- git repositories defined in Puppetfile.hiera (branch X) would be deployed in /etc/puppet/environments/X/hieradata
+
+
 More information
 ----------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -289,7 +289,7 @@ For example:
         puppetfile: 'Puppetfile.hiera'
         subdir: 'hieradata'
 
-The Environment Repository (site-environments) would need to have at least three files: Puppetfile (default), Puppetfile.manifests and Puppetfile.hieradata. All those three $puppetfile files would have the same format, but each would be deployed in a different subdirectory below the environment name, with the shape $basedir/<env_branch>/$subdir:
+The Environment Repository (site-environments) would need to have at least three files: Puppetfile (default), Puppetfile.manifests and Puppetfile.hiera. All those three $puppetfile files would have the same format, but each would be deployed in a different subdirectory below the environment name, with the shape $basedir/<env_branch>/$subdir:
 - git repositories defined in Puppetfile (branch X) would be deployed in /etc/puppet/environments/X/modules (default)
 - git repositories defined in Puppetfile.manifests (branch X) would be deployed in /etc/puppet/environments/X/manifests
 - git repositories defined in Puppetfile.hiera (branch X) would be deployed in /etc/puppet/environments/X/hieradata

--- a/lib/r10k/deployment/environment.rb
+++ b/lib/r10k/deployment/environment.rb
@@ -28,13 +28,15 @@ class Environment
   # @param [String] basedir
   # @param [String] dirname The directory to clone the root into, defaults to ref
   # @param [String] source_name An additional string which may be used with ref to build dirname
-  def initialize(ref, remote, basedir, dirname = nil, source_name = "")
+  def initialize(ref, remote, basedir, dirname = nil, source_name = "", puppetfile_file = nil, subdir = nil)
     @ref     = ref
     @remote  = remote
     @basedir = basedir
     alternate_name =  source_name.empty? ? ref : source_name + "_" + ref
     @dirname = sanitize_dirname(dirname || alternate_name)
-
+    @puppetfile_file = puppetfile_file
+    @subdir = subdir
+    
     @working_dir = R10K::Git::WorkingDir.new(@ref, @remote, @basedir, @dirname)
 
     @full_path = File.join(@basedir, @dirname)
@@ -57,7 +59,7 @@ class Environment
   end
 
   def puppetfile
-    @puppetfile ||= R10K::Puppetfile.new(@full_path)
+    @puppetfile ||= R10K::Puppetfile.new(@full_path, @subdir, @puppetfile_file)
   end
 
   def modules

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -30,10 +30,10 @@ class Puppetfile
 
   # @param [String] basedir
   # @param [String] puppetfile The path to the Puppetfile, default to #{basedir}/Puppetfile
-  def initialize(basedir, moduledir = nil, puppetfile = nil)
+  def initialize(basedir, moduledir = 'modules', puppetfile = 'Puppetfile')
     @basedir         = basedir
-    @moduledir       = moduledir  || File.join(basedir, 'modules')
-    @puppetfile_path = puppetfile || File.join(basedir, 'Puppetfile')
+    @moduledir       = File.join(basedir, moduledir)
+    @puppetfile_path = File.join(basedir, puppetfile)
 
     @modules = []
     @forge   = 'forge.puppetlabs.com'

--- a/lib/r10k/task/puppetfile.rb
+++ b/lib/r10k/task/puppetfile.rb
@@ -12,7 +12,7 @@ module Puppetfile
     end
 
     def call
-      logger.info "Loading modules from Puppetfile into queue"
+      logger.info "Loading modules from #{@puppetfile.puppetfile_path} into queue"
 
       @puppetfile.load
       @puppetfile.modules.each do |mod|


### PR DESCRIPTION
Hi,

This adds two optional parameters (puppetfile and subdir) to each source inside /etc/r10k.yaml, that used to be pre-defined constants (Puppetfile and modules, respectively). This adds a lot of flexibility by allowing other non-modules repositories to be deployed with r10k as well (like hieradata, roles, etc) 

For example:

```
:sources:
  # This will clone the git repository and instantiate an environment per
  # branch in /etc/puppet/environments
  :moria_modules:
    remote: 'xxx.xx:/git/puppet/config/moria-site.git'
    basedir: '/root/environments'
    puppetfile: 'Puppetfile.modules'
    subdir: 'modules'

  :moria_roles:
    remote: 'xxx.xx:/git/puppet/config/moria-site.git'
    basedir: '/root/environments'
    puppetfile: 'Puppetfile.roles'
    subdir: 'roles'

  :moria_hieradata:
    remote: 'xxx.xx:/git/puppet/config/moria-site.git'
    basedir: '/root/environments'
    puppetfile: 'Puppetfile.hieradata'
    subdir: 'hieradata'
```

This would take each source and deploy, based on different Puppetfiles (even in the same repo), in a separate subdirectory (whose parent is $basedir/$env), like this:

```
[root@puppet01 production]# pwd; ls
/root/environments/production
hieradata/  modules/  roles/  Puppetfile.hieradata  Puppetfile.modules  Puppetfile.roles  
```

(where each Puppetfile is a simple set of "mod" lines)

This feature has the potential to allow other non-puppet uses for r10k, like software deployment. It is also backwards compatible. It proposed it for 1.3.x, but it works for 1.2.x as well.

I am sorry, but I am not familiar with the rspec test ruby development... so I could not contribute to that part.

Hope you like it!
