### PR TITLE
(CODEMGMT-30) Rename and Move Integration Tests

### DIFF
--- a/integration/test_run_scripts/user_scenario/basic_workflow/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/user_scenario/basic_workflow/all_tests-pe-centos6.sh
@@ -3,8 +3,8 @@ SCRIPT_PATH=$(pwd)
 BASENAME_CMD="basename ${SCRIPT_PATH}"
 SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
 
-if [ $SCRIPT_BASE_PATH = "user_scenario" ]; then
-  cd ../../
+if [ $SCRIPT_BASE_PATH = "basic_workflow" ]; then
+  cd ../../../
 fi
 
 export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
@@ -13,7 +13,7 @@ beaker \
   --preserve-hosts onfail \
   --config configs/pe/centos-6-64mda \
   --debug \
-  --tests tests/user_scenario \
+  --tests tests/user_scenario/basic_workflow \
   --keyfile ~/.ssh/id_rsa-acceptance \
   --pre-suite pre-suite/pe_install.rb,pre-suite/pe_r10k.rb \
   --load-path lib

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
@@ -1,6 +1,6 @@
 require 'git_utils'
 require 'master_manipulator'
-test_name "RK-5 - C59118 - Basic User Scenario"
+test_name 'CODEMGMT - C59121 - Single Environment with Custom Module and Forge Module'
 
 #Init
 master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
@@ -9,12 +9,30 @@ last_commit = git_last_commit(master, git_environments_path)
 local_files_root_path = ENV['FILES'] || 'files'
 helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
 
-#Manifest
-site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
-site_pp = create_site_pp(master_certname, '  include helloworld')
-
 #Verification
+motd_path = '/etc/motd'
+motd_contents = 'Hello!'
+motd_contents_regex = /\A#{motd_contents}\z/
+
 notify_message_regex = /I am in the production environment/
+
+#File
+puppet_file = <<-PUPPETFILE
+mod "puppetlabs/motd"
+PUPPETFILE
+
+puppet_file_path = File.join(git_environments_path, 'Puppetfile')
+
+#Manifest
+manifest = <<-MANIFEST
+  class { 'helloworld': }
+  class { 'motd':
+    content => '#{motd_contents}',
+  }
+MANIFEST
+
+site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
+site_pp = create_site_pp(master_certname, manifest)
 
 #Teardown
 teardown do
@@ -32,17 +50,25 @@ scp_to(master, helloworld_module_path, File.join(git_environments_path, "site", 
 step 'Inject New "site.pp" to the "production" Environment'
 inject_site_pp(master, site_pp_path, site_pp)
 
+step 'Create "Puppetfile" for the "production" Environment'
+create_remote_file(master, puppet_file_path, puppet_file)
+
 step 'Push Changes'
-git_add_commit_push(master, 'production', 'Update site.pp and add module.', git_environments_path)
+git_add_commit_push(master, 'production', 'Update site.pp and add modules.', git_environments_path)
 
 #Tests
 step 'Deploy "production" Environment via r10k'
-on(master, 'r10k deploy environment -v')
+on(master, 'r10k deploy environment -v -p')
 
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
+  end
+
+  step "Verify MOTD Contents"
+  on(agent, "cat #{motd_path}") do |result|
+    assert_match(motd_contents_regex, result.stdout, 'File content is invalid!')
   end
 end

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_module.rb
@@ -1,6 +1,6 @@
 require 'git_utils'
 require 'master_manipulator'
-test_name "RK-12 - C59121 - Custom Module with Forge Module"
+test_name 'CODEMGMT-22 - C59118 - Single Environment with Custom Module'
 
 #Init
 master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
@@ -9,30 +9,12 @@ last_commit = git_last_commit(master, git_environments_path)
 local_files_root_path = ENV['FILES'] || 'files'
 helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
 
-#Verification
-motd_path = '/etc/motd'
-motd_contents = 'Hello!'
-motd_contents_regex = /\A#{motd_contents}\z/
-
-notify_message_regex = /I am in the production environment/
-
-#File
-puppet_file = <<-PUPPETFILE
-mod "puppetlabs/motd"
-PUPPETFILE
-
-puppet_file_path = File.join(git_environments_path, 'Puppetfile')
-
 #Manifest
-manifest = <<-MANIFEST
-  class { 'helloworld': }
-  class { 'motd':
-    content => '#{motd_contents}',
-  }
-MANIFEST
-
 site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
-site_pp = create_site_pp(master_certname, manifest)
+site_pp = create_site_pp(master_certname, '  include helloworld')
+
+#Verification
+notify_message_regex = /I am in the production environment/
 
 #Teardown
 teardown do
@@ -50,25 +32,17 @@ scp_to(master, helloworld_module_path, File.join(git_environments_path, "site", 
 step 'Inject New "site.pp" to the "production" Environment'
 inject_site_pp(master, site_pp_path, site_pp)
 
-step 'Create "Puppetfile" for the "production" Environment'
-create_remote_file(master, puppet_file_path, puppet_file)
-
 step 'Push Changes'
-git_add_commit_push(master, 'production', 'Update site.pp and add modules.', git_environments_path)
+git_add_commit_push(master, 'production', 'Update site.pp and add module.', git_environments_path)
 
 #Tests
 step 'Deploy "production" Environment via r10k'
-on(master, 'r10k deploy environment -v -p')
+on(master, 'r10k deploy environment -v')
 
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
-  end
-
-  step "Verify MOTD Contents"
-  on(agent, "cat #{motd_path}") do |result|
-    assert_match(motd_contents_regex, result.stdout, 'File content is invalid!')
   end
 end


### PR DESCRIPTION
Now that I have a better understanding of r10k I need to rename and move
existing integration tests so that it follows the logical pattern of the r10k
design. This change does not affect how the tests run.
