### PR TITLE
[module_repository/forge] Force json_pure on 1.8.7

### DIFF
--- a/spec/unit/module_repository/forge_spec.rb
+++ b/spec/unit/module_repository/forge_spec.rb
@@ -14,7 +14,7 @@ describe R10K::ModuleRepository::Forge do
     expect(forge.forge).to eq 'forge.example.local'
   end
 
-  describe "and the expected version is :latest", :vcr => true, :unless => (RUBY_VERSION == '1.8.7') do
+  describe "and the expected version is :latest", :vcr => true do
     subject(:forge) { described_class.new }
 
     before do


### PR DESCRIPTION
When multi_json is running under Ruby 1.8.7, the json gem isn't present,
but the json_pure gem is present, the multi_json library may mistake the
json_pure gem as the json gem, try to load the latter, and fail. r10k
specifically pulls in json_pure for 1.8.7 compatibility and our current
use of JSON parsing is pretty minimal so we don't need blazing speed. To
simplify the use of JSON and ensure consistent behavior we force use of
json_pure on 1.8.7.
