### PR TITLE
(CODEMGMT-95) Fix Use of "production" Environment

### DIFF
--- a/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
@@ -66,7 +66,7 @@ on(master, "cd #{prod_env_test_files_path};md5sum -c #{prod_env_checksum_file_pa
 
 agents.each do |agent|
   step "Run Puppet Agent"
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
@@ -83,7 +83,7 @@ on(master, 'r10k deploy environment -v -p')
 
 agents.each do |agent|
   step "Run Puppet Agent"
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
@@ -65,7 +65,7 @@ on(master, 'r10k deploy environment -v -p')
 
 agents.each do |agent|
   step "Run Puppet Agent"
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_module.rb
@@ -41,7 +41,7 @@ on(master, 'r10k deploy environment -v')
 
 agents.each do |agent|
   step "Run Puppet Agent"
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
@@ -66,7 +66,7 @@ on(master, "cd #{prod_env_test_files_path};md5sum -c #{prod_env_checksum_file_pa
 
 agents.each do |agent|
   step "Run Puppet Agent"
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
@@ -82,7 +82,7 @@ on(master, 'r10k deploy environment -v')
 
 agents.each do |agent|
   step "Run Puppet Agent"
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
@@ -81,7 +81,7 @@ on(master, 'r10k puppetfile purge -v', :acceptable_exit_codes => 1)
 #Agent will fail because r10k will purge the "motd" module
 agents.each do |agent|
   step 'Attempt to Run Puppet Agent'
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 0) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 0) do |result|
     expect_failure('Expected to fail due to CODEMGMT-78') do
       assert_match(error_message_regex, result.stderr, 'Expected error was not detected!')
     end

--- a/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
@@ -65,7 +65,7 @@ on(agents, puppet("plugin download --server #{master}"))
 
 agents.each do |agent|
   step 'Run Puppet Agent Against "production" Environment'
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 

--- a/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
@@ -130,7 +130,7 @@ on(master, 'r10k deploy environment -v -p')
 #Second Pass Verification
 agents.each do |agent|
   step 'Run Puppet Agent Against "production" Environment'
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(prod_env_notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
@@ -76,7 +76,7 @@ on(master, 'r10k deploy environment -v')
 #Second Pass Verification
 agents.each do |agent|
   step 'Run Puppet Agent Against "production" Environment'
-  on(agent, puppet('agent', '--test'), :acceptable_exit_codes => 2) do |result|
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end


### PR DESCRIPTION
Currently, when integration tests run against the "production" environment it
is assumed the default environment is automatically set on the agent. Because
of PE-7069 this assumption is no longer valid and all tests referencing the
"production" environment implicitly need to be changed to be explicit.
