### PR TITLE
Add the local module type

### DIFF
--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -188,7 +188,7 @@ appropriately secured.
 
 You can define manually managed modules using the `:local` type.
 
-    mod 'my_module', :local
+    mod 'mymodule', :local
 
 ## Environment variables
 

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -188,7 +188,7 @@ appropriately secured.
 
 You can define manually managed modules using the `:local` type.
 
-    mod 'my-module', :local
+    mod 'my_module', :local
 
 ## Environment variables
 

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -184,6 +184,12 @@ credentials may be visible in the process table when r10k is running. If you
 choose to supply SVN credentials make sure that the system running r10k is
 appropriately secured.
 
+### Local
+
+You can define manually managed modules using the `:local` type.
+
+    mod 'my-module', :local
+
 ## Environment variables
 
 It is possible to set an alternate name/location for your `Puppetfile` and

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -186,9 +186,16 @@ appropriately secured.
 
 ### Local
 
-You can define manually managed modules using the `:local` type.
+In the event you want to store locally written modules in your r10k-managed
+repository rather than storing each in their own repository, you can use 
+the `:local` type. 
+
+For instance, if you create a module under `modules` with the name `mymodule` 
+then the following will tell r10k to not manage that module.
 
     mod 'mymodule', :local
+
+**Note**: Version control is not supported in this scenario. *Caveat Emptor*.
 
 ## Environment variables
 

--- a/lib/r10k/module.rb
+++ b/lib/r10k/module.rb
@@ -33,4 +33,5 @@ module R10K::Module
   require 'r10k/module/git'
   require 'r10k/module/svn'
   require 'r10k/module/forge'
+  require 'r10k/module/local'
 end

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -18,4 +18,11 @@ class R10K::Module::Local < R10K::Module::Base
 
   def sync
   end
+
+  private
+
+  def parse_title(title)
+    ["", title]
+  end
+
 end

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -1,0 +1,21 @@
+require 'r10k/module'
+
+class R10K::Module::Local < R10K::Module::Base
+
+  R10K::Module.register(self)
+
+  def self.implement?(name, args)
+    args.is_a? Symbol and args == :local
+  end
+
+  def initialize(name, dirname, opts)
+    super
+  end
+
+  def status
+    :insync
+  end
+
+  def sync
+  end
+end


### PR DESCRIPTION
Fixes #172 

This type is needed in cases where the 'modules' directory contains "managed" and "unmanaged" modules in the same time. Local module type protects modules from purging during r10k run.
