### PR TITLE
More verbose module name error messages

### DIFF
--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -96,7 +96,7 @@ class R10K::Module::Base
     elsif (match = title.match(/\A(\w+)[-\/](\w+)\Z/))
       [match[1], match[2]]
     else
-      raise ArgumentError, "Module names must match either 'modulename' or 'owner/modulename'"
+      raise ArgumentError, "Module name (#{title}) must match either 'modulename' or 'owner/modulename'"
     end
   end
 end

--- a/spec/unit/module/base_spec.rb
+++ b/spec/unit/module/base_spec.rb
@@ -24,7 +24,7 @@ describe R10K::Module::Base do
     it "raises an error when the title is not correctly formatted" do
       expect {
         described_class.new('branan!eight_hundred', '/moduledir', [])
-      }.to raise_error(ArgumentError, "Module names must match either 'modulename' or 'owner/modulename'")
+      }.to raise_error(ArgumentError, "Module name (branan!eight_hundred) must match either 'modulename' or 'owner/modulename'")
     end
   end
 


### PR DESCRIPTION
When a module name doesn't match one of the acceptable regexes, then
print out the name of the module that was the problem.
