### PR TITLE
Feature/master/gh 95 action subsystem

### DIFF
--- a/lib/r10k/action/cri_runner.rb
+++ b/lib/r10k/action/cri_runner.rb
@@ -2,6 +2,12 @@ require 'r10k/action/runner'
 
 module R10K
   module Action
+
+    # Adapt the Cri runner interface to the R10K::Action::Runner interface
+    #
+    # This class provides the necessary glue to translate behavior specific
+    # to Cri and the CLI component in general to the interface agnostic runner
+    # class.
     class CriRunner
 
       def self.wrap(klass)
@@ -12,8 +18,22 @@ module R10K
         @klass = klass
       end
 
+      # @todo swap args order for consistency
       def new(opts, args, _cmd)
-        # @todo swap args order for consistency
+
+        # Translate from the Cri verbose logging option to the internal logging setting.
+        loglevel = opts.delete(:verbose)
+        case loglevel
+        when String, Numeric
+          opts[:loglevel] = loglevel
+        when TrueClass
+          opts[:loglevel] = 'INFO'
+        else
+          # When the type is unsure just pass it in as-is and let the internals
+          # raise the appropriate errors.
+          opts[:loglevel] = loglevel
+        end
+
         R10K::Action::Runner.new(args, opts, @klass)
       end
     end

--- a/lib/r10k/action/cri_runner.rb
+++ b/lib/r10k/action/cri_runner.rb
@@ -28,6 +28,8 @@ module R10K
           opts[:loglevel] = loglevel
         when TrueClass
           opts[:loglevel] = 'INFO'
+        when NilClass
+          # pass
         else
           # When the type is unsure just pass it in as-is and let the internals
           # raise the appropriate errors.

--- a/lib/r10k/action/cri_runner.rb
+++ b/lib/r10k/action/cri_runner.rb
@@ -18,9 +18,7 @@ module R10K
         @klass = klass
       end
 
-      # @todo swap args order for consistency
       def new(opts, args, _cmd)
-
         # Translate from the Cri verbose logging option to the internal logging setting.
         loglevel = opts.delete(:verbose)
         case loglevel
@@ -36,7 +34,7 @@ module R10K
           opts[:loglevel] = loglevel
         end
 
-        R10K::Action::Runner.new(args, opts, @klass)
+        R10K::Action::Runner.new(opts, args, @klass)
       end
     end
   end

--- a/lib/r10k/action/cri_runner.rb
+++ b/lib/r10k/action/cri_runner.rb
@@ -32,7 +32,7 @@ module R10K
       # @param _cmd [Cri::Command] The command that was invoked. This value
       #   is not used and is only present to adapt the Cri interface to r10k.
       # @return [self]
-      def new(opts, args, _cmd)
+      def new(opts, args, _cmd = nil)
         # Translate from the Cri verbose logging option to the internal logging setting.
         loglevel = opts.delete(:verbose)
         case loglevel

--- a/lib/r10k/action/cri_runner.rb
+++ b/lib/r10k/action/cri_runner.rb
@@ -1,0 +1,21 @@
+require 'r10k/action/runner'
+
+module R10K
+  module Action
+    class CriRunner
+
+      def self.wrap(klass)
+        new(klass)
+      end
+
+      def initialize(klass)
+        @klass = klass
+      end
+
+      def new(opts, args, _cmd)
+        # @todo swap args order for consistency
+        R10K::Action::Runner.new(args, opts, @klass)
+      end
+    end
+  end
+end

--- a/lib/r10k/action/deploy.rb
+++ b/lib/r10k/action/deploy.rb
@@ -1,83 +1,8 @@
-require 'r10k/util/attempt'
-require 'r10k/util/setopts'
-require 'r10k/deployment'
-require 'set'
-
 module R10K
   module Action
     module Deploy
-      class Environments
-
-        include R10K::Util::Setopts
-
-        def initialize(argv, opts)
-          @argv = argv
-          @opts = opts
-          setopts(opts, {
-            :config     => :self,
-            :puppetfile => :self,
-            :purge      => :self,
-            :trace      => :nil
-          })
-
-          @purge = true
-          @deployment = R10K::Deployment.load_config(@config)
-        end
-
-        def call
-          attempt = R10K::Util::Attempt.new(@deployment, :trace => @opts[:trace])
-
-          attempt.try do |deployment|
-            # Ensure that everything can be preloaded. If we cannot preload all
-            # sources then we can't fully enumerate all environments which
-            # could be dangerous. If this fails then an exception will be raised
-            # and execution will be halted.
-            deployment.preload!
-
-            if @purge
-              paths = Set.new
-              @deployment.sources.each { |source| paths.add(source.basedir) }
-              paths.each do |path|
-                R10K::Util::Basedir.new(path, @deployment.sources).purge!
-              end
-            end
-
-            environments
-          end
-
-          attempt.try do |environment|
-            environment.sync
-            environment.modules if @puppetfile
-          end.try do |mod|
-            mod.sync
-          end
-
-          attempt.run
-        end
-
-        private
-
-        def validate!
-          if @argv.empty? && @deployment.environments.empty?
-            raise R10K::R10KError, "No environments supplied in any sources, nothing to do"
-          end
-        end
-
-
-        def environments
-          @_environments ||= filter
-        end
-
-        def filter
-          if @argv.empty?
-            @deployment.environments
-          else
-            @deployment.environments.select do |env|
-              @argv.any? { |name| env.dirname == name }
-            end
-          end
-        end
-      end
+      require 'r10k/action/deploy/environment'
+      require 'r10k/action/deploy/module'
     end
   end
 end

