### PR TITLE
(RK-17) Add rugged based Git implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source 'https://rubygems.org'
 
 gemspec
 
+group :extra do
+  gem 'rugged', '~> 0.21.4' if RUBY_VERSION > '1.8.7'
+end
+
 group :development do
   gem 'simplecov', '~> 0.9.1' if RUBY_VERSION > '1.8.7'
 end

--- a/lib/r10k/features.rb
+++ b/lib/r10k/features.rb
@@ -14,3 +14,5 @@ module R10K
 end
 
 R10K::Features.add(:shellgit) { R10K::Util::Commands.which('git') }
+
+R10K::Features.add(:rugged, :libraries => 'rugged')

--- a/lib/r10k/git/rugged.rb
+++ b/lib/r10k/git/rugged.rb
@@ -1,3 +1,10 @@
+require 'r10k/git'
+
+begin
+  require 'rugged'
+rescue LoadError
+end
+
 module R10K
   module Git
     module Rugged

--- a/lib/r10k/git/rugged.rb
+++ b/lib/r10k/git/rugged.rb
@@ -1,0 +1,6 @@
+module R10K
+  module Git
+    module Rugged
+    end
+  end
+end

--- a/lib/r10k/git/rugged.rb
+++ b/lib/r10k/git/rugged.rb
@@ -2,6 +2,7 @@ module R10K
   module Git
     module Rugged
       require 'r10k/git/rugged/bare_repository'
+      require 'r10k/git/rugged/working_repository'
     end
   end
 end

--- a/lib/r10k/git/rugged.rb
+++ b/lib/r10k/git/rugged.rb
@@ -4,6 +4,7 @@ module R10K
       require 'r10k/git/rugged/bare_repository'
       require 'r10k/git/rugged/working_repository'
       require 'r10k/git/rugged/cache'
+      require 'r10k/git/rugged/thin_repository'
     end
   end
 end

--- a/lib/r10k/git/rugged.rb
+++ b/lib/r10k/git/rugged.rb
@@ -3,6 +3,7 @@ module R10K
     module Rugged
       require 'r10k/git/rugged/bare_repository'
       require 'r10k/git/rugged/working_repository'
+      require 'r10k/git/rugged/cache'
     end
   end
 end

--- a/lib/r10k/git/rugged.rb
+++ b/lib/r10k/git/rugged.rb
@@ -1,6 +1,7 @@
 module R10K
   module Git
     module Rugged
+      require 'r10k/git/rugged/bare_repository'
     end
   end
 end

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -1,0 +1,48 @@
+require 'r10k/git/rugged'
+require 'r10k/git/rugged/base_repository'
+require 'rugged'
+
+class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
+
+  # @param basedir [String] The base directory of the Git repository
+  # @param dirname [String] The directory name of the Git repository
+  def initialize(basedir, dirname)
+    @path = Pathname.new(File.join(basedir, dirname))
+
+    if exist?
+      @rugged_repo = ::Rugged::Repository.bare(@path.to_s)
+    end
+  end
+
+  # @return [Pathname] The path to this Git repository
+  def git_dir
+    @path
+  end
+
+  # Clone the given remote.
+  #
+  # This should only be called if the repository does not exist.
+  #
+  # @param remote [String] The URL of the Git remote to clone.
+  # @return [void]
+  def clone(remote)
+    @rugged_repo = ::Rugged::Repository.init_at(@path.to_s, true)
+    config = @rugged_repo.config
+    config['remote.origin.url']    = remote
+    config['remote.origin.fetch']  = '+refs/*:refs/*'
+    config['remote.origin.mirror'] = 'true'
+    fetch
+  end
+
+  # Fetch refs and objects from the origin remote
+  #
+  # @return [void]
+  def fetch
+    refspecs = ['+refs/*:refs/*']
+    @rugged_repo.fetch('origin', refspecs)
+  end
+
+  def exist?
+    @path.exist?
+  end
+end

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -1,6 +1,5 @@
 require 'r10k/git/rugged'
 require 'r10k/git/rugged/base_repository'
