### PR TITLE
Allow module names to contain dashes

### DIFF
--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -91,12 +91,12 @@ class R10K::Module::Base
   private
 
   def parse_title(title)
-    if (match = title.match(/\A(\w+)\Z/))
-      [nil, match[1]]
-    elsif (match = title.match(/\A(\w+)[-\/](\w+)\Z/))
+    if (match = title.match(/\A(\w+)[-\/]([[:alnum:]_-]+)\Z/))
       [match[1], match[2]]
+    elsif (match = title.match(/\A([[:alnum:]_-]+)\Z/))
+      [nil, match[1]]
     else
-      raise ArgumentError, "Module names must match either 'modulename' or 'owner/modulename'"
+      raise ArgumentError, "Module name (#{title}) must match either 'modulename' or 'owner/modulename'"
     end
   end
 end

--- a/spec/unit/module/base_spec.rb
+++ b/spec/unit/module/base_spec.rb
@@ -24,7 +24,7 @@ describe R10K::Module::Base do
     it "raises an error when the title is not correctly formatted" do
       expect {
         described_class.new('branan!eight_hundred', '/moduledir', [])
-      }.to raise_error(ArgumentError, "Module names must match either 'modulename' or 'owner/modulename'")
+      }.to raise_error(ArgumentError, "Module name (branan!eight_hundred) must match either 'modulename' or 'owner/modulename'")
     end
   end
 


### PR DESCRIPTION
It's not recommended that module names contain dashes, yet some of them
do.  This changes the module name parsing to allow alpha-numeric
characters plus underscores and dashes.

Additionally, this logs the name of the invalid entry when an invalid
module name is found.
