### PR TITLE
[runner/pump] reduce minimum wait delay

### DIFF
--- a/lib/r10k/util/subprocess/runner/pump.rb
+++ b/lib/r10k/util/subprocess/runner/pump.rb
@@ -22,7 +22,7 @@ class R10K::Util::Subprocess::Runner::Pump
     @thread = nil
     @string = ''
     @run    = true
-    @min_delay = 0.001
+    @min_delay = 0.1
     @max_delay = 1.0
   end
 


### PR DESCRIPTION
The pump loop uses IO.select to sleep between reads, which means that
we'll restart the loop as soon as data becomes available. This means
that we can be much less aggressive in how we poll the IO instance.