-require 'rugged'
 
 class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
 

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -10,7 +10,7 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     @path = Pathname.new(File.join(basedir, dirname))
 
     if exist?
-      @rugged_repo = ::Rugged::Repository.bare(@path.to_s)
+      @_rugged_repo = ::Rugged::Repository.bare(@path.to_s)
     end
   end
 
@@ -26,7 +26,7 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
   # @param remote [String] The URL of the Git remote to clone.
   # @return [void]
   def clone(remote)
-    @rugged_repo = ::Rugged::Repository.init_at(@path.to_s, true)
+    @_rugged_repo = ::Rugged::Repository.init_at(@path.to_s, true)
     with_repo do |repo|
       config = repo.config
       config['remote.origin.url']    = remote

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -27,11 +27,13 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
   # @return [void]
   def clone(remote)
     @rugged_repo = ::Rugged::Repository.init_at(@path.to_s, true)
-    config = @rugged_repo.config
-    config['remote.origin.url']    = remote
-    config['remote.origin.fetch']  = '+refs/*:refs/*'
-    config['remote.origin.mirror'] = 'true'
-    fetch
+    with_repo do |repo|
+      config = repo.config
+      config['remote.origin.url']    = remote
+      config['remote.origin.fetch']  = '+refs/*:refs/*'
+      config['remote.origin.mirror'] = 'true'
+      fetch
+    end
   end
 
   # Fetch refs and objects from the origin remote
@@ -39,7 +41,7 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
   # @return [void]
   def fetch
     refspecs = ['+refs/*:refs/*']
-    @rugged_repo.fetch('origin', refspecs)
+    with_repo { |repo| repo.fetch('origin', refspecs) }
   end
 
   def exist?

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -40,8 +40,8 @@ class R10K::Git::Rugged::BaseRepository
   private
 
   def with_repo
-    yield @rugged_repo if @rugged_repo
+    yield @_rugged_repo if @_rugged_repo
   ensure
-    @rugged_repo.close if @rugged_repo
+    @_rugged_repo.close if @_rugged_repo
   end
 end

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -3,7 +3,7 @@ require 'r10k/git/rugged'
 class R10K::Git::Rugged::BaseRepository
 
   def resolve(pattern)
-    object = @rugged_repo.rev_parse(pattern)
+    object = with_repo { |repo| repo.rev_parse(pattern) }
     case object
     when NilClass
       nil
@@ -17,11 +17,11 @@ class R10K::Git::Rugged::BaseRepository
   end
 
   def branches
-    @rugged_repo.branches.each_name(:local).to_a
+    with_repo { |repo| repo.branches.each_name(:local).to_a }
   end
 
   def tags
-    @rugged_repo.tags.each_name.to_a
+    with_repo { |repo| repo.tags.each_name.to_a }
   end
 
   # @return [Symbol] The type of the given ref, one of :branch, :tag, :commit, or :unknown
@@ -35,5 +35,13 @@ class R10K::Git::Rugged::BaseRepository
     else
       :unknown
     end
+  end
+
+  private
+
+  def with_repo
+    yield @rugged_repo if @rugged_repo
+  ensure
+    @rugged_repo.close if @rugged_repo
   end
 end

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -1,0 +1,39 @@
+require 'r10k/git/rugged'
+
+class R10K::Git::Rugged::BaseRepository
+
+  def resolve(pattern)
+    object = @rugged_repo.rev_parse(pattern)
+    case object
+    when NilClass
+      nil
+    when ::Rugged::Tag, ::Rugged::Tag::Annotation
+      object.target.oid
+    else
+      object.oid
+    end
+  rescue ::Rugged::ReferenceError
+    nil
+  end
+
+  def branches
+    @rugged_repo.branches.each_name(:local).to_a
+  end
+
+  def tags
+    @rugged_repo.tags.each_name.to_a
+  end
+
+  # @return [Symbol] The type of the given ref, one of :branch, :tag, :commit, or :unknown
+  def ref_type(pattern)
+    if branches.include? pattern
+      :branch
+    elsif tags.include? pattern
+      :tag
+    elsif resolve(pattern)
+      :commit
+    else
+      :unknown
+    end
+  end
+end

