### PR TITLE
(CODEMGMT-74) Fix Broken Test

### DIFF
--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
@@ -16,7 +16,7 @@ PUPPETFILE
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')
 
 #Verification
-error_message_regex = /fatal: HTTP request failed/
+error_message_regex = /ERROR\] Couldn't update git cache/
 
 #Teardown
 teardown do


### PR DESCRIPTION
The "neg_bad_git_module.rb" test fails on EL 7 platforms because of a weak
regex for an error message.
