### PR TITLE
[action/deploy/environment] fix missing environment validation

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -46,6 +46,7 @@ module R10K
           # could be dangerous. If this fails then an exception will be raised
           # and execution will be halted.
           deployment.preload!
+          deployment.validate!
 
           yield
 


### PR DESCRIPTION
Broken by the rewrite to visitor in
  f894a9dfb2cbefc88b3d5827f4af29a059c8f301

Question is: should we do a test for that? :)

The current test only checks if the .validate call fails on something, not if it is called.
