### PR TITLE
(CODEMGMT-94) Fix Skipping Tests

### DIFF
--- a/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
@@ -3,8 +3,6 @@ require 'r10k_utils'
 require 'master_manipulator'
 test_name 'CODEMGMT-63 - C59258 - Attempt to Deploy Environment with Duplicate Module Names'
 
-skip_test('Skipping test because of CODEMGMT-71')
-
 #Init
 git_environments_path = '/root/environments'
 last_commit = git_last_commit(master, git_environments_path)
@@ -37,6 +35,8 @@ git_add_commit_push(master, 'production', 'Add modules.', git_environments_path)
 
 #Tests
 step 'Attempt to Deploy via r10k'
-on(master, 'r10k deploy environment -v -p', :acceptable_exit_codes => 1) do |result|
-  assert_match(error_message_regex, result.stderr, 'Expected message not found!')
+on(master, 'r10k deploy environment -v -p', :acceptable_exit_codes => 0) do |result|
+  expect_failure('Expected to fail due to CODEMGMT-71') do
+    assert_match(error_message_regex, result.stderr, 'Expected message not found!')
+  end
 end

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_invalid_env_name.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_invalid_env_name.rb
@@ -3,16 +3,13 @@ require 'r10k_utils'
 require 'master_manipulator'
 test_name 'CODEMGMT-63 - C62511 - Attempt to Deploy Environment Containing Invalid Character in Name'
 
-#Note: this is not much of a negative test because it actually works.
-#Waiting on CODEMGMT-65 so that this actually fails.
-
 #Init
 git_environments_path = '/root/environments'
 last_commit = git_last_commit(master, git_environments_path)
 invalid_env_name = 'should-not-contain-dashes'
 
 #Verification
-error_message_regex = /WARN\] Environment "#{invalid_env_name}" contained non-word characters/
+error_message_regex = /ERROR\]/
 
 #Teardown
 teardown do
@@ -30,5 +27,7 @@ git_push(master, invalid_env_name, git_environments_path)
 #Tests
 step 'Attempt to Deploy via r10k'
 on(master, 'r10k deploy environment -v') do |result|
-  assert_match(error_message_regex, result.stderr, 'Expected message not found!')
+  expect_failure('Expected to fail due to CODEMGMT-65') do
+    assert_match(error_message_regex, result.stderr, 'Expected message not found!')
+  end
 end


### PR DESCRIPTION
Beaker has been updated to include the "expect_failure" function. This new
function allows us to phase out the use of "skip_test". Now tests will fail
when the underlying bug is fixed.
