### PR TITLE
(RK-17) Detect presence of Git binary and use ShellGit implementation.

### DIFF
--- a/lib/r10k/features.rb
+++ b/lib/r10k/features.rb
@@ -1,5 +1,6 @@
 require 'r10k/feature/collection'
 require 'forwardable'
+require 'r10k/util/commands'
 
 module R10K
   module Features
@@ -11,3 +12,5 @@ module R10K
     end
   end
 end
+
+R10K::Features.add(:shellgit) { R10K::Util::Commands.which('git') }

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -1,3 +1,6 @@
+require 'r10k/features'
+require 'r10k/errors'
+
 module R10K
   module Git
     require 'r10k/git/errors'
@@ -12,5 +15,33 @@ module R10K
     require 'r10k/git/cache'
     require 'r10k/git/alternates'
     require 'r10k/git/working_dir'
+
+    require 'r10k/git/shellgit'
+
+    @providers = {:shellgit => R10K::Git::ShellGit}
+
+    def self.default
+      if R10K::Features.available?(:shellgit)
+        @providers[:shellgit]
+      else
+        raise R10K::Error, "No Git providers are functional"
+      end
+    end
+
+    def self.provider
+      @provider = default
+    end
+
+    def self.cache
+      provider::Cache
+    end
+
+    def self.bare_repository
+      provider::BareRepository
+    end
+
+    def self.thin_repository
+      provider::ThinRepository
+    end
   end
 end

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -1,4 +1,4 @@
-require 'r10k/git/shellgit/thin_repository'
+require 'r10k/git'
 require 'r10k/git/errors'
 require 'forwardable'
 
@@ -22,8 +22,8 @@ class R10K::Git::StatefulRepository
     @ref = ref
     @remote = remote
 
-    @repo = R10K::Git::ShellGit::ThinRepository.new(basedir, dirname)
-    @cache = R10K::Git::ShellGit::Cache.generate(remote)
+    @repo = R10K::Git.thin_repository.new(basedir, dirname)
+    @cache = R10K::Git.cache.generate(remote)
   end
 
   def sync

--- a/lib/r10k/util/commands.rb
+++ b/lib/r10k/util/commands.rb
@@ -1,0 +1,31 @@
+module R10K
+  module Util
+    module Commands
+      module_function
+
+      # Find the full path of a shell command.
+      #
+      # On POSIX platforms, the PATHEXT environment variable will be unset, so
+      # the first command named 'cmd' will be returned.
+      #
+      # On Windows platforms, the PATHEXT environment variable will contain a
+      # semicolon delimited list of executable file extensions, so the first
+      # command with a matching path extension will be returned.
+      #
+      # @param cmd [String] The name of the command to search for
+      # @return [String, nil] The path to the file if found, nil otherwise
+      def which(cmd)
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+        ENV['PATH'].split(File::PATH_SEPARATOR).each do |dir|
+          exts.each do |ext|
+            path = File.join(dir, "#{cmd}#{ext}")
+            if File.executable?(path) && File.file?(path)
+              return path
+            end
+          end
+        end
+        nil
+      end
+    end
+  end
+end

--- a/lib/r10k/util/exec_env.rb
+++ b/lib/r10k/util/exec_env.rb
@@ -1,0 +1,36 @@
+module R10K
+  module Util
+
+    # Utility methods for dealing with environment variables
+    module ExecEnv
+      module_function
+
+      # Swap out all environment settings
+      #
+      # @param env [Hash] The new environment to use
+      # @return [void]
+      def reset(env)
+        env.each_pair do |key, value|
+          ENV[key] = value
+        end
+
+        (ENV.keys - env.keys).each do |key|
+          ENV.delete(key)
+        end
+      end
+
+      # Add the specified settings to the env for the supplied block
+      #
+      # @param env [Hash] The values to add to the environment
+      # @param block [Proc] The code to call with the modified environnment
+      # @return [void]
+      def withenv(env, &block)
+        original = ENV.to_hash
+        reset(original.merge(env))
+        block.call
+      ensure
+        reset(original)
+      end
+    end
+  end
+end

--- a/spec/integration/git/stateful_repository_spec.rb
+++ b/spec/integration/git/stateful_repository_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'r10k/git/shellgit/thin_repository'
+require 'r10k/git'
 require 'r10k/git/stateful_repository'
 
 describe R10K::Git::StatefulRepository do
