### PR TITLE
Support moduledir with relative path

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'r10k/module'
 require 'r10k/util/purgeable'
 
@@ -58,7 +59,11 @@ class Puppetfile
 
   # @param [String] moduledir
   def set_moduledir(moduledir)
-    @moduledir = moduledir
+    @moduledir = if Pathname.new(moduledir).absolute?
+      moduledir
+    else
+      File.join(basedir, moduledir)
+    end
   end
 
   # @param [String] name

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'r10k/puppetfile'
+
+describe R10K::Puppetfile do
+
+  subject do
+    described_class.new(
+      '/some/nonexistent/basedir',
+    )
+  end
+
+  describe "the default moduledir" do
+    it "is the basedir joined with '/modules' path" do
+      expect(subject.moduledir).to eq '/some/nonexistent/basedir/modules'
+    end
+  end
+
+  describe "setting moduledir" do
+    it "changes to given moduledir if it is an absolute path" do
+      subject.set_moduledir('/absolute/path/moduledir')
+      expect(subject.moduledir).to eq '/absolute/path/moduledir'
+    end
+
+    it "joins the basedir with the given moduledir if it is a relative path" do
+      subject.set_moduledir('relative/moduledir')
+      expect(subject.moduledir).to eq '/some/nonexistent/basedir/relative/moduledir'
+    end
+  end
+end


### PR DESCRIPTION
When using the moduledir directive in a Puppetfile, the path was assumed to
be an absolute path, even if the path did not start with a slash. In that case, the
directory was relative to the directory from where the user ran the `r10k` command.

Now when the moduledir path is relative, the path is joined with the Puppetfile basedir.
When the moduledir path is absolute, the behavior is the same as before.
