### PR TITLE
[deployment] prefix support for multi-tenancy

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -116,7 +116,7 @@ from. It may be any valid URL that the source may check out or clone. The remote
 must be able to be fetched without any interactive input, eg usernames or
 passwords cannot be prompted for in order to fetch the remote.
 
-```
+```yaml
 ---
 sources:
   mysource:
@@ -155,6 +155,10 @@ sources:
     basedir: '/etc/puppet/environments'
     prefix: true # All environments will be prefixed with "mysource_"
 ```
+#### prefix behaviour
+* if `true` environment folder will be prefixed with the name of the source.
+* if `false` (default) environment folder will not be prefixed
+* if `String` environment folder will be prefixed with the `prefix` value.
 
 Examples
 --------
@@ -224,3 +228,34 @@ This will create the following directory structure:
 `-- dev_loadtest     # dev repository, loadtest branch
 ```
 
+#### Multiple tenancy with external hieradata
+
+If hiera data is in a separate repository from your control repository, you
+must override the `prefix` so environment folders line up in both directories:
+
+```yaml
+---
+  sources:
+    main:
+      app1_data:
+        remote: 'git://git-server.site/my-org/app1-hieradata'
+        basedir: '/etc/puppet/hieradata'
+        prefix: "app1"
+      app1_modules:
+        remote: 'git://git-server.site/my-org/app1-puppet-modules'
+        basedir: '/etc/puppet/environments'
+        prefix: "app1"
+```
+
+
+This will create the following directory structure:
+
+```
+/etc/puppet/environments
+|-- app1_production  # app1 modules repository, production branch
+|-- app1_develop     # app1 modules repository, develop branch
+
+/etc/puppet/hieradata
+|-- app1_production  # app1 data repository, production branch
+|-- app1_develop     # app1 data repository, develop branch
+```

--- a/lib/r10k/environment/name.rb
+++ b/lib/r10k/environment/name.rb
@@ -59,15 +59,27 @@ module R10K
       def dirname
         dir = @name.dup
 
-        if @prefix
-          dir = "#{@source}_#{dir}"
-        end
+        prefix = derive_prefix(@source,@prefix)
 
         if @correct
           dir.gsub!(INVALID_CHARACTERS, '_')
         end
 
-        dir
+        "#{prefix}#{dir}"
+      end
+
+
+      private
+
+      def derive_prefix(source,prefix)
+
+        if prefix == true
+          "#{source}_"
+        elsif prefix.is_a? String
+          "#{prefix}_"
+        else
+          nil
+        end
       end
     end
   end

--- a/lib/r10k/source/base.rb
+++ b/lib/r10k/source/base.rb
@@ -12,8 +12,8 @@ class R10K::Source::Base
   attr_reader :name
 
   # @!attribute [r] prefix
-  #   @return [true, false] Whether the source name should be prefixed to each
-  #     environment basedir. Defaults to false
+  #   @return [String, nil] The prefix for the environments basedir.
+  #     Defaults to nil.
   attr_reader :prefix
 
   # Initialize the given source.
@@ -23,9 +23,9 @@ class R10K::Source::Base
   # @param options [Hash] An additional set of options for this source. The
   #   semantics of this hash may depend on the source implementation.
   #
-  # @option options [Boolean] :prefix Whether to prefix the source name to the
-  #   environment directory names. All sources should respect this option.
-  #   Defaults to false.
+  # @option options [Boolean, String] :prefix If a String this becomes the prefix.
+  #   If true, will use the source name as the prefix. All sources should respect this option.
+  #   Defaults to false for no environment prefix.
   def initialize(name, basedir, options = {})
     @name    = name
     @basedir = basedir

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -42,8 +42,9 @@ class R10K::Source::Git < R10K::Source::Base
   # @param basedir [String] The base directory where the generated environments will be created.
   # @param options [Hash] An additional set of options for this source.
   #
-  # @option options [Boolean] :prefix Whether to prefix the source name to the
-  #   environment directory names. Defaults to false.
+  # @option options [Boolean, String] :prefix If a String this becomes the prefix.
+  #   If true, will use the source name as the prefix.
+  #   Defaults to false for no environment prefix.
   # @option options [String] :remote The URL to the base directory of the SVN repository
   # @option options [Hash] :remote Additional settings that configure how the
   #   source should behave.

--- a/spec/unit/environment/name_spec.rb
+++ b/spec/unit/environment/name_spec.rb
@@ -12,6 +12,16 @@ describe R10K::Environment::Name do
       bn = described_class.new('mybranch', :source => 'source', :prefix => true)
       expect(bn.dirname).to eq 'source_mybranch'
     end
+
+    it "prepends the prefix name when prefixing is overridden" do
+      bn = described_class.new('mybranch', {:prefix => "bar", :sourcename => 'foo'})
+      expect(bn.dirname).to eq 'bar_mybranch'
+    end
+
+    it "uses the branch name as the dirname when prefixing is nil" do
+      bn = described_class.new('mybranch', {:prefix => nil, :sourcename => 'foo'})
+      expect(bn.dirname).to eq 'mybranch'
+    end
   end
 
   describe "determining the validate behavior with :invalid" do


### PR DESCRIPTION
Intended to solve #195 

This adds functionality to the **prefix** config variable, changing the type from _boolean_ to a  _boolean/String_ hybrid. 

This feature is backwards compatible - existing deployments of r10k should be unaffected, as true/false are still valid, and the default value is still false.
