### PR TITLE
[util/subprocess] Log subprocess start level at debug2

### DIFF
--- a/lib/r10k/util/subprocess.rb
+++ b/lib/r10k/util/subprocess.rb
@@ -70,7 +70,7 @@ module R10K
 
         logmsg = "Starting process: #{@argv.inspect}"
         logmsg << "(cwd: #{@cwd})" if @cwd
-        logger.debug1 logmsg
+        logger.debug2(logmsg)
 
         result = subprocess.run
         logger.debug2("Finished process:\n#{result.format}")


### PR DESCRIPTION
The debug1 log level consisted entirely of spam about command execution;
if users are interested in seeing the executed commands they generally
want to see the output as well so logging start and finish messages at
different levels provided zero value. This commit makes all subprocess
debug messages log at the same level.
