### PR TITLE
[SPIKE] Speedup entire environment deployment

### DIFF
--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -51,12 +51,14 @@ scheduled. On subsequent deployments, Puppetfile deployment will default to off.
           DESCRIPTION
 
           flag :p, :puppetfile, 'Deploy modules from a puppetfile'
+          flag :i, :puppetfile_if_changed, 'Deploy modules from a puppetfile if the environment changed since last deploy'
 
           run do |opts, args, cmd|
             deploy = R10K::Deployment.load_config(opts[:config])
 
             task = R10K::Task::Deployment::DeployEnvironments.new(deploy)
             task.update_puppetfile = opts[:puppetfile]
+            task.update_puppetfile_if_changed = opts[:puppetfile_if_changed]
             task.environment_names = args
 
             purge = R10K::Task::Deployment::PurgeEnvironments.new(deploy)

--- a/lib/r10k/environment/git.rb
+++ b/lib/r10k/environment/git.rb
@@ -45,6 +45,10 @@ class R10K::Environment::Git < R10K::Environment::Base
     @puppetfile  = R10K::Puppetfile.new(@full_path)
   end
 
+  def outdated?
+    @working_dir.outdated?
+  end
+
   # Clone or update the given Git environment.
   #
   # If the environment is being created for the first time, it will

--- a/lib/r10k/git/working_dir.rb
+++ b/lib/r10k/git/working_dir.rb
@@ -106,7 +106,8 @@ class R10K::Git::WorkingDir < R10K::Git::Repository
   end
 
   def outdated?
-    @ref.fetch? or needs_checkout?
+    fetch_from_cache
+    needs_checkout?
   end
 
   # Prefer remote heads from the 'cache' remote over the real remote

--- a/lib/r10k/task/deployment.rb
+++ b/lib/r10k/task/deployment.rb
@@ -66,9 +66,14 @@ module Deployment
     #   @return [TrueClass, FalseClass] Whether to deploy modules in a puppetfile
     attr_accessor :update_puppetfile
 
+    # @!attribute update_puppetfile_if_changed
+    #   @return [TrueClass, FalseClass] Whether to deploy modules in a puppetfile if the environment changed since last deploy
+    attr_accessor :update_puppetfile_if_changed
+
     def initialize(deployment)
       @deployment = deployment
       @update_puppetfile = false
+      @update_puppetfile_if_changed = false
       @environment_names = []
     end
 
@@ -78,6 +83,7 @@ module Deployment
       with_environments(@environment_names) do |env|
         task = R10K::Task::Environment::Deploy.new(env)
         task.update_puppetfile = @update_puppetfile
+        task.update_puppetfile_if_changed = @update_puppetfile_if_changed
         task_runner.insert_task_after(self, task)
       end
     end

--- a/lib/r10k/task/environment.rb
+++ b/lib/r10k/task/environment.rb
@@ -7,22 +7,32 @@ module Environment
   class Deploy < R10K::Task::Base
 
     attr_writer :update_puppetfile
+    attr_writer :update_puppetfile_if_changed
 
     def initialize(environment)
       @environment = environment
 
       @update_puppetfile = false
+      @update_puppetfile_if_changed = false
     end
 
     def call
       logger.notice "Deploying environment #{@environment.dirname}"
+
+      environment_outdated = @environment.outdated?
+
       @environment.sync
 
-      if @update_puppetfile
+      if update_puppetfile?(environment_outdated)
         task = R10K::Task::Puppetfile::Sync.new(@environment.puppetfile)
         task_runner.insert_task_after(self, task)
       end
     end
+
+    private
+      def update_puppetfile?(environment_outdated)
+        @update_puppetfile || (@update_puppetfile_if_changed && environment_outdated)
+      end
   end
 end
 end


### PR DESCRIPTION
This changes introduces a new option `puppetfile_if_changed` for the
`deploy environment` task.

It will check if the environment changed since last time and
automatically update modules if there is a change.

The goal is to have a fast deployment without clever post-receive hook
hacks. This option allows to run r10k e. g. as a cronjob each minute and
will always ensure up-to-date env without any manual intervention.

Thus we get a resilient and self-healing deployment for puppet
masters. The env will auto-heal even after network or machine failures.
Developers can expect to always have the latest env deployed without
manual intervention. All advantages of pull-style deploy apply.

This has only be implemented for git as a spike. Will add tests and doc
if the general idea looks good.
