### PR TITLE
[subprocess/runner] (RK-18) fix output truncation

### DIFF
--- a/lib/r10k/util/subprocess/runner/posix.rb
+++ b/lib/r10k/util/subprocess/runner/posix.rb
@@ -77,8 +77,8 @@ class R10K::Util::Subprocess::Runner::POSIX < R10K::Util::Subprocess::Runner
       _, @status = Process.waitpid2(pid)
     else
       _, @status = Process.waitpid2(pid)
-      @stdout_pump.halt!
-      @stderr_pump.halt!
+      @stdout_pump.wait
+      @stderr_pump.wait
       stdout = @stdout_pump.string
       stderr = @stderr_pump.string
     end

--- a/spec/shared-examples/subprocess-runner.rb
+++ b/spec/shared-examples/subprocess-runner.rb
@@ -32,6 +32,17 @@ shared_examples_for "a subprocess runner" do |fixture_root|
     end
   end
 
+  describe "running a command with a sleep in it" do
+    subject do
+      described_class.new(['ruby', '-e', 'print("foo"); sleep(1); print("bar")'])
+    end
+
+    it "does not truncate output" do
+      result = subject.run
+      expect(result.stdout).to eq 'foobar'
+    end
+  end
+
   describe "running 'ls' with a different working directory" do
     subject do
       described_class.new(%w[ls]).tap do |o|


### PR DESCRIPTION
This is an alternate solution (to #285) which should fix JIRA issue [RK-18](https://tickets.puppetlabs.com/browse/RK-18) while maintaining compatibility with #169.  I had some difficulty reproducing the issue as written, but I was able to trigger a race condition consistently by adding a sleep to the loop in the Pump class's pump function and running the Runner::Posix spec tests.  This PR includes an additional test which helped with the debugging process.  I am unable to re-produce the problem with this change applied.  The implementation of this PR is explained in the commit message, but the essential issue is that the pump thread could terminate too early while data was still in the pipe due to a lack of synchronization.  Reading until EOF would be simpler, but would cause r10k to block when a grandchild process holds a pipe open (see #169).
