### PR TITLE
RK-17 Make R10K::Git::Cache an abstract class

### DIFF
--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -14,10 +14,11 @@ class R10K::Git::Cache
 
   def_setting_attr :cache_root, File.expand_path(ENV['HOME'] ? '~/.r10k/git': '/root/.r10k/git')
 
-  # Lazily construct an instance cache for R10K::Git::Cache objects
+  @instance_cache = R10K::InstanceCache.new(self)
+
   # @api private
   def self.instance_cache
-    @instance_cache ||= R10K::InstanceCache.new(self)
+    @instance_cache
   end
 
   # Generate a new instance with the given remote or return an existing object

--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -31,6 +31,10 @@ class R10K::Git::Cache
     instance_cache.generate(remote)
   end
 
+  def self.bare_repository
+    R10K::Git::ShellGit::BareRepository
+  end
+
   include R10K::Logging
 
   extend Forwardable
@@ -53,7 +57,7 @@ class R10K::Git::Cache
   # @param [String] cache_root
   def initialize(remote)
     @remote = remote
-    @repo = R10K::Git::ShellGit::BareRepository.new(settings[:cache_root], sanitized_dirname)
+    @repo = self.class.bare_repository.new(settings[:cache_root], sanitized_dirname)
   end
 
   def sync

--- a/lib/r10k/git/shellgit/cache.rb
+++ b/lib/r10k/git/shellgit/cache.rb
@@ -1,0 +1,11 @@
+require 'r10k/git/shellgit'
+require 'r10k/git/cache'
+
+class R10K::Git::ShellGit::Cache < R10K::Git::Cache
+
+  @instance_cache = R10K::InstanceCache.new(self)
+
+  def self.bare_repository
+    R10K::Git::ShellGit::BareRepository
+  end
+end

--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -1,4 +1,5 @@
 require 'r10k/git/shellgit'
+require 'r10k/git/shellgit/cache'
 require 'r10k/git/shellgit/working_repository'
 
 # Manage a Git working repository backed with cached bare repositories. Instead
@@ -45,7 +46,7 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
   private
 
   def set_cache(remote)
-    @cache_repo = R10K::Git::Cache.generate(remote)
+    @cache_repo = R10K::Git::ShellGit::Cache.generate(remote)
   end
 
   def setup_cache_remote

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -23,7 +23,7 @@ class R10K::Git::StatefulRepository
     @remote = remote
 
     @repo = R10K::Git::ShellGit::ThinRepository.new(basedir, dirname)
-    @cache = R10K::Git::Cache.generate(remote)
+    @cache = R10K::Git::ShellGit::Cache.generate(remote)
   end
 
   def sync

--- a/lib/r10k/git/working_dir.rb
+++ b/lib/r10k/git/working_dir.rb
@@ -41,7 +41,7 @@ class R10K::Git::WorkingDir < R10K::Git::Repository
     @git_dir   = File.join(@full_path, '.git')
 
     @alternates = R10K::Git::Alternates.new(Pathname.new(@git_dir))
-    @cache      = R10K::Git::Cache.generate(@remote)
+    @cache      = R10K::Git::ShellGit::Cache.generate(@remote)
 
     if ref.is_a? String
       @ref = R10K::Git::Ref.new(ref, self)

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -56,7 +56,7 @@ class R10K::Source::Git < R10K::Source::Base
     @remote           = options[:remote]
     @invalid_branches = (options[:invalid_branches] || 'correct_and_warn')
 
-    @cache  = R10K::Git::Cache.generate(@remote)
+    @cache  = R10K::Git::ShellGit::Cache.generate(@remote)
   end
 
   # Update the git cache for this git source to get the latest list of environments.

--- a/spec/integration/git/shellgit/thin_repository_spec.rb
+++ b/spec/integration/git/shellgit/thin_repository_spec.rb
@@ -8,7 +8,7 @@ describe R10K::Git::ShellGit::ThinRepository do
 
   subject { described_class.new(basedir, dirname) }
 
-  let(:cacherepo) { R10K::Git::Cache.generate(remote) }
+  let(:cacherepo) { R10K::Git::ShellGit::Cache.generate(remote) }
 
   it_behaves_like "a git thin repository"
 end

--- a/spec/integration/git/stateful_repository_spec.rb
+++ b/spec/integration/git/stateful_repository_spec.rb
@@ -8,7 +8,7 @@ describe R10K::Git::StatefulRepository do
   let(:dirname) { 'working-repo' }
 
   let(:thinrepo) { R10K::Git::ShellGit::ThinRepository.new(basedir, dirname) }
-  let(:cacherepo) { R10K::Git::Cache.generate(remote) }
+  let(:cacherepo) { R10K::Git::ShellGit::Cache.generate(remote) }
 
   subject { described_class.new('0.9.x', remote, basedir, dirname) }
 

--- a/spec/unit/git/cache_spec.rb
+++ b/spec/unit/git/cache_spec.rb
@@ -3,13 +3,21 @@ require 'r10k/git/cache'
 
 describe R10K::Git::Cache do
 
-  subject(:cache) { described_class.new('git://some/git/remote') }
+  let(:subclass) do
+    Class.new(described_class) do
+      def self.bare_repository
+        Class.new { def initialize(*args) end }
+      end
+    end
+  end
+
+  subject { subclass.new('git://some/git/remote') }
 
   describe "updating the cache" do
     it "only updates the cache once" do
-      expect(cache).to receive(:sync!).exactly(1).times
-      cache.sync
-      cache.sync
+      expect(subject).to receive(:sync!).exactly(1).times
+      subject.sync
+      subject.sync
     end
   end
 

--- a/spec/unit/git/shellgit/cache_spec.rb
+++ b/spec/unit/git/shellgit/cache_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'r10k/git/shellgit/cache'
+
+describe R10K::Git::ShellGit::Cache do
+  subject(:cache) { described_class.new('git://some/git/remote') }
+
+  it "wraps a ShellGit::BareRepository instance" do
+    expect(cache.repo).to be_a_kind_of R10K::Git::ShellGit::BareRepository
+  end
+
+  describe "settings" do
+    before do
+      R10K::Git::Cache.settings[:cache_root] = '/some/path'
+      described_class.settings.reset!
+    end
+
+    after do
+      R10K::Git::Cache.settings.reset!
+      described_class.settings.reset!
+    end
+
+    it "falls back to the parent class settings" do
+      expect(described_class.settings[:cache_root]).to eq '/some/path'
+    end
+  end
+end

--- a/spec/unit/git/shellgit/cache_spec.rb
+++ b/spec/unit/git/shellgit/cache_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 require 'r10k/git/shellgit/cache'
 
 describe R10K::Git::ShellGit::Cache do
-  subject(:cache) { described_class.new('git://some/git/remote') }
+
+  subject { described_class.new('git://some/git/remote') }
 
   it "wraps a ShellGit::BareRepository instance" do
-    expect(cache.repo).to be_a_kind_of R10K::Git::ShellGit::BareRepository
+    expect(subject.repo).to be_a_kind_of R10K::Git::ShellGit::BareRepository
   end
 
   describe "settings" do


### PR DESCRIPTION
In order to make sure that separate Git implementations don't accidentally intermix by sharing Cache objects, we need to subclass Git::Cache and use the appropriate concrete implementation. When the libgit2 implementation is merged we can switch from instantiating a specific subclass to a factory method that'll select the appropriate implementation.
