### PR TITLE
[action/deploy/environment] (GH-260) Handle \W in environment names

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -13,7 +13,7 @@ module R10K
 
         def initialize(opts, argv)
           @opts = opts
-          @argv = argv
+          @argv = argv.map { |arg| arg.gsub(/\W/,'_') }
           setopts(opts, {
             :config     => :self,
             :puppetfile => :self,


### PR DESCRIPTION
Version 1.4.0 broke handling of environment names containing \W. When determining which branch to check out, it compares the unnormalized environment name(s) passed in on the command line to the normalized environment name returned by the backend. This normalizes the names passed in on the command line before the comparison happens.
