### PR TITLE
[puppetfile] Wrap SyntaxError and LoadError on load

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -1,6 +1,7 @@
 require 'pathname'
 require 'r10k/module'
 require 'r10k/util/purgeable'
+require 'r10k/errors'
 
 module R10K
 class Puppetfile
@@ -50,6 +51,8 @@ class Puppetfile
   def load!
     dsl = R10K::Puppetfile::DSL.new(self)
     dsl.instance_eval(puppetfile_contents, @puppetfile_path)
+  rescue SyntaxError, LoadError => e
+    raise R10K::Error.wrap(e, "Failed to evaluate #{@puppetfile_path}")
   end
 
   # @param [String] forge

--- a/spec/fixtures/unit/puppetfile/invalid-syntax/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/invalid-syntax/Puppetfile
@@ -1,0 +1,1 @@
+mod 'branan/eight_hundred' :git => 'https://github.com/branan/eight_hundred'

--- a/spec/fixtures/unit/puppetfile/load-error/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/load-error/Puppetfile
@@ -1,0 +1,1 @@
+require 'a-shrubbery!'

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -26,4 +26,34 @@ describe R10K::Puppetfile do
       expect(subject.moduledir).to eq '/some/nonexistent/basedir/relative/moduledir'
     end
   end
+
+  describe "evaluating a Puppetfile" do
+    def expect_wrapped_error(orig, pf_path, wrapped_error)
+      expect(orig).to be_a_kind_of(R10K::Error)
+      expect(orig.message).to eq("Failed to evaluate #{pf_path}")
+      expect(orig.original).to be_a_kind_of(wrapped_error)
+    end
+
+    it "wraps and re-raises syntax errors" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'invalid-syntax')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect {
+        subject.load!
+      }.to raise_error do |e|
+        expect_wrapped_error(e, pf_path, SyntaxError)
+      end
+    end
+
+    it "wraps and re-raises load errors" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'load-error')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect {
+        subject.load!
+      }.to raise_error do |e|
+        expect_wrapped_error(e, pf_path, LoadError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
SyntaxError and LoadError don't inherit from StandardError, so if
the process of loading a Puppetfile raises either one of those, it will
completely unwind the stack and crash the r10k process. Since this is a
special case where we're loading Ruby code that's not actual application
code we need to rescue and wrap these errors.
