### PR TITLE
Improve Git integration #fetch specs

### DIFF
--- a/spec/shared-examples/git/bare_repository.rb
+++ b/spec/shared-examples/git/bare_repository.rb
@@ -20,20 +20,19 @@ RSpec.shared_examples "a git bare repository" do
   end
 
   describe "updating the repo" do
-    let(:objectdir) { objectdir = File.join(basedir, dirname, 'objects') }
+    let(:tag_090) { subject.git_dir + 'refs' + 'tags' + '0.9.0' }
+    let(:packed_refs) { subject.git_dir + 'packed-refs' }
 
     before do
       subject.clone(remote)
-      # Remove objects to pretend the upstream made changes
-      Dir.glob(File.join(objectdir, '*')).each do |path|
-        FileUtils.rm_rf(path)
-      end
+      tag_090.delete if tag_090.exist?
+      packed_refs.delete if packed_refs.exist?
     end
 
     it "fetches objects from the remote" do
+      expect(subject.tags).to_not include('0.9.0')
       subject.fetch
-      objectfiles = Dir.glob(File.join(objectdir, '*'))
-      expect(objectfiles).to_not be_empty
+      expect(subject.tags).to include('0.9.0')
     end
   end
 

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -57,6 +57,22 @@ RSpec.shared_examples "a git working repository" do
     end
   end
 
+  describe "updating the repo" do
+    let(:tag_090) { subject.git_dir + 'refs' + 'tags' + '0.9.0' }
+    let(:packed_refs) { subject.git_dir + 'packed-refs' }
+
+    before do
+      subject.clone(remote)
+      tag_090.delete if tag_090.exist?
+      packed_refs.delete if packed_refs.exist?
+    end
+
+    it "fetches objects from the remote" do
+      subject.fetch
+      expect(subject.tags).to include('0.9.0')
+    end
+  end
+
   describe "listing branches" do
     before do
       subject.clone(remote)


### PR DESCRIPTION
The bare repository integration specs for testing #fetch were a bit sketchy and the working repository specs had no test coverage for #fetch at all; this commit adds a better test case and applies it to the working repository shared examples as well.