--- a/lib/r10k/git/rugged/cache.rb
+++ b/lib/r10k/git/rugged/cache.rb
@@ -1,0 +1,11 @@
+require 'r10k/git/rugged'
+require 'r10k/git/cache'
+
+class R10K::Git::Rugged::Cache < R10K::Git::Cache
+
+  @instance_cache = R10K::InstanceCache.new(self)
+
+  def self.bare_repository
+    R10K::Git::Rugged::BareRepository
+  end
+end

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -26,7 +26,7 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
     objectpath = (@cache_repo.git_dir + 'objects').to_s
 
     ::Rugged::Repository.init_at(@path.to_s, false)
-    @rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [objectpath])
+    @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [objectpath])
     alternates << objectpath
 
     with_repo do |repo|

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -1,0 +1,67 @@
+require 'r10k/git'
+require 'r10k/git/rugged/working_repository'
+require 'r10k/git/rugged/cache'
+
+class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
+  def initialize(basedir, dirname)
+    super
+
+    if exist? && origin
+      set_cache(origin)
+    end
+  end
+
+  # Clone this git repository
+  #
+  # @param remote [String] The Git remote to clone
+  # @param opts [Hash]
+  #
+  # @options opts [String] :ref The git ref to check out on clone
+  #
+  # @return [void]
+  def clone(remote, opts = {})
+    set_cache(remote)
+    @cache_repo.sync
+
+    objectpath = (@cache_repo.git_dir + 'objects').to_s
+
+    ::Rugged::Repository.init_at(@path.to_s, false)
+    @rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [objectpath])
+    alternates << objectpath
+
+    config = @rugged_repo.config
+    config['remote.origin.url']    = remote
+    config['remote.origin.fetch']  = '+refs/heads/*:refs/remotes/origin/*'
+    config['remote.cache.url']     = @cache_repo.git_dir.to_s
+    config['remote.cache.fetch']   = '+refs/heads/*:refs/remotes/cache/*'
+
+    if opts[:ref]
+      checkout(opts[:ref])
+    end
+  end
+
+  def checkout(ref)
+    super(@cache_repo.resolve(ref))
+  end
+
+  # Fetch refs and objects from one of the Git remotes
+  #
+  # @param remote [String] The remote to fetch, defaults to 'cache'
+  # @return [void]
+  def fetch(remote = 'cache')
+    super(remote)
+  end
+
+  # @return [String] The cache remote URL
+  def cache
+    if @rugged_repo.config
+      @rugged_repo.config['remote.cache.url']
+    end
+  end
+
+  private
+
+  def set_cache(remote)
+    @cache_repo = R10K::Git::Rugged::Cache.generate(remote)
+  end
+end

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -29,11 +29,13 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
     @rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [objectpath])
     alternates << objectpath
 
-    config = @rugged_repo.config
-    config['remote.origin.url']    = remote
-    config['remote.origin.fetch']  = '+refs/heads/*:refs/remotes/origin/*'
-    config['remote.cache.url']     = @cache_repo.git_dir.to_s
-    config['remote.cache.fetch']   = '+refs/heads/*:refs/remotes/cache/*'
+    with_repo do |repo|
+      config = repo.config
+      config['remote.origin.url']    = remote
+      config['remote.origin.fetch']  = '+refs/heads/*:refs/remotes/origin/*'
+      config['remote.cache.url']     = @cache_repo.git_dir.to_s
+      config['remote.cache.fetch']   = '+refs/heads/*:refs/remotes/cache/*'
+    end
 
     if opts[:ref]
       checkout(opts[:ref])
@@ -54,9 +56,7 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
 
   # @return [String] The cache remote URL
   def cache
-    if @rugged_repo.config
-      @rugged_repo.config['remote.cache.url']
-    end
+    with_repo { |repo| repo.config['remote.cache.url'] }
   end
 
   private

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -25,6 +25,12 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
 
     objectpath = (@cache_repo.git_dir + 'objects').to_s
 
