### PR TITLE
Update to faraday 0.9.0

### DIFF
--- a/lib/r10k/module_repository/forge.rb
+++ b/lib/r10k/module_repository/forge.rb
@@ -56,10 +56,7 @@ class R10K::ModuleRepository::Forge
     # Force use of json_pure with multi_json on Ruby 1.8.7
     multi_json_opts = (RUBY_VERSION == "1.8.7" ? {:adapter => :json_pure} : {})
 
-    Faraday.new(
-      :url => "https://#{@forge}",
-      :user_agent => "Ruby/r10k #{R10K::VERSION}"
-    ) do |builder|
+    Faraday.new(:url => "https://#{@forge}") do |builder|
       builder.request(:multi_json, multi_json_opts)
       builder.response(:multi_json, multi_json_opts)
 

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json', '~> 1.8.2'
   s.add_dependency 'json_pure',  '~> 1.8'
 
-  s.add_dependency 'faraday',                       '~> 0.8.8'
+  s.add_dependency 'faraday',                       '~> 0.9.0'
   s.add_dependency 'faraday_middleware',            '~> 0.9.0'
   s.add_dependency 'faraday_middleware-multi_json', '~> 0.0.5'
 

--- a/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/and_the_expected_version_is_latest/can_fetch_all_versions_of_a_given_module.yml
+++ b/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/and_the_expected_version_is_latest/can_fetch_all_versions_of_a_given_module.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.8.8
+      - Faraday v0.9.0
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/and_the_expected_version_is_latest/can_fetch_the_latest_version_of_a_given_module.yml
+++ b/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/and_the_expected_version_is_latest/can_fetch_the_latest_version_of_a_given_module.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.8.8
+      - Faraday v0.9.0
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/looking_up_versions.yml
+++ b/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/looking_up_versions.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.8.8
+      - Faraday v0.9.0
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/looking_up_versions/can_fetch_all_versions_of_a_given_module.yml
+++ b/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/looking_up_versions/can_fetch_all_versions_of_a_given_module.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.8.8
+      - Faraday v0.9.0
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/looking_up_versions/can_fetch_the_latest_version_of_a_given_module.yml
+++ b/spec/fixtures/vcr/cassettes/R10K_ModuleRepository_Forge/looking_up_versions/can_fetch_the_latest_version_of_a_given_module.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.8.8
+      - Faraday v0.9.0
   response:
     status:
       code: 200

--- a/spec/fixtures/vcr/cassettes/R10K_Module_Forge/and_the_expected_version_is_latest/sets_the_expected_version_based_on_the_latest_forge_version.yml
+++ b/spec/fixtures/vcr/cassettes/R10K_Module_Forge/and_the_expected_version_is_latest/sets_the_expected_version_based_on_the_latest_forge_version.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.8.8
+      - Faraday v0.9.0
   response:
     status:
       code: 200


### PR DESCRIPTION
The user_agent attribute is dropped apparently, and no replacement was needed
since it seems to send the desired user-agent string
