### PR TITLE
Add Settings::Container#reset!, set up inheritance relationship

### DIFF
--- a/lib/r10k/settings/container.rb
+++ b/lib/r10k/settings/container.rb
@@ -74,6 +74,12 @@ class R10K::Settings::Container
     end
   end
 
+  # Clear all existing settings in this container. Valid settings are left alone.
+  # @return [void]
+  def reset!
+    @settings = {}
+  end
+
   private
 
   def validate_key!(key)

--- a/lib/r10k/settings/mixin.rb
+++ b/lib/r10k/settings/mixin.rb
@@ -41,5 +41,14 @@ module R10K::Settings::Mixin
     def settings
       @settings ||= R10K::Settings::Container.new(defaults)
     end
+
+    # Allow subclasses to use the settings of the parent class as default values
+    #
+    # @return [void]
+    def inherited(subclass)
+      subclass.instance_eval do
+        @settings = R10K::Settings::Container.new(superclass.settings)
+      end
+    end
   end
 end

--- a/spec/unit/settings/container_spec.rb
+++ b/spec/unit/settings/container_spec.rb
@@ -65,4 +65,21 @@ describe R10K::Settings::Container do
       end
     end
   end
+
+  describe "resetting" do
+    before do
+      subject.add_valid_key :v
+    end
+
+    it "unsets all settings" do
+      subject[:v] = "hi"
+      subject.reset!
+      expect(subject[:v]).to be_nil
+    end
+
+    it "doesn't remove valid values" do
+      subject.reset!
+      expect(subject.valid_key?(:v)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
In order to add a rugged based Git implementation we need to subclass R10K::Git::Cache, which relies on having settings applied to the subclass. This adds adding some cleanup functionality for the tests for those examples, and reconfigures the settings mixin to properly handle inheritance of settings values.
