### PR TITLE
Don't include spec/integration in gemspec files

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'yard', '~> 0.8.7.3'
 
-  s.files        = %x[git ls-files].split($/)
+  s.files        = %x[git ls-files].split($/).select { |path| !path.match(/^("?integration|spec)/) }
   s.require_path = 'lib'
   s.bindir       = 'bin'
   s.executables  = 'r10k'

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -40,6 +40,4 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.bindir       = 'bin'
   s.executables  = 'r10k'
-
-  s.test_files   = Dir.glob("spec/**/*_spec.rb")
 end


### PR DESCRIPTION
The unicode files in the `integration` directory are causing bundler to complain about the gemspec being invalid, and specs aren't really used as part of the installed gem. We can ignore both.