--- a/lib/r10k/action/deploy.rb
+++ b/lib/r10k/action/deploy.rb
@@ -1,0 +1,79 @@
+require 'r10k/util/attempt'
+require 'r10k/util/setopts'
+require 'r10k/deployment'
+
+module R10K
+  module Action
+    module Deploy
+      class Environments
+
+        include R10K::Util::Setopts
+
+        def initialize(argv, opts)
+          @argv = argv
+          @opts = opts
+          setopts(opts, {
+            :config     => :self,
+            :puppetfile => :self,
+            #:purge      => :self,
+            :trace      => :nil
+          })
+
+          @purge = true
+          @deployment = R10K::Deployment.load_config(@config)
+        end
+
+        def call
+          attempt = R10K::Util::Attempt.new(@deployment, :trace => @opts[:trace])
+
+          attempt.try do |deployment|
+            # Ensure that everything can be preloaded. If we cannot preload all
+            # sources then we can't fully enumerate all environments which
+            # could be dangerous. If this fails then an exception will be raised
+            # and execution will be halted.
+            deployment.preload!
+
+            #if @purge
+            #  basedir = R10K::Util::Basedir.from_deployment(@config)
+            #  basedir.purge!
+            #end
+
+            environments
+          end
+
+          attempt.try do |environment|
+            environment.sync
+            environment.modules if @puppetfile
+          end.try do |mod|
+            mod.sync
+          end
+
+          attempt.run
+        end
+
+        private
+
+        def validate!
+          if @argv.empty? && @deployment.environments.empty?
+            raise R10K::R10KError, "No environments supplied in any sources, nothing to do"
+          end
+        end
+
+
+        def environments
+          @_environments ||= filter
+        end
+
+        def filter
+          if @argv.empty?
+            @deployment.environments
+          else
+            @deployment.environments.select do |env|
+              @argv.any? { |name| env.dirname == name }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/r10k/action/deploy.rb
+++ b/lib/r10k/action/deploy.rb
@@ -1,6 +1,7 @@
 require 'r10k/util/attempt'
 require 'r10k/util/setopts'
 require 'r10k/deployment'
+require 'set'
 
 module R10K
   module Action
@@ -15,7 +16,7 @@ module R10K
           setopts(opts, {
             :config     => :self,
             :puppetfile => :self,
-            #:purge      => :self,
+            :purge      => :self,
             :trace      => :nil
           })
 
@@ -33,10 +34,13 @@ module R10K
             # and execution will be halted.
             deployment.preload!
 
-            #if @purge
-            #  basedir = R10K::Util::Basedir.from_deployment(@config)
-            #  basedir.purge!
-            #end
+            if @purge
+              paths = Set.new
+              @deployment.sources.each { |source| paths.add(source.basedir) }
+              paths.each do |path|
+                R10K::Util::Basedir.new(path, @deployment.sources).purge!
+              end
+            end
 
             environments
           end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -1,7 +1,6 @@
 require 'r10k/util/attempt'
 require 'r10k/util/setopts'
 require 'r10k/deployment'
-require 'set'
 
 module R10K
   module Action
@@ -35,11 +34,7 @@ module R10K
             deployment.preload!
 
             if @purge
-              paths = Set.new
-              @deployment.sources.each { |source| paths.add(source.basedir) }
-              paths.each do |path|
-                R10K::Util::Basedir.new(path, @deployment.sources).purge!
-              end
+              deployment.purge!
             end
 
             environments

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -1,0 +1,82 @@
+require 'r10k/util/attempt'
+require 'r10k/util/setopts'
+require 'r10k/deployment'
+require 'set'
+
+module R10K
+  module Action
+    module Deploy
+      class Environment
+
+        include R10K::Util::Setopts
+
+        def initialize(argv, opts)
+          @argv = argv
+          @opts = opts
+          setopts(opts, {
+            :config     => :self,
+            :puppetfile => :self,
+            :purge      => :self,
+            :trace      => :nil
+          })
+
+          @purge = true
+          @deployment = R10K::Deployment.load_config(@config)
+        end
+
+        def call
+          attempt = R10K::Util::Attempt.new(@deployment, :trace => @opts[:trace])
+
+          attempt.try do |deployment|
+            # Ensure that everything can be preloaded. If we cannot preload all
+            # sources then we can't fully enumerate all environments which
+            # could be dangerous. If this fails then an exception will be raised
+            # and execution will be halted.
+            deployment.preload!
+
+            if @purge
+              paths = Set.new
+              @deployment.sources.each { |source| paths.add(source.basedir) }
+              paths.each do |path|
+                R10K::Util::Basedir.new(path, @deployment.sources).purge!
+              end
+            end
+
+            environments
+          end
+
+          attempt.try do |environment|
+            environment.sync
+            environment.modules if @puppetfile
+          end.try do |mod|
+            mod.sync
+          end
+
+          attempt.run
+        end
+
+        private
+
+        def validate!
+          if @argv.empty? && @deployment.environments.empty?
+            raise R10K::R10KError, "No environments supplied in any sources, nothing to do"
+          end
+        end
+
+        def environments
+          @_environments ||= filter
+        end
+
+        def filter
+          if @argv.empty?
+            @deployment.environments
+          else
+            @deployment.environments.select do |env|
+              @argv.any? { |name| env.dirname == name }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -57,6 +57,8 @@ module R10K
           end
 
           attempt.run
