### PR TITLE
[deployment] (RK-4) Raise meaningful error on missing sources

### DIFF
--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -114,6 +114,9 @@ module R10K
 
     def load_sources
       sources = @config.setting(:sources)
+      if sources.nil? || sources.empty?
+        raise R10K::Error, "'sources' key in #{@config.configfile} missing or empty."
+      end
       @_sources = sources.map do |(name, hash)|
         R10K::Source.from_hash(name, hash)
       end

--- a/spec/r10k-mocks/mock_config.rb
+++ b/spec/r10k-mocks/mock_config.rb
@@ -7,6 +7,10 @@ module R10K
         @hash = hash
       end
 
+      def configfile
+        "/some/nonexistent/config_file"
+      end
+
       # Perform a scan for key and check for both string and symbol keys
       def setting(key)
         keys = [key]

--- a/spec/unit/deployment_spec.rb
+++ b/spec/unit/deployment_spec.rb
@@ -140,3 +140,23 @@ describe R10K::Deployment, "with environment collisions" do
     }.to raise_error(R10K::R10KError, /Environment collision at .* between s\d:third and s\d:third/)
   end
 end
+
+describe R10K::Deployment, "checking the 'sources' key" do
+
+  {
+    "when missing" => {},
+    "when empty" => {:sources => []},
+  }.each_pair do |desc, config_hash|
+    describe desc do
+
+      let(:config) { R10K::Deployment::MockConfig.new(config_hash) }
+      subject(:deployment) { described_class.new(config) }
+
+      it "raises an error when enumerating sources" do
+        expect {
+          deployment.sources
+        }.to raise_error(R10K::Error, "'sources' key in /some/nonexistent/config_file missing or empty.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the 'sources' key in r10k.yaml was left unset, was misspelled, or was
empty, r10k try to blindly iterate through it as a hash and would
subsequently raise an error. This commit updates the source enumeration
code to check for these error case and raise a meaningful error.

Per the comment on RK-4 there are other issues with config loading but they're out of scope for this issue; the broader issue is tracked in RK-34.
