### PR TITLE
Don't link to the librarian-puppet Puppetfile docs

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -8,11 +8,10 @@ Puppet environment and module deployment
 Description
 -----------
 
-[librarian-puppet]: https://github.com/rodjek/librarian-puppet
 [workflow]: http://puppetlabs.com/blog/git-workflow-and-puppet-environments/
 
 R10k provides a general purpose toolset for deploying Puppet environments and
-modules. It implements the [Puppetfile][librarian-puppet] format and provides a native
+modules. It implements the [Puppetfile](doc/puppetfile.mkd) format and provides a native
 implementation of Puppet [dynamic environments][workflow].
 
 Requirements


### PR DESCRIPTION
The acceptable Puppetfile format defers slightly for r10k compared to librarian-puppet.
eg. puppetlabs/ntp compared to puppetlabs-ntp
This patch links to the r10k docs instead to avoid confusion.
