### PR TITLE
[runner/posix] (RK-18) Read stdout/stderr to EOF

### DIFF
--- a/lib/r10k/util/subprocess/runner/posix.rb
+++ b/lib/r10k/util/subprocess/runner/posix.rb
@@ -77,8 +77,8 @@ class R10K::Util::Subprocess::Runner::POSIX < R10K::Util::Subprocess::Runner
       _, @status = Process.waitpid2(pid)
     else
       _, @status = Process.waitpid2(pid)
-      @stdout_pump.halt!
-      @stderr_pump.halt!
+      @stdout_pump.wait
+      @stderr_pump.wait
       stdout = @stdout_pump.string
       stderr = @stderr_pump.string
     end


### PR DESCRIPTION
In order to capture all command output we need to read until an explicit EOF on the IO pipes.

This conflicts with GH-169.
