### PR TITLE
(RK-17) Move Shell based git implementation to namespace

### DIFF
--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -1,6 +1,5 @@
 require 'r10k/git'
-require 'r10k/git/repository'
-require 'r10k/git/bare_repository'
+require 'r10k/git/shellgit/bare_repository'
 
 require 'r10k/settings'
 require 'r10k/instance_cache'
@@ -53,7 +52,7 @@ class R10K::Git::Cache
   # @param [String] cache_root
   def initialize(remote)
     @remote = remote
-    @repo = R10K::Git::BareRepository.new(settings[:cache_root], sanitized_dirname)
+    @repo = R10K::Git::ShellGit::BareRepository.new(settings[:cache_root], sanitized_dirname)
   end
 
   def sync

--- a/lib/r10k/git/shellgit.rb
+++ b/lib/r10k/git/shellgit.rb
@@ -1,0 +1,9 @@
+module R10K
+  module Git
+    module ShellGit
+      require 'r10k/git/shellgit/bare_repository'
+      require 'r10k/git/shellgit/working_repository'
+      require 'r10k/git/shellgit/thin_repository'
+    end
+  end
+end

--- a/lib/r10k/git/shellgit/bare_repository.rb
+++ b/lib/r10k/git/shellgit/bare_repository.rb
@@ -1,9 +1,8 @@
-require 'r10k/git'
-require 'r10k/git/base_repository'
-require 'r10k/logging'
+require 'r10k/git/shellgit'
+require 'r10k/git/shellgit/base_repository'
 
 # Create and manage Git bare repositories.
-class R10K::Git::BareRepository < R10K::Git::BaseRepository
+class R10K::Git::ShellGit::BareRepository < R10K::Git::ShellGit::BaseRepository
 
   # @return [Pathname] The path to this Git repository
   def git_dir

--- a/lib/r10k/git/shellgit/base_repository.rb
+++ b/lib/r10k/git/shellgit/base_repository.rb
@@ -1,7 +1,7 @@
-require 'r10k/git'
+require 'r10k/git/shellgit'
 require 'r10k/logging'
 
-class R10K::Git::BaseRepository
+class R10K::Git::ShellGit::BaseRepository
 
   # @abstract
   # @return [Pathname] The path to the Git directory

--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -1,11 +1,11 @@
-require 'r10k/git'
-require 'r10k/git/working_repository'
+require 'r10k/git/shellgit'
+require 'r10k/git/shellgit/working_repository'
 
 # Manage a Git working repository backed with cached bare repositories. Instead
 # of duplicating all objects for new clones and updates, this uses Git
 # alternate object databases to reuse objects from an existing repository,
 # making new clones very lightweight.
-class R10K::Git::ThinRepository < R10K::Git::WorkingRepository
+class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingRepository
 
   def initialize(basedir, dirname)
     super

--- a/lib/r10k/git/shellgit/working_repository.rb
+++ b/lib/r10k/git/shellgit/working_repository.rb
@@ -1,9 +1,9 @@
 require 'r10k/git'
-require 'r10k/git/base_repository'
 require 'r10k/git/alternates'
+require 'r10k/git/shellgit/base_repository'
 
 # Manage a non-bare Git repository
-class R10K::Git::WorkingRepository < R10K::Git::BaseRepository
+class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseRepository
 
   # @attribute [r] path
   #   @return [Pathname]

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -1,4 +1,4 @@
-require 'r10k/git/thin_repository'
+require 'r10k/git/shellgit/thin_repository'
 require 'r10k/git/errors'
 require 'forwardable'
 
@@ -22,7 +22,7 @@ class R10K::Git::StatefulRepository
     @ref = ref
     @remote = remote
 
-    @repo = R10K::Git::ThinRepository.new(basedir, dirname)
+    @repo = R10K::Git::ShellGit::ThinRepository.new(basedir, dirname)
     @cache = R10K::Git::Cache.generate(remote)
   end
 

--- a/spec/integration/git/shellgit/bare_repository_spec.rb
+++ b/spec/integration/git/shellgit/bare_repository_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'r10k/git/bare_repository'
+require 'r10k/git/shellgit/bare_repository'
 
-describe R10K::Git::BareRepository do
+describe R10K::Git::ShellGit::BareRepository do
   include_context 'Git integration'
 
   let(:dirname) { 'bare-repo.git' }

--- a/spec/integration/git/shellgit/thin_repository_spec.rb
+++ b/spec/integration/git/shellgit/thin_repository_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'r10k/git/thin_repository'
+require 'r10k/git/shellgit/thin_repository'
 
-describe R10K::Git::ThinRepository do
+describe R10K::Git::ShellGit::ThinRepository do
   include_context 'Git integration'
 
   let(:dirname) { 'working-repo' }

--- a/spec/integration/git/shellgit/working_repository_spec.rb
+++ b/spec/integration/git/shellgit/working_repository_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'r10k/git/working_repository'
+require 'r10k/git/shellgit/working_repository'
 
-describe R10K::Git::WorkingRepository do
+describe R10K::Git::ShellGit::WorkingRepository do
   include_context 'Git integration'
 
   let(:dirname) { 'working-repo' }

--- a/spec/integration/git/stateful_repository_spec.rb
+++ b/spec/integration/git/stateful_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'r10k/git/thin_repository'
+require 'r10k/git/shellgit/thin_repository'
 require 'r10k/git/stateful_repository'
 
 describe R10K::Git::StatefulRepository do
@@ -7,7 +7,7 @@ describe R10K::Git::StatefulRepository do
 
   let(:dirname) { 'working-repo' }
 
-  let(:thinrepo) { R10K::Git::ThinRepository.new(basedir, dirname) }
+  let(:thinrepo) { R10K::Git::ShellGit::ThinRepository.new(basedir, dirname) }
   let(:cacherepo) { R10K::Git::Cache.generate(remote) }
 
   subject { described_class.new('0.9.x', remote, basedir, dirname) }


### PR DESCRIPTION
This moves all Git classes that are based on shelling out to Git into a separate namespace, pending the implementation of a Rugged based Git implementation. It does not add any new behavior and just renames/renamespaces files.

This pull request is based on GH-318.
