### PR TITLE
Add 'strip_branchname_prefix' option for git

### DIFF
--- a/doc/dynamic-environments/git-environments.mkd
+++ b/doc/dynamic-environments/git-environments.mkd
@@ -63,3 +63,25 @@ Valid values:
   * 'correct': Non-word characters will silently be replaced with underscores.
   * 'error': Branches with non-word characters will be ignored and an error will
     be emitted.
+
+### strip_branchname_prefix:
+
+This setting tells r10k to strip a fixed string from the start of a Git branch
+name before using it. If the branch name does not start with the specified
+prefix, nothing happens and processing continues as normal. Please note that
+the string gets stripped before any of the other settings that might influence
+the name of the Puppet environment (e.g. 'invalid_branches' or 'prefix') take
+effect.
+
+For example, a Git branch called 'personal/username/branchname' will cause r10k
+to create a Puppet environment named 'personal_username_branchname' by default
+(assuming that 'invalid_branches' is set to 'correct' or 'correct_and_warn',
+and 'prefix' is not enabled). However, if you were to set:
+
+    strip_branchname_prefix: personal/
+
+on the source in r10k.yaml, this prefix would be stripped and you would end up
+with a Puppet environment called 'username_branchname'. This is useful if you
+are using personal branches with Gitolite, as the 'personal/' prefix is only
+really there to allow Gitolite to match up permissions, and just adds noise to
+the Puppet environment name.

--- a/spec/unit/source/git_spec.rb
+++ b/spec/unit/source/git_spec.rb
@@ -271,4 +271,49 @@ describe R10K::Source::Git::BranchName do
       end
     end
   end
+
+  describe "stripping prefixes from branch names" do
+    branch = 'personal/user/branch'
+
+    describe "and strip_branchname_prefix matches the branch name" do
+      describe "and prefix is true" do
+        it "strips the specified prefix from #{branch}" do
+          bn = described_class.new(branch.dup, {
+            :prefix => true,
+            :correct => true,
+            :sourcename => 'foo',
+            :strip_branchname_prefix => 'personal/',
+          })
+          expect(bn.dirname).to eq 'foo_user_branch'
+        end
+      end
+
+      describe "and prefix is false" do
+        it "strips the specified prefix from #{branch}" do
+          bn = described_class.new(branch.dup, {
+            :prefix => false,
+            :correct => true,
+            :sourcename => 'foo',
+            :strip_branchname_prefix => 'personal/',
+          })
+          expect(bn.dirname).to eq 'user_branch'
+        end
+      end
+    end
+
+    describe "and strip_branchname_prefix does not match the branch name" do
+      it "doesn't modify #{branch}" do
+        bn = described_class.new(branch.dup, {:strip_branchname_prefix => 'foo/'})
+        expect(bn.dirname).to eq branch
+      end
+
+    end
+
+    describe "and strip_branchname_prefix is not set" do
+      it "doesn't modify #{branch}" do
+        bn = described_class.new(branch.dup, {:strip_branchname_prefix => nil})
+        expect(bn.dirname).to eq branch
+      end
+    end
+  end
 end


### PR DESCRIPTION
Gitolite supports [personal branches](http://gitolite.com/gitolite/user.html#pers), which are a convenient way to allow a large group of developers push access to any number of branches within their own dedicated namespace. Personal branches require a fixed prefix on the branch name (e.g. "personal/". It works really nicely as a way to deliver dynamic Puppet environments, but it does add some noise to the naming - given enough development streams, you wind up with lots and lots of Puppet environments called `personal_<something>`

This commit provides a 'strip_branchname_prefix' option, to allow you to strip a fixed string from the start of a branch name before r10k goes and does its stuff.

(I'm not sure how widely used personal branches are for Puppet, and therefore how many other r10k users might want something like this - but we needed this to migrate to r10k from our custom post-hook.)
