### PR TITLE
[puppetfile] (GH-186) Rescue Puppetfile parse errors

### DIFF
--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -63,13 +63,15 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
             puppetfile = R10K::Puppetfile.new(puppetfile_root, puppetfile_path, puppetfile)
             begin
               puppetfile.load
-            rescue LoadError => ex
-              $stderr.puts "ERROR: Puppetfile bad syntax"
-              ex.backtrace.each do |line|
-                  puts line
+            rescue SyntaxError, LoadError => e
+              $stderr.puts "ERROR: Could not parse Puppetfile"
+              $stderr.puts e.message
+              if opts[:trace]
+                $stderr.puts e.backtrace.join("\n")
               end
               exit 1
             end
+            puts "Syntax OK"
             exit 0
           end
         end


### PR DESCRIPTION
When a Puppetfile with invalid syntax is parsed it raises a SyntaxError,
and the `r10k puppetfile check` code was not specifically handling that.
Thus when checking an invalid file r10k was actually crashing and not
gracefully handling the error.

This commit cleans up the puppetfile check logic and adds a message on
valid parse to indicate success.
