### PR TITLE
Deployments fail where a branch has \W in the git branch name

### DIFF
--- a/lib/r10k/task/deployment.rb
+++ b/lib/r10k/task/deployment.rb
@@ -23,8 +23,14 @@ module Deployment
         # while this should be optimized that optimization can wait a while.
         names.each do |env_name|
 
+          # Elsewhere, we sanitise the env.dirname to sub any \W to _
+          # For this to match here (a single environment deploy where the 
+          # branch name has \W we need to sanitise the branch name to match
+
+          safe_branch_name = env_name.gsub(/\W/,'_')
+
           matching = all_environments.select do |env|
-            env.dirname == env_name
+            env.dirname == safe_branch_name
           end
 
           if matching.empty?


### PR DESCRIPTION
Where an r10k git repo uses branches where the name is a version, e.g. 1.2.3 a deployment will fail in `task/deployment.rb` because the `env.dirname` has been sanitised but the branchname which is later used to match is not.  This patch is the simple case of following the gsub performed elsewhere but in a private method.
