### PR TITLE
GH-120 Documentation updates

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,4 +1,4 @@
-r10k
+R10k
 ====
 
 Puppet environment and module deployment
@@ -11,21 +11,21 @@ Description
 [librarian-puppet]: https://github.com/rodjek/librarian-puppet
 [workflow]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments/
 
-r10k provides a general purpose toolset for deploying Puppet environments and
+R10k provides a general purpose toolset for deploying Puppet environments and
 modules. It implements the [Puppetfile][librarian-puppet] format and provides a native
 implementation of Puppet [dynamic environments][workflow].
 
 Requirements
 ------------
 
-r10k supports the following Ruby versions:
+R10k supports the following Ruby versions:
 
   - 1.8.7 (POSIX minimum version)
   - 1.9.3 (Windows minimum version)
   - 2.0.0
   - 2.1.0
 
-r10k requires additional components, depending on how you plan on managing
+R10k requires additional components, depending on how you plan on managing
 environments and modules.
 
   - Installing modules from the Puppet Forge requires Puppet 3.0.0+ or later.
@@ -65,19 +65,21 @@ a git repository using Bundler for dependencies:
 Usage
 -----
 
-r10k has two primary roles: installing Puppet modules using a standalone
+R10k has two primary roles: installing Puppet modules using a standalone
 Puppetfile, and managing Git and SVN based dynamic environments. For more
 information see the topic specific documentation:
 
-  * Puppetfile documentation: [doc/puppetfile.mkd](doc/puppetfile.mkd)
-  * Environment deployment documentation: [doc/dynamic-environments.mkd](doc/dynamic-environments.mkd)
+  * [doc/puppetfile.mkd](Puppetfile documentation)
+  * [doc/dynamic-environments.mkd](Environment deployment documentation)
+  * [doc/quickstart.mkd](Quickstart)
+  * [doc/common-patterns.mkd](Common Patterns)
 
 For more general questions, see the [FAQ](doc/faq.mkd).
 
 Getting help
 ------------
 