@@ -7,8 +7,8 @@ describe R10K::Git::StatefulRepository do
 
   let(:dirname) { 'working-repo' }
 
-  let(:thinrepo) { R10K::Git::ShellGit::ThinRepository.new(basedir, dirname) }
-  let(:cacherepo) { R10K::Git::ShellGit::Cache.generate(remote) }
+  let(:thinrepo) { R10K::Git.thin_repository.new(basedir, dirname) }
+  let(:cacherepo) { R10K::Git.cache.generate(remote) }
 
   subject { described_class.new('0.9.x', remote, basedir, dirname) }
 

--- a/spec/unit/util/commands_spec.rb
+++ b/spec/unit/util/commands_spec.rb
@@ -1,0 +1,61 @@
+require 'r10k/util/commands'
+require 'r10k/util/exec_env'
+
+require 'tmpdir'
+
+describe R10K::Util::Commands do
+  describe "#which" do
+
+    before do
+      allow(File).to receive(:executable?).and_return false
+      allow(File).to receive(:file?).and_return false
+    end
+
+    def stub_executable(exe)
+      allow(File).to receive(:executable?).with(exe).and_return true
+      allow(File).to receive(:file?).with(exe).and_return true
+    end
+
+    describe "when ENV['PATHEXT'] is unset" do
+      let(:path) { Dir.mktmpdir }
+
+      around(:each) do |example|
+        R10K::Util::ExecEnv.withenv('PATHEXT' => nil, 'PATH' => path) do
+          example.run
+        end
+      end
+
+      it "returns the first matching command in PATH" do
+        exe = File.join(path, 'git')
+        stub_executable(exe)
+        expect(described_class.which("git")).to eq exe
+      end
+
+      it "returns nil if the command could not be found" do
+        exe = File.join(path, 'git')
+        expect(described_class.which("git")).to be_nil
+      end
+    end
+
+    describe "when ENV['PATHEXT'] is set" do
+      let(:path) { Dir.mktmpdir }
+
+      around(:each) do |example|
+        R10K::Util::ExecEnv.withenv('PATHEXT' => '.bat;.exe;.cmd', 'PATH' => path) do
+          example.run
+        end
+      end
+
+      it "returns the first matching command in PATH" do
+        exe = File.join(path, 'git.exe')
+        stub_executable(exe)
+        expect(described_class.which("git")).to eq exe
+      end
+
+      it "returns nil if the command could not be found" do
+        exe = File.join(path, 'git.exe')
+        expect(described_class.which("git")).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/util/exec_env_spec.rb
+++ b/spec/unit/util/exec_env_spec.rb
@@ -1,0 +1,56 @@
+require 'r10k/util/exec_env'
+
+describe R10K::Util::ExecEnv do
+  describe "withenv" do
+    it "adds the keys to the environment during the block" do
+      val = nil
+      described_class.withenv('VAL' => 'something') do
+        val = ENV['VAL']
+      end
+      expect(val).to eq 'something'
+    end
+
+    it "doesn't modify values that were not modified by the passed hash" do
+      origpath = ENV['PATH']
+      path = nil
+      described_class.withenv('VAL' => 'something') do
+        path = ENV['PATH']
+      end
+      expect(path).to eq origpath
+    end
+
+    it "removes new values after the block" do
+      val = nil
+      described_class.withenv('VAL' => 'something') { }
+      expect(ENV['VAL']).to be_nil
+    end
+
+    it "restores old values after the block" do
+      path = ENV['PATH']
+      described_class.withenv('PATH' => '/usr/bin') { }
+      expect(ENV['PATH']).to eq path
+    end
+  end
+
+  describe "reset" do
+
+    after { ENV.delete('VAL') }
+
+    it "replaces environment keys with the specified keys" do
+      ENV['VAL'] = 'hi'
+
+      newenv = ENV.to_hash
+      newenv['VAL'] = 'bye'
+
+      described_class.reset(newenv)
+      expect(ENV['VAL']).to eq 'bye'
+    end
+
+    it "removes any keys that were not provided" do
+      env = ENV.to_hash
+      ENV['VAL'] = 'hi'
+      described_class.reset(env)
+      expect(ENV['VAL']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This pull request uses the feature detection code to check for the presence of the Git binary and use the appropriate Git provider. Since there's only one implementation this is pretty limited in scope but provides the base for adding additional implementations.

This is required for GH-326 so that the rugged based Git implementation is bypassed on Ruby 1.8.7.