+    # {Rugged::Repository.clone_at} doesn't support :alternates, which
+    # completely breaks how thin repositories need to work. To circumvent
+    # this we manually create a Git repository, set up git remotes, and
+    # update 'objects/info/alternates' with the path. We don't actually
+    # fetch any objects because we don't need them, and we don't actually
+    # use any refs in this repository so we skip all those steps.
     ::Rugged::Repository.init_at(@path.to_s, false)
     @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [objectpath])
     alternates << objectpath

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -1,6 +1,5 @@
 require 'r10k/git/rugged'
 require 'r10k/git/rugged/base_repository'
-require 'rugged'
 
 class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
 

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -1,0 +1,77 @@
+require 'r10k/git/rugged'
+require 'r10k/git/rugged/base_repository'
+require 'rugged'
+
+class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
+
+  #  @return [Pathname] The path to this directory
+  attr_reader :path
+
+  # @return [Pathname] The path to the Git repository inside of this directory
+  def git_dir
+    @path + '.git'
+  end
+
+  # @param basedir [String] The base directory of the Git repository
+  # @param dirname [String] The directory name of the Git repository
+  def initialize(basedir, dirname)
+    @path = Pathname.new(File.join(basedir, dirname))
+    if exist? && git_dir.exist?
+      @rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => alternates.to_a)
+    end
+  end
+
+  # Clone this git repository
+  #
+  # @param remote [String] The Git remote to clone
+  # @param opts [Hash]
+  #
+  # @options opts [String] :ref The git ref to check out on clone
+  # @options opts [String] :reference A Git repository to use as an alternate object database
+  #
+  # @return [void]
+  def clone(remote, opts = {})
+    @rugged_repo = ::Rugged::Repository.clone_at(remote, @path.to_s, :alternates => opts[:reference])
+
+    if opts[:reference]
+      alternates << File.join(opts[:reference], 'objects')
+    end
+
+    if opts[:ref]
+      checkout(opts[:ref])
+    end
+  end
+
+  # Check out the given Git ref
+  #
+  # @param ref [String] The git reference to check out
+  # @return [void]
+  def checkout(ref)
+    sha = resolve(ref)
+    @rugged_repo.checkout(sha)
+    @rugged_repo.reset(sha, :hard)
+  end
+
+  def fetch(remote = 'origin')
+    refspecs = ["+refs/heads/*:refs/remotes/#{remote}/*"]
+    @rugged_repo.fetch(remote, refspecs)
+  end
+
+  def exist?
+    @path.exist?
+  end
+
+  def head
+    resolve('HEAD')
+  end
+
+  def alternates
+    R10K::Git::Alternates.new(git_dir)
+  end
+
+  def origin
+    if @rugged_repo
+      @rugged_repo.config['remote.origin.url']
+    end
+  end
+end

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -17,7 +17,7 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   def initialize(basedir, dirname)
     @path = Pathname.new(File.join(basedir, dirname))
     if exist? && git_dir.exist?
-      @rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => alternates.to_a)
+      @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => alternates.to_a)
     end
   end
 
@@ -33,7 +33,7 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   def clone(remote, opts = {})
     options = {}
     options.merge!(:alternates => [File.join(opts[:reference], 'objects')]) if opts[:reference]
-    @rugged_repo = ::Rugged::Repository.clone_at(remote, @path.to_s, options)
+    @_rugged_repo = ::Rugged::Repository.clone_at(remote, @path.to_s, options)
 
     if opts[:reference]
       alternates << File.join(opts[:reference], 'objects')

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -31,6 +31,14 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   #
   # @return [void]
   def clone(remote, opts = {})
+
+    # libgit2/rugged doesn't support cloning a repository and providing an
+    # alternate object database, making the handling of :alternates a noop.
+    # Unfortunately this means that this method can't really use alternates
+    # and running the clone will duplicate all objects in the specified
+    # repository. However alternate databases can be handled when an existing
+    # repository is loaded, so loading a cloned repo will correctly use
+    # alternate object database.
     options = {}
     options.merge!(:alternates => [File.join(opts[:reference], 'objects')]) if opts[:reference]
     @_rugged_repo = ::Rugged::Repository.clone_at(remote, @path.to_s, options)

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -42,7 +42,6 @@ class R10K::Git::StatefulRepository
       @repo.path.rmtree
       @repo.clone(@remote, {:ref => sha})
     when :outdated
