### PR TITLE
[deploy/display] (RK-36) Monkey patch Symbol#<=> on Ruby 1.8.7

### DIFF
--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -1,3 +1,4 @@
+require 'r10k/util/monkey_patches'
 require 'r10k/util/setopts'
 require 'r10k/deployment'
 require 'r10k/logging'

--- a/lib/r10k/util/monkey_patches.rb
+++ b/lib/r10k/util/monkey_patches.rb
@@ -1,0 +1,11 @@
+if !Symbol.instance_methods.include?(:<=>)
+  class Symbol
+    # Ruby 1.8.7 does not define #<=>, which subsequently breaks Enumerable#sort
+    # when sorting an array of symbols.
+    #
+    # @see https://github.com/puppetlabs/r10k/issues/310
+    def <=>(other)
+      self.to_s <=> other.to_s if other.is_a?(Symbol)
+    end
+  end
+end

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'r10k/util/monkey_patches'
+
+describe Symbol, "comparison operator", :if => RUBY_VERSION == '1.8.7' do
+  it "returns nil if the other value is incomparable" do
+    expect(:aaa <=> 'bbb').to be_nil
+  end
+
+  it "returns -1 if the value sorts lower than the compared value" do
+    expect(:aaa <=> :bbb).to eq(-1)
+  end
+
+  it "returns 0 if the values are equal" do
+    expect(:aaa <=> :aaa).to eq(0)
+  end
+
+  it "returns 1 if the value sorts higher than the compared value" do
+    expect(:bbb <=> :aaa).to eq(1)
+  end
+end


### PR DESCRIPTION
Ruby 1.8.7 didn't implement Symbol#<=>, which broke sort operations on
arrays of symbols. This commit backports the 1.9 symbol comparison method
to remove the inconsistency.

Thanks to Eli Young elyscape@gmail.com for suggesting the monkey patch
instead of inserting 1.8.7 specific hacks into random methods.
