### PR TITLE
[git] (maint) Clean up requires of deprecated classes

### DIFF
--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -3,19 +3,6 @@ require 'r10k/errors'
 
 module R10K
   module Git
-    require 'r10k/git/errors'
-
-    require 'r10k/git/ref'
-    require 'r10k/git/tag'
-    require 'r10k/git/head'
-    require 'r10k/git/remote_head'
-    require 'r10k/git/commit'
-
-    require 'r10k/git/repository'
-    require 'r10k/git/cache'
-    require 'r10k/git/alternates'
-    require 'r10k/git/working_dir'
-
     require 'r10k/git/shellgit'
 
     @providers = {:shellgit => R10K::Git::ShellGit}

--- a/lib/r10k/git/working_dir.rb
+++ b/lib/r10k/git/working_dir.rb
@@ -2,6 +2,13 @@ require 'forwardable'
 require 'r10k/git'
 require 'r10k/git/cache'
 
+require 'r10k/git/working_dir'
+require 'r10k/git/ref'
+require 'r10k/git/tag'
+require 'r10k/git/head'
+require 'r10k/git/remote_head'
+require 'r10k/git/commit'
+
 # Implements sparse git repositories with shared objects
 #
 # Working directory instances use the git alternatives object store, so that

--- a/spec/unit/git/commit_spec.rb
+++ b/spec/unit/git/commit_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'r10k/git'
+require 'r10k/git/commit'
 
 describe R10K::Git::Commit do
 

--- a/spec/unit/git/head_spec.rb
+++ b/spec/unit/git/head_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'r10k/git'
+require 'r10k/git/head'
 
 describe R10K::Git::Head do
 

--- a/spec/unit/git/tag_spec.rb
+++ b/spec/unit/git/tag_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'r10k/git'
+require 'r10k/git/tag'
 
 describe R10K::Git::Tag do
 

--- a/spec/unit/git/working_dir_spec.rb
+++ b/spec/unit/git/working_dir_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'r10k/git'
+require 'r10k/git/working_dir'
 
 describe R10K::Git::WorkingDir do
   include_context "fail on execution"


### PR DESCRIPTION
A number of git classes are now being required in a more granular manner
and others are no longer in use; it doesn't make sense to require them
all in the single top level class.
