### PR TITLE
(RK-11) empty pipe buffers during command execution

### DIFF
--- a/lib/r10k/util/subprocess/runner/posix.rb
+++ b/lib/r10k/util/subprocess/runner/posix.rb
@@ -25,6 +25,11 @@ class R10K::Util::Subprocess::Runner::POSIX < R10K::Util::Subprocess::Runner
     # and will contain an error message on failure.
     exec_r, exec_w = pipe
 
+    @stdout_pump = R10K::Util::Subprocess::Runner::Pump.new(@stdout_r)
+    @stderr_pump = R10K::Util::Subprocess::Runner::Pump.new(@stderr_r)
+    @stdout_pump.start
+    @stderr_pump.start
+
     pid = fork do
       exec_r.close
       execute_child(exec_w)
@@ -71,13 +76,10 @@ class R10K::Util::Subprocess::Runner::POSIX < R10K::Util::Subprocess::Runner
       _, @status = Process.waitpid2(pid)
     else
       _, @status = Process.waitpid2(pid)
-      stdout = @stdout_r.read
-
-      # Use non-blocking read for stderr_r to work around an issue with OpenSSH
-      # ControlPersist: https://bugzilla.mindrot.org/show_bug.cgi?id=1988
-      # Blocking should not occur in any other case since the process that was
-      # attached to the pipe has already terminated.
-      stderr = read_nonblock(@stderr_r)
+      @stdout_pump.halt!
+      @stderr_pump.halt!
+      stdout = @stdout_pump.string
+      stderr = @stderr_pump.string
     end
     exec_r.close
 
@@ -90,21 +92,6 @@ class R10K::Util::Subprocess::Runner::POSIX < R10K::Util::Subprocess::Runner
   def mkpipes
     @stdout_r, @stdout_w = pipe
     @stderr_r, @stderr_w = pipe
-  end
-
-  # Perform non-blocking reads on a pipe that could still be open
-  # Give up on reaching EOF or blocking and return what was read
-  def read_nonblock(rd_io)
-    data = ''
-    begin
-      # Loop until EOF or blocking
-      loop do
-          # do an 8k non-blocking read and append the result
-          data << rd_io.read_nonblock(8192)
-      end
-    rescue EOFError, Errno::EAGAIN, Errno::EWOULDBLOCK
-    end
-    data
   end
 
   def pipe

--- a/lib/r10k/util/subprocess/runner/pump.rb
+++ b/lib/r10k/util/subprocess/runner/pump.rb
@@ -1,0 +1,54 @@
+require 'r10k/util/subprocess/runner'
+
+# Perform nonblocking reads on a streaming IO instance.
+#
+# @api private
+class R10K::Util::Subprocess::Runner::Pump
+
+  # !@attribute [r] string
+  #   @return [String] The output collected from the IO device
+  attr_reader :string
+
+  # @!attribute [r] min_delay
+  #   @return [Float] The minimum time to wait while polling the IO device
+  attr_accessor :min_delay
+
+  def initialize(io)
+    @io     = io
+    @thread = nil
+    @string = ''
+    @run    = true
+    @min_delay = 0.001
+  end
+
+  def start
+    @thread = Thread.new { pump }
+  end
+
+  def halt!
+    @run = false
+    @thread.join
+  end
+
+  # Block until the pumping thread reaches EOF on the IO object.
+  def wait
+    @thread.join
+  end
+
+  private
+
+  def pump
+    backoff = @min_delay
+    while @run
+      begin
+        @string << @io.read_nonblock(4096)
+        backoff /= 2 if backoff > @min_delay
+      rescue Errno::EWOULDBLOCK, Errno::EAGAIN
+        backoff *= 2
+        IO.select([@io], [], [], backoff)
+      rescue EOFError
+        @run = false
+      end
+    end
+  end
+end

--- a/lib/r10k/util/subprocess/runner/pump.rb
+++ b/lib/r10k/util/subprocess/runner/pump.rb
@@ -13,12 +13,17 @@ class R10K::Util::Subprocess::Runner::Pump
   #   @return [Float] The minimum time to wait while polling the IO device
   attr_accessor :min_delay
 
+  # @!attribute [r] max_delay
+  #   @return [Float] The maximum time to wait while polling the IO device
+  attr_accessor :max_delay
+
   def initialize(io)
     @io     = io
     @thread = nil
     @string = ''
     @run    = true
     @min_delay = 0.001
