### PR TITLE
[git/errors] (GH-269) Improve error messaging on checkout

### DIFF
--- a/lib/r10k/git/errors.rb
+++ b/lib/r10k/git/errors.rb
@@ -10,31 +10,17 @@ module R10K
       attr_reader :ref
       attr_reader :git_dir
 
-      def initialize(*args)
+      def initialize(mesg, options = {})
         super
-
-        @hash    = @options[:ref]
+        @ref     = @options[:ref]
         @git_dir = @options[:git_dir]
       end
 
-      HASHLIKE = %r[[A-Fa-f0-9]]
-
-      # Print a friendly error message if an object hash is given as the message
       def message
-        if @mesg
-          msg = @mesg
-        else
-          msg = "Could not locate hash"
-
-          if @hash
-            msg << " '#{@hash}'"
-          end
-        end
-
+        msg = super
         if @git_dir
           msg << " at #{@git_dir}"
         end
-
         msg
       end
     end

--- a/lib/r10k/git/repository.rb
+++ b/lib/r10k/git/repository.rb
@@ -38,7 +38,7 @@ class R10K::Git::Repository
     if commit
       commit.chomp
     else
-      raise R10K::Git::UnresolvableRefError.new(:ref => pattern, :git_dir => git_dir)
+      raise R10K::Git::UnresolvableRefError.new("Could not resolve Git ref '#{ref}'", :ref => pattern, :git_dir => git_dir)
     end
   end
   alias rev_parse resolve_ref

--- a/lib/r10k/git/working_dir.rb
+++ b/lib/r10k/git/working_dir.rb
@@ -89,13 +89,9 @@ class R10K::Git::WorkingDir < R10K::Git::Repository
   #
   # @param ref [R10K::Git::Ref] The git reference to check out
   def checkout(ref)
-    if ref.resolvable?
-      git ["checkout", "--force", @ref.sha1], :path => @full_path
-    else
-      raise R10K::Git::UnresolvableRefError.new(
-        "Cannot check out unresolvable ref '#{@ref}'",
-        :git_dir => @full_path)
-    end
+    git ["checkout", "--force", @ref.sha1], :path => @full_path
+  rescue => e
+    raise R10K::Git::GitError.wrap(e, "Cannot check out Git ref '#{@ref}'")
   end
 
   # The currently checked out HEAD


### PR DESCRIPTION
If a working directory is instructed to check out a Git reference that's
unresolvable it would previously spit out a pretty useless error
message; this commit corrects the emitted error message and adds
additional context for the error.
