### PR TITLE
[cli/version] (RK-37) Add --verbose flag to r10k version

### DIFF
--- a/lib/r10k/cli/version.rb
+++ b/lib/r10k/cli/version.rb
@@ -12,7 +12,16 @@ module R10K::CLI
         summary 'Print the version of r10k'
 
         run do |opts, args, cmd|
-          puts R10K::VERSION
+          puts "r10k #{R10K::VERSION}"
+          if opts[:verbose]
+            puts RUBY_DESCRIPTION
+            cmdpath = caller.last.slice(/\A.*#{$PROGRAM_NAME}/)
+            puts "Command path: #{cmdpath}"
+            puts "Interpreter path: #{Gem.ruby}"
+            if RUBY_VERSION >= '1.9'
+              puts "Default encoding: #{Encoding.default_external.name}"
+            end
+          end
           exit 0
         end
       end


### PR DESCRIPTION
This adds support for the `-v`/`--verbose` flag to `r10k version`:

Without the flag:

``` shellsession
[root@puppet cli]# r10k version
r10k 1.4.1
```

Note that this now prints `r10k 1.4.1` instead of `1.4.1`.  This is because it was simpler to always print `r10k 1.4.1` than to print `1.4.1` normally and `r10k 1.4.1` if passed `-v`/`--verbose`.

With the flag on a 1.8.7 box:

``` shellsession
[root@puppet-eli cli]# r10k version --verbose
r10k 1.4.1
ruby 1.8.7 (2013-06-27 patchlevel 374) [x86_64-linux]
Command path: /usr/bin/r10k
Interpreter path: /usr/bin/ruby
```

With the flag on a 1.9.3 box:

``` shellsession
[root@puppet cli]# r10k version -v
r10k 1.4.1
ruby 1.9.3p484 (2013-11-22 revision 43786) [x86_64-linux]
Command path: /usr/bin/r10k
Interpreter path: /opt/puppet/bin/ruby
Default encoding: UTF-8
```

This change is documented in [RK-37](https://tickets.puppetlabs.com/browse/RK-37).