+    @max_delay = 1.0
   end
 
   def start
@@ -44,7 +49,7 @@ class R10K::Util::Subprocess::Runner::Pump
         @string << @io.read_nonblock(4096)
         backoff /= 2 if backoff > @min_delay
       rescue Errno::EWOULDBLOCK, Errno::EAGAIN
-        backoff *= 2
+        backoff *= 2 if backoff < @max_delay
         IO.select([@io], [], [], backoff)
       rescue EOFError
         @run = false

--- a/spec/shared-examples/subprocess-runner.rb
+++ b/spec/shared-examples/subprocess-runner.rb
@@ -20,6 +20,18 @@ shared_examples_for "a subprocess runner" do |fixture_root|
     end
   end
 
+  describe "running a command with a large amount of output" do
+    subject do
+      described_class.new(['ruby', '-e', 'blob = "buffalo!" * (2 << 16); puts blob'])
+    end
+
+    it "does not hang" do
+      Timeout.timeout(5) do
+        subject.run
+      end
+    end
+  end
+
   describe "running 'ls' with a different working directory" do
     subject do
       described_class.new(%w[ls]).tap do |o|

--- a/spec/unit/util/subprocess/runner/pump_spec.rb
+++ b/spec/unit/util/subprocess/runner/pump_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'r10k/util/subprocess/runner/pump'
+
+describe R10K::Util::Subprocess::Runner::Pump do
+
+  let(:pair) { IO.pipe }
+  let(:r) { pair.first }
+  let(:w) { pair.last }
+
+  after do
+    pair.each { |io| io.close unless io.closed? }
+  end
+
+  subject { described_class.new(r) }
+
+  it "returns an empty string if nothing has been read" do
+    expect(subject.string).to eq('')
+  end
+
+  describe "reading all data in the stream" do
+    it "reads data until the stream reaches EOF" do
+      subject.start
+      w << "hello"
+      w << " "
+      w << "world!"
+      w.close
+      subject.wait
+      expect(subject.string).to eq("hello world!")
+    end
+  end
+
+  describe "halting" do
+    it "does not read any more information read off the pipe" do
+      subject.min_delay = 0.01
+      subject.start
+      w << "hello"
+
+      # This should ensure that we yield to the pumping thread. If this test
+      # sporadically fails then we may need to increase the timeout.
+      sleep 0.1
+      subject.halt!
+      w << " world!"
+
+      expect(subject.string).to eq("hello")
+    end
+  end
+
+  # Linux 2.6.11+ has a maximum pipe capacity of 64 KiB, and writing to the
+  # pipe when the pipe is at capacity will block. To make sure the pump is
+  # actively removing contents from the pipe we need to attempt to fill up
+  # the entire pipe.
+  #
+  # See man pipe(7)
+  it "does not block if more than 64 kilobytes are fed into the pipe" do
+    # The maximum pipe buffer size is 2 ** 16 bytes, so that's the minimum
+    # amount of data needed to cause further writes to block. We then double
+    # this value to make sure that we are continuously emptying the pipe.
+    pipe_buffer_size = 2 ** 17
+    blob = "buffalo!" * pipe_buffer_size
+    subject.start
+    Timeout.timeout(60) { w << blob }
+    w.close
+    subject.wait
+  end
+end

--- a/spec/unit/util/subprocess/runner/pump_spec.rb
+++ b/spec/unit/util/subprocess/runner/pump_spec.rb
@@ -45,6 +45,19 @@ describe R10K::Util::Subprocess::Runner::Pump do
     end
   end
 
+  describe "backing off" do
+    it "does not back off more than the max delay time" do
+      subject.max_delay = 0.005
+      subject.start
+      sleep 0.1
+
+      Timeout.timeout(0.01) do
+        subject.halt!
+      end
+
+    end
+  end
+
   # Linux 2.6.11+ has a maximum pipe capacity of 64 KiB, and writing to the
   # pipe when the pipe is at capacity will block. To make sure the pump is
   # actively removing contents from the pipe we need to attempt to fill up


### PR DESCRIPTION
This pull request is based on GH-276. 

See https://tickets.puppetlabs.com/browse/RK-10 and https://github.com/puppetlabs/r10k/issues/265 .
