### PR TITLE
[doc] Improve link title text

### DIFF
--- a/doc/dynamic-environments/git-environments.mkd
+++ b/doc/dynamic-environments/git-environments.mkd
@@ -12,7 +12,7 @@ The core idea of dynamic environments is that you should be able to manage your
 Puppet modules in the same manner that you would manage any other code base. It
 builds on top of Git topic branch model.
 
-[git-topic-branching]: http://git-scm.com/book/en/Git-Branching-Branching-Workflows#Topic-Branches "Git Topic Branches"
+[git-topic-branching]: http://git-scm.com/book/en/Git-Branching-Branching-Workflows#Topic-Branches
 
 One of the most prevalent ways of using Git relies on using [topic branches][git-topic-branching].
 Whenever changes need to be made that need to be reviewed or tested before going

--- a/doc/faq.mkd
+++ b/doc/faq.mkd
@@ -43,10 +43,10 @@ on your remote repositories:
   * [Gitolite v2][gitolite-v2-default-branch]
   * [Gitolite v3][gitolite-v3-default-branch]
 
-[git-clone]: https://www.kernel.org/pub/software/scm/git/docs/git-clone.html "git-clone(1)"
-[git-symbolic-ref]: https://www.kernel.org/pub/software/scm/git/docs/git-symbolic-ref.html "git-symbolic-ref(1)"
+[git-clone]: https://www.kernel.org/pub/software/scm/git/docs/git-clone.html "Man page for git-clone"
+[git-symbolic-ref]: https://www.kernel.org/pub/software/scm/git/docs/git-symbolic-ref.html "Man page for git-symbolic-ref"
 
-[github-default-branch]: https://help.github.com/articles/setting-the-default-branch "Setting the default branch"
-[bitbucket-default-branch]: https://answers.atlassian.com/questions/280944/how-to-change-main-branch-in-bitbucket "How to change MAIN branch in BitBucket?"
-[gitolite-v2-default-branch]: http://stackoverflow.com/questions/7091599/git-default-remote-branch-with-gitolite "git default remote branch with gitolite"
-[gitolite-v3-default-branch]: http://stackoverflow.com/questions/13949093/git-change-default-branch-gitolite "git change default branch (gitolite)"
+[github-default-branch]: https://help.github.com/articles/setting-the-default-branch "Changing the default branch on GitHub"
+[bitbucket-default-branch]: https://answers.atlassian.com/questions/280944/how-to-change-main-branch-in-bitbucket "Changing the default branch on Bitbucket"
+[gitolite-v2-default-branch]: http://stackoverflow.com/questions/7091599/git-default-remote-branch-with-gitolite "Changing the default branch on Gitolite v2"
+[gitolite-v3-default-branch]: http://stackoverflow.com/questions/13949093/git-change-default-branch-gitolite "Changing the default branch on Gitolite v3"


### PR DESCRIPTION
As per http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/H33, link title text should be used to clarify the purpose of a link when necessary.  This pull request clarifies the title text of several links and removes the title text of one link for which it was unnecessary.
