### PR TITLE
[errors] Remove ExecutionFailure

### DIFF
--- a/lib/r10k/errors.rb
+++ b/lib/r10k/errors.rb
@@ -2,11 +2,6 @@ require 'r10k'
 
 module R10K
 
-  # @deprecated
-  class ExecutionFailure < StandardError
-    attr_accessor :exit_code, :stdout, :stderr
-  end
-
   # An error class that accepts an optional hash and wrapped error message
   #
   class Error < StandardError


### PR DESCRIPTION
The R10K::Execution mixin was the only class that could have ever raised
this exception and has been removed; since it's not used anywhere it can
be removed.