-      @repo.fetch
       @repo.checkout(sha)
     end
   end

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -27,7 +27,7 @@ class R10K::Git::StatefulRepository
   end
 
   def sync
-    @cache.sync
+    @cache.sync if sync?
 
     sha = @cache.resolve(@ref)
 
@@ -61,5 +61,14 @@ class R10K::Git::StatefulRepository
     else
       :insync
     end
+  end
+
+  private
+
+  def sync?
+    return true if !@cache.exist?
+    return true if !(sha = @cache.resolve(@ref))
+    return true if !([:commit, :tag].include? @cache.ref_type(sha))
+    return false
   end
 end

--- a/spec/integration/git/rugged/bare_repository_spec.rb
+++ b/spec/integration/git/rugged/bare_repository_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'r10k/git/rugged/bare_repository'
 
-describe R10K::Git::Rugged::BareRepository do
+describe R10K::Git::Rugged::BareRepository, :if => R10K::Features.available?(:rugged) do
   include_context 'Git integration'
 
   let(:dirname) { 'bare-repo.git' }

--- a/spec/integration/git/rugged/bare_repository_spec.rb
+++ b/spec/integration/git/rugged/bare_repository_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'r10k/git/rugged/bare_repository'
+
+describe R10K::Git::Rugged::BareRepository do
+  include_context 'Git integration'
+
+  let(:dirname) { 'bare-repo.git' }
+
+  subject { described_class.new(basedir, dirname) }
+
+  it_behaves_like 'a git repository'
+  it_behaves_like 'a git bare repository'
+end

--- a/spec/integration/git/rugged/thin_repository_spec.rb
+++ b/spec/integration/git/rugged/thin_repository_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'r10k/git/rugged/thin_repository'
+
+describe R10K::Git::Rugged::ThinRepository do
+  include_context 'Git integration'
+
+  let(:dirname) { 'working-repo' }
+
+  subject { described_class.new(basedir, dirname) }
+
+  let(:cacherepo) { R10K::Git::Rugged::Cache.generate(remote) }
+
+  it_behaves_like "a git thin repository"
+end

--- a/spec/integration/git/rugged/thin_repository_spec.rb
+++ b/spec/integration/git/rugged/thin_repository_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'r10k/git/rugged/thin_repository'
 
-describe R10K::Git::Rugged::ThinRepository do
+describe R10K::Git::Rugged::ThinRepository, :if => R10K::Features.available?(:rugged) do
   include_context 'Git integration'
 
   let(:dirname) { 'working-repo' }

--- a/spec/integration/git/rugged/working_repository_spec.rb
+++ b/spec/integration/git/rugged/working_repository_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'r10k/git/rugged/working_repository'
+
+describe R10K::Git::Rugged::WorkingRepository do
+  include_context 'Git integration'
+
+  let(:dirname) { 'working-repo' }
+
+  subject { described_class.new(basedir, dirname) }
+
+  it_behaves_like 'a git repository'
+  it_behaves_like 'a git working repository'
+end

--- a/spec/integration/git/rugged/working_repository_spec.rb
+++ b/spec/integration/git/rugged/working_repository_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'r10k/git/rugged/working_repository'
 
-describe R10K::Git::Rugged::WorkingRepository do
+describe R10K::Git::Rugged::WorkingRepository, :if => R10K::Features.available?(:rugged) do
   include_context 'Git integration'
 
   let(:dirname) { 'working-repo' }

--- a/spec/integration/git/stateful_repository_spec.rb
+++ b/spec/integration/git/stateful_repository_spec.rb
@@ -60,7 +60,7 @@ describe R10K::Git::StatefulRepository do
 
     describe "if the right ref is checked out" do
       it "is insync" do