-  * IRC: r10k has a dedicated channel, `#r10k`, on Freenode where r10k questions
+  * IRC: R10k has a dedicated channel, `#r10k`, on Freenode where r10k questions
   can be directed. Questions about r10k can frequently be asked in `#puppet` as well.
   * Mailing lists: [puppet-users](https://groups.google.com/forum/#!forum/puppet-users)
   * Q&A: [Puppet Ask](https://ask.puppetlabs.com/questions/)

--- a/doc/common-patterns.mkd
+++ b/doc/common-patterns.mkd
@@ -1,0 +1,43 @@
+Common Patterns
+===============
+
+This guide provides common patterns seen in the r10k community. These patterns
+are, of course, simply a guide. Understand why you are or are not using a
+specific pattern before implementing it.
+
+Repository Setup
+----------------
+
+Use a [Control Repo](http://www.jeffmalnick.com/blog/2014/05/16/r10k-control-repos/)
+to store your **Puppetfile**.
+
+Hiera data should be in the Control repo OR as a separate source in
+**r10k.yaml**. Any **hiera.yaml** in the Control repo will be ignored on a per
+environment basis, locating it at **/etc/puppet/hiera.yaml** is prefered.
+
+Each puppet module should be contained in its own forge module or repository.
+Sub-modules are not supported at this time.
+
+Editing modules
+---------------
+
+All environment content is checked out into $environmentpath/modules. Edits
+made directly to these files will be lost on the next deploy. It is best
+practice not to edit code on the production system in the production paths.
+
+You may clone upstream repositories in a regular user's directory, on the master
+or on another machine. Create a new feature branch locally, make all required
+edits, and push the new branch upstream when ready for testing. R10k will
+deploy changes from the upstream repositories, eliminating the need for manual
+updates of the $environmentpath contents.
+
+Automated deploys
+-----------------
+
+To reduce manual intervention, use a post-receive hook on your control and
+module repos to initiate an r10k deploy. You can develop your own or use a
+publicly available hook. These include:
+
+* [Reaktor](https://github.com/pzim/reaktor)
+* [zack/r10k's Webhooks](https://forge.puppetlabs.com/zack/r10k#webhook-support)
+(Puppet Enterprise only)

--- a/doc/dynamic-environments.mkd
+++ b/doc/dynamic-environments.mkd
@@ -9,13 +9,15 @@ Table of contents
   * [Introduction](dynamic-environments/introduction.mkd): A brief description of
     what dynamic environments are and how they work.
   * [Quickstart](dynamic-environments/quickstart.mkd): Getting started with the
-    essentials of dynamic environments and r10k
+    essentials of dynamic environments and r10k.
   * [Configuration](dynamic-environments/configuration.mkd) A reference of dynamic
     environment configuration options and how they're used
   * [Git environments](dynamic-environments/git-environments.mkd) How r10k
     implements dynamic environments using git
   * [Master Configuration](dynamic-environments/master-configuration.mkd) How to
     configure your Puppet masters to use dynamic environments
+  * [Workflow Guide](dynamic-environments/workflow-guide.mkd) A general-purpose
+    workflow guide for using r10k.
   * [Usage](dynamic-environments/usage.mkd) A reference of r10k commands and how
     they're used.
 

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -1,7 +1,7 @@
 Dynamic Environment Configuration
 =================================
 
-r10k uses a configuration file to determine how dynamic environments should be
+R10k uses a configuration file to determine how dynamic environments should be
 deployed.
 
 Config file location
@@ -35,6 +35,19 @@ cachedir: '/var/cache/r10k'
 The cachedir setting defaults to `~/.r10k`. If the HOME environment variable is
 unset r10k will assume that r10k is being run with the Puppet [`prerun_command`][prerun_command]
 setting and will set the cachedir default to `/root/.r10k`.
+
+### invalid_branches:
+
+This setting specifies how Git branch names that cannot be cleanly mapped to
+Puppet environments will be handled. It has no effect when using Subversion.
+
+Valid values:
+
+  * 'correct_and_warn': Non-word characters will be replaced with underscores
+    and a warning will be emitted. (Default)
+  * 'correct': Non-word characters will silently be replaced with underscores.
+  * 'error': Branches with non-word characters will be ignored and an error will
+    be emitted.
 
 Deployment options
 ------------------

--- a/doc/dynamic-environments/git-environments.mkd
+++ b/doc/dynamic-environments/git-environments.mkd
@@ -1,7 +1,7 @@
 Git Based Dynamic Environments
 ==============================
 
-r10k can use Git repositories to implement dynamic environments. You can create,
+R10k can use Git repositories to implement dynamic environments. You can create,
 update, and delete Puppet environments automatically as part of your normal Git
 workflow.
 
@@ -29,33 +29,17 @@ seamlessly reflected in Puppet environments. This means that creating a new Git
 branch creates a new Puppet environment, updating a Git branch will update that
 environment, and deleting a Git branch will remove that environment.
 
+R10k also works with subversion (SVN) in a similar fashion.
+
 How it works
 ------------
 
-r10k works by tracking the state of your git repositories and comparing them the
-the currently deployed environments. If there's a Git branch that doesn't have a
-corresponding Puppet environment then r10k will clone that branch into the
-appropriate directory. When Git branches are updated r10k will update the
-appropriate Puppet environment to the latest version. Finally if there are
-Puppet environments that don't have matching Git branches, r10k will assume that
-the branches for those environments were deleted and will remove those
-environments.
+R10k works by tracking the state of your git repositories and comparing them
+with each source's basedir's contents. If there's a git branch that does not
+exist in the basedir, then r10k will clone that branch into the appropriate
+directory. When git branches are updated, r10k will update the appropriate
+Puppet environment to the latest version. Finally, if there are Puppet
+environments that don't have matching git branches and the basedir is in the
+purgedir array, r10k will assume that the branches for those environments were
+deleted and will remove those environments.
 
-Configuration
--------------
-
-The following configuration options can be specified for Git based environment
-sources.
-
-### invalid_branches:
-
-This setting specifies how Git branch names that cannot be cleanly mapped to
-Puppet environments will be handled.
-
-Valid values:
-
-  * 'correct_and_warn': Non-word characters will be replaced with underscores
-    and a warning will be emitted. (Default)
-  * 'correct': Non-word characters will silently be replaced with underscores.
-  * 'error': Branches with non-word characters will be ignored and an error will
-    be emitted.

--- a/doc/dynamic-environments/introduction.mkd
+++ b/doc/dynamic-environments/introduction.mkd
@@ -38,12 +38,12 @@ Dynamic environments work by dynamically determining the settings for Puppet
 environment when the environment is used, rather than by defining an explicit
 section in puppet.conf. This works by making the current environment (in the
 '$environment' variable) part of of the path to environment specific settings,
-like modulepath, manifest, and so forth.
+like modulepath, manifest, and so forth. As of Puppet 3.5, the value of
+environmentpath will be prepended to the modules and manifests directory values.
 
 ```ini
 [master]
-vardir = '/var/lib/puppet'
-modulepath = '/etc/puppet/environments/$environment/modules'
+environmentpath = $confdir/environments'
 ```
 
 Running `puppet agent -t --environment myenv` will cause $environment to be

--- a/doc/dynamic-environments/quickstart.mkd
+++ b/doc/dynamic-environments/quickstart.mkd
@@ -109,7 +109,7 @@ find $(puppet master --configprint ssldir) -name "$(puppet master --configprint 
 puppet master --no-daemonize --verbose
 ```
 
-# Install and Configure r10k
+# Install and Configure R10k
 
 Install r10k via Ruby Gems.
 
@@ -217,7 +217,7 @@ We now have the following functional pieces:
 
 1. Puppet master
 2. Hiera
-3. r10k
+3. R10k
 4. Puppet code repository
 5. Initial 'profile' named 'base' that will configure NTP on our servers.
 
@@ -228,4 +228,14 @@ This base will allow us to do all sorts of useful things. Most interesting (to m
 3. Push the new branch up to the repository
 4. Deploy it as a new environment using the `r10k deploy environment -p` command.
 
-Now, you can just modify the `/etc/puppet/puppet.conf` file on a node, change it to be part of this new environment, and voila - you're testing code without impacting your production environment.
+From any agent node (including the master), you may run the agent against the new environment by specifying it on the command line. For example, if you create the branch `test`, run puppet as:
+```
+puppet agent -t --environment test
+```
+You can also modify the `/etc/puppet/puppet.conf` file on a node and add the environment variable to the agent setting to make the change permanent:
+```
+...
+[agent]
+environment = test
+```
+Voila - you're testing code without impacting your production environment!

--- a/doc/dynamic-environments/usage.mkd
+++ b/doc/dynamic-environments/usage.mkd
@@ -29,6 +29,8 @@ is also the slowest by a very large degree because it does the maximum possible
 work. This should not be something you run interactively, or use on a regular
 basis.
 
+Note: Forge modules are not updated unless the Puppetfile specifies a specific
+version or 'latest'.
 - - -
 
 Update environments while avoiding unnecessary recursion
@@ -60,29 +62,32 @@ Update a single environment and force an update of modules:
 This will update the given environment and update all contained modules. This is
 useful if you want to make sure that a given environment is fully up to date.
 
-### Deploying modules
+### Deploying user modules
 
-Update a single module across all environments
+Update a single module across all environments.
 
     r10k deploy module apache
 
-This is useful for when you're working on a module specified in a Puppetfile and want to update it across all environments.
+This is useful for when you're working on a module specified in a Puppetfile
+and want to update it across all environments. See
+[Puppetfile documentation](doc/puppetfile.mkd) for details on how this affects
+forge vs. git/svn modules.
 
 - - -
 
-Update multiple modules across all environments
+Update multiple modules across all environments.
 
     r10k deploy module apache jenkins java
 
 - - -
 
-Update one or more modules in a single environment
+Update one or more modules in a single environment.
 
     r10k deploy module -e production apache jenkins java
 
 ### Viewing environments
 
-Display all environments being managed by r10k
+Display all environments being managed by r10k.
 
     r10k deploy display
 

--- a/doc/dynamic-environments/workflow-guide.mkd
+++ b/doc/dynamic-environments/workflow-guide.mkd
@@ -1,0 +1,262 @@
+R10k's dynamic deployments work best with a workflow that understands and
+respects how r10k works, to prevent automation and manual processes from
+conflicting. Your workflow will need to be customized to meet your team's
+skills, tools, and needs. This guide describes a generic workflow that can
+be customized easily.
+
+This guide assumes that each of your modules is in a separate repository 
+and that the **Puppetfile** is in its own repo called the
+[Control Repo](http://www.jeffmalnick.com/blog/2014/05/16/r10k-control-repos/).
+All module repos have a primary branch of *master* and the Control's primary
+branch is *production*. All changes are made through r10k and no user makes
+manual changes to the environments under **/etc/puppet**.
+
+Adding New Modules
+==================
+
+This workflow is useful when adding a forge or internally-developed module
+to your puppet environment.
+
+Create new feature branch
+-------------------------
+
+Create a new feature branch in your module repositories. Do this for each
+repository, including the control repository, that will reference the new
+module. You do not need to do so for modules that are not being edited.
+
+```git checkout -b feature```
+
+If you are simply adding the module at this time and not referencing it in
+other modules or manifests, only the Control repo requires a new branch.
+
+Add new module and branches to control repo
+-------------------------------------------
+
+The new module is added to the control repository's **Puppetfile** like so:
+
+```
+# Forge modules:
+mod "puppetlabs/ntp"
+
+# Your modules:
+mod "custom_facts",
+  :git => "git://github.com/user/custom_facts"
+```
+
+For any existing modules that you branched, add a reference to the new branch
+name. Don't forget the comma at the end of the *:git* value.
+
+```
+mod "other_module",
+  :git => "git://github.com/user/other_module",
+  :ref => "feature"
+```
+
+Reference new module in manifests, modules, and hiera
+-----------------------------------------------------
+
+If you are simply adding the module at this time and not referencing it in
+other modules or manifests, you may skip this step.
+
+Edit your existing manifests, modules, and hiera as needed to make sure of
+the new module.
+
+Deploy environments
+-------------------
+
+Save all your changes in each module repo. Commit and push the changes upstream:
+
+```
+git commit -a -m ‘Add feature reference to module’
+git push origin feature
+```
+
+Commit and push the change in your control repo upstream:
+
+```
+git commit -a -m ‘Add module puppetlabs/ntp to branch feature'
+git push origin feature
+```
+
+Finally, deploy the environments via r10k. This step must occur on the master:
+
+```r10k deploy environment -p```
+
+Add the **-v** option for verbosity if you need to troubleshoot any errors. The
+new branch should be located at **$environmentpath/feature**.
+
+
+Test the new module branches
+----------------------------
+
+If you are simply adding the module at this time and not referencing it in
+other modules or manifests, you may skip this step.
+
+Run the puppet agent against the new environment from at least two nodes, one
+that should not be impacted by change and one that should be impacted.
+
+```puppet agent -t --environment feature```
+
+Verify that catalog compilation succeeds and that you are satisfied that the
+effective changes match your expected changes. Repeat the steps above until
+you are satisfied with the results.
+
+Merge changes
+-------------
+
+In each of the changed modules and the control repo, checkout the main branch,
+merge, and push changes to the master/production branch.
+
+```
+# Module repos
+git checkout master
+git merge feature
+git push origin master
+
+# Control repo
+git checkout production
+git merge feature
+vi Puppetfile
+# Remove all :ref's pointing to 'feature'. Don't forget the trailing commas
+# on the :git statements
+git commit -a -m 'Remove refs to feature branch for module puppetlabs/ntp'
+git push origin production
+```
+
+If you are simply adding the module at this time and not referencing it in
+other modules or manifests, you are now finished.
+
+Cleanup feature branches
+------------------------
+
+You may skip this step for long-lived branches, however most feature branches
+should be short-lived and can be pruned once testing and merging is complete.
+
+Remove the old branches in each repo:
+
+```
+git branch -D repo
+git push origin :repo
+```
+
+Deploy via r10k on the master and ensure there are no errors. The *feature*
+dynamic environment will no longer exist at **$environmentpath/feature** if you
+deleted the branch in your Control repo.
+
+```r10k deploy environment -p```
+
+Editing existing Modules
+========================
+
+When editing your own existing modules, this workflow should be followed.
+
+Create new feature branches
+---------------------------
+
+Create a new feature branch in your module repositories. Do this in the edited
+module, the control repository, and in each module that will reference the
+updated module. You do not need to do so for modules that are not being edited.
+
+```git checkout -b feature```
+
+Update control repo to reference new branch
+-------------------------------------------
+
+For all modules that you branched, add a reference to the new branch name to
+the **Puppetfile** in your Control repo. Don't forget the comma at the end of
+the *:git* value.
+
+```
+mod "other_module",
+  :git => "git://github.com/user/other_module",
+  :ref => "feature"
+```
+
+Modify existing module, references to module
+--------------------------------------------
+
+Make the required changes to your existing module. Edit your existing manifests,
+modules, and hiera as needed to make sure of the updated module.
+
+Deploy environments
+-------------------
+
+Save all your changes in each modified repo. Commit and push the changes upstream:
+
+```
+git commit -a -m ‘Add feature reference to module’
+git push origin feature
+```
+
+Commit and push the change in your control repo upstream:
+
+```
+git commit -a -m ‘Add module puppetlabs/ntp to branch feature'
+git push origin feature
+```
+
+Finally, deploy the environments via r10k. This step must occur on the master:
+
+```r10k deploy environment -p```
+
+Add the **-v** option for verbosity if you need to troubleshoot any errors. The
+new branch should be located at **$environmentpath/feature**.
+
+Test the new module branches
+----------------------------
+
+Run the puppet agent against the new environment from at least two nodes, one
+that should not be impacted by change and one that should be impacted.
+
+```puppet agent -t --environment feature```
+
+Verify that catalog compilation succeeds and that you are satisfied that the
+effective changes match your expected changes. Repeat the steps above until
+you are satisfied with the results.
+
+Merge changes
+-------------
+
+In each of the changed module repos, checkout the main branch and merge.
+
+```
+# Module repos
+git checkout master
+git merge feature
+git push origin master
+```
+
+In the Control repo, check out master. Do NOT merge the feature branch as it
+now references the incorrect branch for each git repo, and no other changes
+were made (unlike a new module, where a new repo is referenced).
+
+```
+# Control repo
+git checkout master
+```
+
+Cleanup feature branches
+------------------------
+
+You may skip this step for long-lived branches, however most feature branches
+should be short-lived and can be pruned once testing and merging is complete.
+
+Remove the old branches in each repo:
+
+```
+git branch -D repo
+git push origin :repo
+```
+
+Redeploy with r10k on the master and ensure there are no errors. The *feature*
+dynamic environment should no longer exist at **$environmentpath/feature**.
+
+```r10k deploy environment -p```
+
+Customize Your Workflow
+=======================
+
+This guide is very generic in nature. Use it as a template and expand and
+modify it to fit your team, your tools, and your company culture. Above all,
+be consistent in your methodology.
+

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -2,7 +2,7 @@ Puppetfile
 ==========
 
 Puppetfiles are a simple Ruby based DSL that specifies a list of modules to
-install, what version to install, and where to fetch them from. r10k can use a
+install, what version to install, and where to fetch them from. R10k can use a
 Puppetfile to install a set of Puppet modules for local development, or they can
 be used with r10k environment deployments to install additional modules into a
 given environment.
@@ -45,7 +45,7 @@ Puppetfile:
 Module types
 ------------
 
-r10k can install Puppet modules from a number of different sources. Right now
+R10k can install Puppet modules from a number of different sources. Right now
 modules can be installed via Git, SVN, and from the Puppet Forge.
 
 ### Git


### PR DESCRIPTION
  Standardize on 'R10k' as the proper noun in all *.mkd files.
  README.mkd:
    Updated documentation links
  doc/dynamic-environments/configuration.mkd:
    Move invalid_branches description.
    Add purgedirs description.
  doc/dynamic-environments/configuration.mkd:
    Update basedir to reference purgedirs.
  doc/dynamic-environments/git-environments.mkd:
    Clarify the details of how r10k works with git repositories.
    Update introduction to reflect environmentpath beginning with puppet v3.5.
  doc/dynamic-environments/quickstart.mkd:
    Provide alternate method to access a dynamic environment.
  doc/dynamic-environments/usage.mkd:
    Clarify how forge modules are treated.
  doc/dynamic-environments/workflow-guide.mkd:
    Completed workflow guide.
  doc/puppetfile.mkd:
    Link to description of the Control Repo
  docs/best-practices:
    Created an initial draft of a best practices guide for users to follow.