+
+          attempt.ok?
         end
 
         private

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -10,9 +10,9 @@ module R10K
 
         include R10K::Util::Setopts
 
-        def initialize(argv, opts)
-          @argv = argv
+        def initialize(opts, argv)
           @opts = opts
+          @argv = argv
           setopts(opts, {
             :config     => :self,
             :puppetfile => :self,

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -47,7 +47,11 @@ module R10K
 
           attempt.try do |environment|
             environment.sync
-            environment.modules if @puppetfile
+            environment.puppetfile if @puppetfile
+          end.try do |puppetfile|
+            puppetfile.load!
+            puppetfile.purge!
+            puppetfile.modules
           end.try do |mod|
             mod.sync
           end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -1,0 +1,60 @@
+require 'r10k/util/attempt'
+require 'r10k/util/setopts'
+require 'r10k/deployment'
+
+module R10K
+  module Action
+    module Deploy
+      class Module
+
+        include R10K::Logging
+        include R10K::Util::Setopts
+
+        def initialize(argv, opts)
+          @argv = argv
+          @opts = opts
+          setopts(opts, {
+            :config      => :self,
+            :environment => nil,
+            :trace       => nil
+          })
+
+          @purge = true
+          @deployment = R10K::Deployment.load_config(@config)
+        end
+
+        def call
+          # @todo validation
+
+          attempt = R10K::Util::Attempt.new(environments, :trace => @opts[:trace])
+
+          attempt.try do |environment|
+            logger.debug "Updating modules #{@argv.inspect} in environment #{environment.name}"
+            environment.modules.select { |mod| @argv.any? { |name| mod.name == name } }
+          end
+
+          attempt.try do |mod|
+            mod.sync
+          end
+
+          attempt.run
+        end
+
+        private
+
+        def environments
+          @_environments ||= filter
+        end
+
+        def filter
+          if @opts[:environment]
+            @deployment.environments.select { |env| env.dirname = @opts[:environment] }
+          else
+            @deployment.environments
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -10,9 +10,9 @@ module R10K
         include R10K::Logging
         include R10K::Util::Setopts
 
-        def initialize(argv, opts)
-          @argv = argv
+        def initialize(opts, argv)
           @opts = opts
+          @argv = argv
           setopts(opts, {
             :config      => :self,
             :environment => nil,

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -38,6 +38,8 @@ module R10K
           end
 
           attempt.run
+
+          attempt.ok?
         end
 
         private

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -15,7 +15,7 @@ module R10K
       end
 
       def setup_logging
-        if @opts[:loglevel]
+        if @opts.key?(:loglevel)
           R10K::Logging.level = @opts.delete(:loglevel)
         end
       end

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -1,9 +1,9 @@
 module R10K
   module Action
     class Runner
-      def initialize(argv, opts, klass)
-        @argv = argv
+      def initialize(opts, argv, klass)
         @opts = opts
+        @argv = argv
         @klass = klass
       end
 
@@ -11,7 +11,7 @@ module R10K
         setup_logging
         setup_settings
         # check arguments
-        @klass.new(@argv, @opts).call
+        @klass.new(@opts, @argv).call
       end
 
       def setup_logging

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -15,8 +15,8 @@ module R10K
       end
 
       def setup_logging
-        if @opts[:verbose]
-          R10K::Logging.level = @opts.delete(:verbose)
+        if @opts[:loglevel]
+          R10K::Logging.level = @opts.delete(:loglevel)
         end
       end
 

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -7,16 +7,25 @@ module R10K
         @klass = klass
       end
 
+      def instance
+        if @_instance.nil?
+          iopts = @opts.dup
+          iopts.delete(:loglevel)
+          @_instance = @klass.new(iopts, @argv)
+        end
+        @_instance
+      end
+
       def call
         setup_logging
         setup_settings
-        # check arguments
-        @klass.new(@opts, @argv).call
+        # @todo check arguments
+        instance.call
       end
 
       def setup_logging
         if @opts.key?(:loglevel)
-          R10K::Logging.level = @opts.delete(:loglevel)
+          R10K::Logging.level = @opts[:loglevel]
         end
       end
 

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -1,0 +1,27 @@
+module R10K
+  module Action
+    class Runner
+      def initialize(argv, opts, klass)
+        @argv = argv
+        @opts = opts
+        @klass = klass
+      end
+
+      def call
+        setup_logging
+        setup_settings
+        # check arguments
+        @klass.new(@argv, @opts).call
+      end
+
+      def setup_logging
+        if @opts[:verbose]
+          R10K::Logging.level = @opts.delete(:verbose)
+        end
+      end
+
+      def setup_settings
+      end
+    end
+  end
+end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -5,6 +5,10 @@ require 'r10k/deployment/config'
 require 'r10k/task_runner'
 require 'r10k/task/deployment'
 
+require 'r10k/action/cri_runner'
+require 'r10k/action/deploy'
+
+
 require 'cri'
 
 module R10K::CLI
@@ -52,22 +56,7 @@ scheduled. On subsequent deployments, Puppetfile deployment will default to off.
 
           flag :p, :puppetfile, 'Deploy modules from a puppetfile'
 
-          run do |opts, args, cmd|
-            deploy = R10K::Deployment.load_config(opts[:config])
-
-            task = R10K::Task::Deployment::DeployEnvironments.new(deploy)
-            task.update_puppetfile = opts[:puppetfile]
-            task.environment_names = args
-
-            purge = R10K::Task::Deployment::PurgeEnvironments.new(deploy)
-
-            runner = R10K::TaskRunner.new(:trace => opts[:trace])
-            runner.append_task task
-            runner.append_task purge
-            runner.run
-
-            exit runner.exit_value
-          end
+          runner R10K::Action::CriRunner.wrap(R10K::Action::Deploy::Environment)
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -77,19 +77,7 @@ try to deploy the given module names in all environments.
 
           required :e, :environment, 'Update the modules in the given environment'
 
-          run do |opts, args, cmd|
-            deploy = R10K::Deployment.load_config(opts[:config])
-
-            task = R10K::Task::Deployment::DeployModules.new(deploy)
-            task.module_names = args
-            task.environment_names = [opts[:environment]] if opts[:environment]
-
-            runner = R10K::TaskRunner.new(:trace => opts[:trace])
-            runner.append_task task
-            runner.run
-
-            exit runner.exit_value
-          end
+          runner R10K::Action::CriRunner.wrap(R10K::Action::Deploy::Module)
         end
       end
     end

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -1,11 +1,12 @@
-require 'yaml'
-require 'r10k'
 require 'r10k/source'
+require 'set'
 
 module R10K
   # A deployment models the entire state of the configuration that a Puppet
   # master can use. It contains a set of sources that can produce environments
   # and manages the contents of directories where environments are deployed.
+  #
+  # @api private
   class Deployment
 
     require 'r10k/deployment/environment'
@@ -55,6 +56,15 @@ module R10K
     def environments
       load_environments if @_environments.nil?
       @_environments
+    end
+
+    # @return [Set<String>] The paths used by all contained sources
+    def paths
+      paths = Set.new
+      sources.each do |source|
+        paths.add(source.basedir)
+      end
+      paths
     end
 
     private

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -31,6 +31,8 @@ module R10K
     def preload!
       sources.each(&:preload!)
     end
+
+    # @deprecated
     alias fetch_sources preload!
 
     # Lazily load all sources

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -3,72 +3,74 @@ require 'r10k'
 require 'r10k/source'
 
 module R10K
-class Deployment
-  # Model a full installation of module directories and modules.
+  # A deployment models the entire state of the configuration that a Puppet
+  # master can use. It contains a set of sources that can produce environments
+  # and manages the contents of directories where environments are deployed.
+  class Deployment
 
-  require 'r10k/deployment/environment'
-  require 'r10k/deployment/basedir'
-  require 'r10k/deployment/source'
-  require 'r10k/deployment/config'
+    require 'r10k/deployment/environment'
+    require 'r10k/deployment/basedir'
+    require 'r10k/deployment/source'
+    require 'r10k/deployment/config'
 
-  # Generate a deployment object based on a config
-  #
-  # @param path [String] The path to the deployment config
-  # @return [R10K::Deployment] The deployment loaded with the given config
-  def self.load_config(path)
-    config = R10K::Deployment::Config.new(path)
-    new(config)
-  end
+    # Generate a deployment object based on a config
+    #
+    # @param path [String] The path to the deployment config
+    # @return [R10K::Deployment] The deployment loaded with the given config
+    def self.load_config(path)
+      config = R10K::Deployment::Config.new(path)
+      new(config)
+    end
 
-  def initialize(config)
-    @config = config
-  end
+    def initialize(config)
+      @config = config
+    end
 
-  def preload!
-    sources.each(&:preload!)
-  end
-  alias fetch_sources preload!
+    def preload!
+      sources.each(&:preload!)
+    end
+    alias fetch_sources preload!
 
-  # Lazily load all sources
-  #
-  # This instantiates the @_sources instance variable, but should not be
-  # used directly as it could be legitimately unset if we're doing lazy
-  # loading.
-  #
-  # @return [Array<R10K::Source::Base>] All repository sources
-  #   specified in the config
-  def sources
-    load_sources if @_sources.nil?
-    @_sources
-  end
+    # Lazily load all sources
+    #
+    # This instantiates the @_sources instance variable, but should not be
+    # used directly as it could be legitimately unset if we're doing lazy
+    # loading.
+    #
+    # @return [Array<R10K::Source::Base>] All repository sources
+    #   specified in the config
+    def sources
+      load_sources if @_sources.nil?
+      @_sources
+    end
 
-  # Lazily load all environments
-  #
-  # This instantiates the @_environments instance variable, but should not be
-  # used directly as it could be legitimately unset if we're doing lazy
-  # loading.
-  #
-  # @return [Array<R10K::Environment::Base>] All enviroments across
-  #   all sources
-  def environments
-    load_environments if @_environments.nil?
-    @_environments
-  end
+    # Lazily load all environments
+    #
+    # This instantiates the @_environments instance variable, but should not be
+    # used directly as it could be legitimately unset if we're doing lazy
+    # loading.
+    #
+    # @return [Array<R10K::Environment::Base>] All enviroments across
+    #   all sources
+    def environments
+      load_environments if @_environments.nil?
+      @_environments
+    end
 
-  private
+    private
 
-  def load_sources
-    sources = @config.setting(:sources)
-    @_sources = sources.map do |(name, hash)|
-      R10K::Source.from_hash(name, hash)
+    def load_sources
+      sources = @config.setting(:sources)
+      @_sources = sources.map do |(name, hash)|
+        R10K::Source.from_hash(name, hash)
+      end
+    end
+
+    def load_environments
+      @_environments = []
+      sources.each do |source|
+        @_environments += source.environments
+      end
     end
   end
-
-  def load_environments
-    @_environments = []
-    sources.each do |source|
-      @_environments += source.environments
-    end
-  end
-end
 end

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -1,4 +1,5 @@
 require 'r10k/source'
+require 'r10k/util/basedir'
 require 'set'
 
 module R10K
@@ -60,11 +61,21 @@ module R10K
 
     # @return [Set<String>] The paths used by all contained sources
     def paths
-      paths = Set.new
-      sources.each do |source|
-        paths.add(source.basedir)
+      paths_and_sources.keys
+    end
+
+    # @return [Hash<String, Array<R10K::Source::Base>]
+    def paths_and_sources
+      pathmap = Hash.new { |h, k| h[k] = [] }
+      sources.each { |source| pathmap[source.basedir] << source }
+      pathmap
+    end
+
+    # Remove unmanaged content from all source paths
+    def purge!
+      paths_and_sources.each_pair do |path, sources_at_path|
+        R10K::Util::Basedir.new(path, sources_at_path).purge!
       end
-      paths
     end
 
     private

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -15,6 +15,10 @@ class R10K::Environment::Base
   #   @return [String] The directory name for the given environment
   attr_reader :dirname
 
+  # @!attribute [r] path
+  #   @return [Pathname] The full path to the given environment
+  attr_reader :path
+
   # Initialize the given environment.
   #
   # @param name [String] The unique name describing this environment.
@@ -29,6 +33,7 @@ class R10K::Environment::Base
     @options = options
 
     @full_path = File.join(@basedir, @dirname)
+    @path = Pathname.new(File.join(@basedir, @dirname))
   end
 
   # Synchronize the given environment.

--- a/lib/r10k/task/deployment.rb
+++ b/lib/r10k/task/deployment.rb
@@ -9,6 +9,8 @@ require 'r10k/util/basedir'
 module R10K
 module Task
 module Deployment
+
+  # @deprecated
   module SharedBehaviors
 
     private
@@ -56,6 +58,7 @@ module Deployment
     end
   end
 
+  # @deprecated
   class DeployEnvironments < R10K::Task::Base
 
     include SharedBehaviors
@@ -85,6 +88,7 @@ module Deployment
     end
   end
 
+  # @deprecated
   class DeployModules < R10K::Task::Base
 
     include SharedBehaviors
@@ -112,6 +116,7 @@ module Deployment
     end
   end
 
+  # @deprecated
   class PurgeEnvironments < R10K::Task::Base
 
     def initialize(deployment)

--- a/lib/r10k/task/environment.rb
+++ b/lib/r10k/task/environment.rb
@@ -4,6 +4,8 @@ require 'r10k/task/puppetfile'
 module R10K
 module Task
 module Environment
+
+  # @deprecated
   class Deploy < R10K::Task::Base
 
     attr_writer :update_puppetfile

--- a/lib/r10k/util/attempt.rb
+++ b/lib/r10k/util/attempt.rb
@@ -4,25 +4,52 @@ require 'colored'
 
 module R10K
   module Util
+
+    # Attempt a series of dependent nested tasks and cleanly handle errors.
+    #
+    # @api private
     class Attempt
 
       include R10K::Logging
       include R10K::Util::Setopts
 
-      def initialize(value, opts = {})
-        @value = value
-        @tries = []
+      # @!attribute [r] status
+      #   @return [Symbol] The status of this task
+      attr_reader :status
 
+      def initialize(initial, opts = {})
+        @initial = initial
+        @tries = []
+        @status = :notrun
         setopts(opts, {:trace => :self})
       end
 
+      # Run this attempt to completion.
+      #
+      # @todo determine the structure of the ret
+      # @return [Object] The aggregate result of all work performed.
       def run
-        apply(@value, @tries)
+        @status = :running
+        result = apply(@initial, @tries)
+        @status = :ok if @status == :running
+        result
       end
 
+      # Add another action to take for this attempt
+      #
+      # @yieldparam [Object] The result of the previous action.
+      # @yieldreturn [Object, Array<Object>, NilClass] The result of this action.
+      #   If the value is an object, it will be passed to the next attempt. If
+      #   the value is an Array then each element will be individually passed
+      #   to the next try. If the value is false or nil then no further action
+      #   will be taken.
       def try(&block)
         @tries << block
         self
+      end
+
+      def ok?
+        @status == :ok
       end
 
       private
@@ -47,6 +74,7 @@ module R10K
       def apply_one(value, tries)
         apply(tries.first.call(value), tries.drop(1))
       rescue => e
+        @status = :failed
         logger.error e.message
         $stderr.puts e.backtrace.join("\n").red if @trace
         e

--- a/lib/r10k/util/attempt.rb
+++ b/lib/r10k/util/attempt.rb
@@ -1,0 +1,56 @@
+require 'r10k/logging'
+require 'r10k/util/setopts'
+require 'colored'
+
+module R10K
+  module Util
+    class Attempt
+
+      include R10K::Logging
+      include R10K::Util::Setopts
+
+      def initialize(value, opts = {})
+        @value = value
+        @tries = []
+
+        setopts(opts, {:trace => :self})
+      end
+
+      def run
+        apply(@value, @tries)
+      end
+
+      def try(&block)
+        @tries << block
+        self
+      end
+
+      private
+
+      def apply(input, tries)
+        return input if tries.empty?
+
+        case input
+        when Array
+          apply_all(input, tries)
+        when NilClass, FalseClass
+          input
+        else
+          apply_one(input, tries)
+        end
+      end
+
+      def apply_all(values, tries)
+        values.map { |v| apply_one(v, tries) }
+      end
+
+      def apply_one(value, tries)
+        apply(tries.first.call(value), tries.drop(1))
+      rescue => e
+        logger.error e.message
+        $stderr.puts e.backtrace.join("\n").red if @trace
+        e
+      end
+    end
+  end
+end

--- a/spec/matchers/exit_with.rb
+++ b/spec/matchers/exit_with.rb
@@ -1,0 +1,22 @@
+RSpec::Matchers.define :exit_with do |expected|
+  actual = nil
+  match do |block|
+    begin
+      block.call
+    rescue SystemExit => e
+      actual = e.status
+    end
+    actual and actual == expected
+  end
+  failure_message_for_should do |block|
+    "expected exit with code #{expected} but " +
+      (actual.nil? ? " exit was not called" : "we exited with #{actual} instead")
+  end
+  failure_message_for_should_not do |block|
+    "expected that exit would not be called with #{expected}"
+  end
+  description do
+    "expect exit with #{expected}"
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'r10k'
 
 require 'shared-examples/git-ref'
+require 'matchers/exit_with'
 
 PROJECT_ROOT = File.expand_path('..', File.dirname(__FILE__))
 

--- a/spec/unit/action/cri_runner_spec.rb
+++ b/spec/unit/action/cri_runner_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'r10k/action/cri_runner'
+
+describe R10K::Action::CriRunner do
+
+  let(:action_class) do
+    Class.new do
+      attr_reader :opts
+      attr_reader :argv
+
+      def initialize(opts, argv)
+        @opts = opts
+        @argv = argv
+      end
+
+      def call
+        @opts[:runok]
+      end
+    end
+  end
+
+  subject(:cri_runner) { described_class.wrap(action_class)  }
+
+  let(:opts) { {:value => :yep} }
+  let(:argv) { %w[value yes] }
+
+  describe "proxying invocations to .new" do
+    it "returns itself" do
+      expect(cri_runner.new(opts, argv, :cri_cmd)).to eql cri_runner
+    end
+
+    it "adapts the :verbose flag to :loglevel" do
+      expect(R10K::Action::Runner).to receive(:new).with({:value => :yep, :loglevel => 'DEBUG'}, argv, action_class)
+      cri_runner.new({:value => :yep, :verbose => 'DEBUG'}, argv, :cri_cmd)
+    end
+  end
+
+  describe "calling" do
+    it "exits with a return value of 0 if the action returned true" do
+      expect {
+        cri_runner.new({:runok => true}, []).call
+      }.to exit_with(0)
+    end
+
+    it "exits with a return value of 1 if the action returned false" do
+      expect {
+        cri_runner.new({:runok => false}, []).call
+      }.to exit_with(1)
+    end
+  end
+end

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'r10k/action/runner'
+
+
+describe R10K::Action::Runner do
+
+  let(:action_class) do
+    Class.new do
+      attr_reader :opts
+      attr_reader :argv
+
+      def initialize(opts, argv)
+        @opts = opts
+        @argv = argv
+      end
+
+      def call
+        @argv.map(&:upcase)
+      end
+    end
+  end
+
+  subject(:runner) { described_class.new({:opts => :yep}, %w[args yes], action_class) }
+
+  describe "instantiating the wrapped class" do
+    it "creates an instance of the class" do
+      expect(runner.instance).to be_a_kind_of action_class
+    end
+
+    it "passes the opts and argv to the instance" do
+      expect(runner.instance.opts).to eq(:opts => :yep)
+      expect(runner.instance.argv).to eq(%w[args yes])
+    end
+
+    it "strips out options that the runner handles" do
+      runner = described_class.new({:opts => :yep, :loglevel => 'FATAL'}, %w[args yes], action_class)
+      expect(runner.instance.opts).to eq(:opts => :yep)
+    end
+  end
+
+  describe "calling" do
+    it "configures logging" do
+      expect(runner).to receive(:setup_logging)
+      runner.call
+    end
+
+    it "returns the result of the wrapped class #call method" do
+      expect(runner.call).to eq %w[ARGS YES]
+    end
+  end
+
+  describe "configuring logging" do
+    it "sets the log level if :loglevel is provided" do
+      runner = described_class.new({:opts => :yep, :loglevel => 'FATAL'}, %w[args yes], action_class)
+      expect(R10K::Logging).to receive(:level=).with('FATAL')
+      runner.call
+    end
+
+    it "does not modify the loglevel if :loglevel is not provided" do
+      expect(R10K::Logging).to_not receive(:level=)
+      runner.call
+    end
+  end
+end

--- a/spec/unit/deployment_spec.rb
+++ b/spec/unit/deployment_spec.rb
@@ -33,10 +33,10 @@ describe R10K::Deployment do
 
   subject(:deployment) { described_class.new(config) }
 
-  describe "loading" do
-    let(:control) { deployment.sources.find { |source| source.name == :control } }
-    let(:hiera)   { deployment.sources.find { |source| source.name == :hiera } }
+  let(:control) { deployment.sources.find { |source| source.name == :control } }
+  let(:hiera)   { deployment.sources.find { |source| source.name == :hiera } }
 
+  describe "loading" do
     describe "sources" do
       it "creates a source for each key in the ':sources' config entry" do
 
@@ -72,6 +72,30 @@ describe R10K::Deployment do
     it "retrieves the path for each source" do
       expect(deployment.paths).to include(File.join(config.confdir, 'environments'))
       expect(deployment.paths).to include(File.join(config.confdir, 'hiera'))
+    end
+  end
+
+  describe "paths and sources" do
+    it "retrieves the path for each source" do
+      p_a_s = deployment.paths_and_sources
+
+      expect(p_a_s[File.join(config.confdir, 'environments')]).to eq([control])
+      expect(p_a_s[File.join(config.confdir, 'hiera')]).to eq([hiera])
+    end
+  end
+
+  describe "purging" do
+    it "purges each managed directory" do
+      env_basedir = double("basedir environments")
+      hiera_basedir = double("basedir hiera")
+
+      expect(env_basedir).to receive(:purge!)
+      expect(hiera_basedir).to receive(:purge!)
+
+      expect(R10K::Util::Basedir).to receive(:new).with(File.join(config.confdir, 'environments'), [control]).and_return(env_basedir)
+      expect(R10K::Util::Basedir).to receive(:new).with(File.join(config.confdir, 'hiera'), [hiera]).and_return(hiera_basedir)
+
+      deployment.purge!
     end
   end
 end

--- a/spec/unit/deployment_spec.rb
+++ b/spec/unit/deployment_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'r10k/deployment'
+require 'tmpdir'
+
+describe R10K::Deployment do
+
+  let(:config) do
+    Object.new.tap do |o|
+
+      # Scope hack. Ignore.
+      def o.confdir
+        @confdir ||= Dir.mktmpdir
+      end
+
+      def o.setting(key)
+        hash = {
+          :sources => {
+            :control => {
+              :basedir => File.join(confdir, 'environments'),
+              :remote  => 'git://some-git-server/puppet-control.git',
+            },
+            :hiera => {
+              :basedir => File.join(confdir, 'hiera'),
+              :remote  => 'git://some-git-server/hiera.git',
+            }
+          }
+        }
+
+        hash[key]
+      end
+    end
+  end
+
+  subject(:deployment) { described_class.new(config) }
+
+  describe "loading" do
+    let(:control) { deployment.sources.find { |source| source.name == :control } }
+    let(:hiera)   { deployment.sources.find { |source| source.name == :hiera } }
+
+    describe "sources" do
+      it "creates a source for each key in the ':sources' config entry" do
+
+        expect(control.basedir).to eq(File.join(config.confdir, 'environments'))
+        expect(hiera.basedir).to eq(File.join(config.confdir, 'hiera'))
+      end
+    end
+
+    describe "loading environments" do
+      before do
+        allow(control).to receive(:environments).and_return(%w[first second third])
+        allow(hiera).to receive(:environments).and_return(%w[fourth fifth sixth])
+      end
+
+      it "loads environments from each source" do
+        %w[first second third fourth fifth sixth].each do |env|
+          expect(deployment.environments).to include(env)
+        end
+      end
+    end
+  end
+
+  describe "preloading" do
+    it "invokes #preload! on each source" do
+      deployment.sources.each do |source|
+        expect(source).to receive(:preload!)
+      end
+      deployment.preload!
+    end
+  end
+end

--- a/spec/unit/deployment_spec.rb
+++ b/spec/unit/deployment_spec.rb
@@ -67,4 +67,11 @@ describe R10K::Deployment do
       deployment.preload!
     end
   end
+
+  describe "paths" do
+    it "retrieves the path for each source" do
+      expect(deployment.paths).to include(File.join(config.confdir, 'environments'))
+      expect(deployment.paths).to include(File.join(config.confdir, 'hiera'))
+    end
+  end
 end

--- a/spec/unit/environment/base_spec.rb
+++ b/spec/unit/environment/base_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'r10k/environment'
+
+describe R10K::Environment::Base do
+
+  subject(:environment) { described_class.new('envname', '/some/imaginary/path', 'env_name', {}) }
+
+  it "can return the fully qualified path" do
+    expect(environment.path).to eq(Pathname.new('/some/imaginary/path/env_name'))
+  end
+
+  it "raises an exception when #sync is called" do
+    expect { environment.sync }.to raise_error(NotImplementedError)
+  end
+end

--- a/spec/unit/util/attempt_spec.rb
+++ b/spec/unit/util/attempt_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+require 'r10k/util/attempt'
+
+describe R10K::Util::Attempt do
+
+  describe "with a single truthy value" do
+    subject(:attempt) { described_class.new("hello") }
+
+    it "invokes the next action with the value" do
+      value = nil
+      attempt.try { |inner| value = inner }
+      attempt.run
+      expect(attempt).to be_ok
+      expect(value).to eq "hello"
+    end
+
+    it "returns the resulting value from the block" do
+      attempt.try { |inner| inner + " world" }
+      result = attempt.run
+      expect(attempt).to be_ok
+      expect(result).to eq "hello world"
+    end
+  end
+
+  describe "with a false value" do
+    subject(:attempt) { described_class.new(nil) }
+
+    it "does not evaluate the block" do
+      value = "outside of block"
+      attempt.try { |inner| value = "ran block" }
+      attempt.run
+      expect(attempt).to be_ok
+      expect(value).to eq "outside of block"
+    end
+
+    it "does not continue execution" do
+      attempt.try { |_| "something" }.try { raise }
+      expect(attempt.run).to be_nil
+    end
+  end
+
+  describe "with an array" do
+    subject(:attempt) { described_class.new([1, 2, 3, 4, 5]) }
+
+    it "runs the block for each element in the array" do
+      sum = 0
+      attempt.try { |inner| sum += inner }
+      attempt.run
+      expect(attempt).to be_ok
+      expect(sum).to eq 15
+    end
+
+    it "returns the result of the operation on each array member" do
+      sum = 0
+      attempt.try { |inner| sum += inner }
+      result = attempt.run
+      expect(result).to eq([1, 3, 6, 10, 15])
+    end
+  end
+
+  describe "when an exception is raised" do
+    subject(:attempt) { described_class.new("initial") }
+
+    it "returns the exception" do
+      attempt.try { |_| raise RuntimeError }
+      result = attempt.run
+      expect(attempt).to_not be_ok
+      expect(result).to be_a_kind_of RuntimeError
+    end
+
+    it "does not continue execution" do
+      attempt.try { |_| raise RuntimeError }.try { |_| "This should not be run" }
+      result = attempt.run
+      expect(result).to be_a_kind_of RuntimeError
+    end
+
+    it "only rescues descendants of StandardError" do
+      attempt.try { |_| raise Exception }
+      expect { attempt.run }.to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This is a partial implementation of GH-95. It implements the framework of the Action system and starts decoupling the internal library from the CLI, and moves most of the deployment functionality into independent method objects that can be called with no additional setup.

This also addresses GH-193 by revamping how environment deployment and purging is handled. The new deploy environment logic tries to preload environments first, and if that fails it will immediately halt further execution, thereby preventing the accidental deployment of additional environments.