-        thinrepo.clone(remote, {:ref => 'origin/0.9.x'})
+        thinrepo.clone(remote, {:ref => '0.9.x'})
         expect(subject.status).to eq :insync
       end
     end

--- a/spec/matchers/match_realpath.rb
+++ b/spec/matchers/match_realpath.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :match_realpath do |expected|
+
+  match do |actual|
+    actual == expected || realpath(actual) == realpath(expected)
+  end
+
+  failure_message do |actual|
+    "expected that #{actual} would have a real path of #{expected}"
+  end
+
+  failure_message_when_negated do |actual|
+    "expected that #{actual} would not have a real path of #{expected}"
+  end
+
+  def realpath(path)
+    Pathname.new(path).realpath.to_s
+  end
+end

--- a/spec/shared-examples/git/thin_repository.rb
+++ b/spec/shared-examples/git/thin_repository.rb
@@ -18,7 +18,9 @@ RSpec.shared_examples "a git thin repository" do
     it "adds the cache repo to the alternates file" do
       subject.clone(remote)
       objectpath = cacherepo.git_dir + 'objects'
-      expect(subject.alternates.to_a).to eq [objectpath.realpath.to_s]
+      alternates = subject.alternates.to_a
+      expect(alternates.size).to eq 1
+      expect(alternates[0]).to match_realpath objectpath
     end
   end
 end

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -73,6 +73,23 @@ RSpec.shared_examples "a git working repository" do
     end
   end
 
+  describe "updating the repo" do
+    let(:tag_090) { subject.git_dir + 'refs' + 'tags' + '0.9.0' }
+    let(:packed_refs) { subject.git_dir + 'packed-refs' }
+
+    before do
+      subject.clone(remote)
+      tag_090.delete if tag_090.exist?
+      packed_refs.delete if packed_refs.exist?
+    end
+
+    it "fetches objects from the remote" do
+      expect(subject.tags).to_not include('0.9.0')
+      subject.fetch
+      expect(subject.tags).to include('0.9.0')
+    end
+  end
+
   describe "listing branches" do
     before do
       subject.clone(remote)

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -52,7 +52,9 @@ RSpec.shared_examples "a git working repository" do
     describe "with a reference repository" do
       it "adds the reference repository to the alternates directory" do
         subject.clone(remote, {:reference => remote})
-        expect(subject.alternates.to_a).to eq [File.join(remote, 'objects')]
+        alternates = subject.alternates.to_a
+        expect(alternates.size).to eq 1
+        expect(alternates[0]).to match_realpath File.join(remote, 'objects')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ Dir.glob(File.expand_path('spec/shared-examples/**/*.rb', PROJECT_ROOT)).each { 
 
 require 'shared-contexts/git-fixtures'
 require 'matchers/exit_with'
+require 'matchers/match_realpath'
 require 'r10k-mocks'
 
 

--- a/spec/unit/git/rugged/cache_spec.rb
+++ b/spec/unit/git/rugged/cache_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'r10k/git/rugged/cache'
+
+describe R10K::Git::Rugged::Cache do
+  subject(:cache) { described_class.new('git://some/git/remote') }
+
+  it "wraps a Rugged::BareRepository instance" do
+    expect(cache.repo).to be_a_kind_of R10K::Git::Rugged::BareRepository
+  end
+
+  describe "settings" do
+    before do
+      R10K::Git::Cache.settings[:cache_root] = '/some/path'
+      described_class.settings.reset!
+    end
+
+    after do
+      R10K::Git::Cache.settings.reset!
+      described_class.settings.reset!
+    end
+
+    it "falls back to the parent class settings" do
+      expect(described_class.settings[:cache_root]).to eq '/some/path'
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a rugged based implementation of all of the Git classes. The rugged and shellgit based implementations should have identical interfaces and run the same integration specs, so hopefully transitioning from one to another should be seamless.

TODO: figure out how rugged runs ssh, because that might not be seamless.

This code will crash and burn on Ruby 1.8.7 because rugged doesn't support that; disabling the rugged classes on 1.8.7 will come later.

This PR is based on #322, #323, and #324.
