### PR TITLE
[git] (RK-32) Use Rugged as the fallback Git provider

### DIFF
--- a/doc/git/providers.mkd
+++ b/doc/git/providers.mkd
@@ -1,0 +1,53 @@
+Git Providers
+=============
+
+As of 1.5.0, r10k can interact with Git repositories using multiple Git
+providers.
+
+Shellgit
+--------
+
+The shellgit provider is the original Git provider that is based on shelling out
+to the `git` binary. It relies on the standard set of Git userland executables
+in order to work.
+
+The shellgit provider is the default Git provider in order to maintain
+compatibility with existing r10k installations.
+
+### Requirements
+
+The shellgit provider requires that `git` can be found on the `PATH` environment
+variable. This can be done by installing the git package via the system package
+manager.
+
+### SSH Configuration
+
+Because the shellgit provider relies on the `git` command which in turn uses the
+`ssh` binary as the SSH transport layer, configuring access to Git repositories
+over SSH is done by configuring the underlying `ssh` command.
+
+Rugged
+------
+
+The rugged provider is based on the [libgit2](https://github.com/libgit2/libgit2)
+library and the Ruby [rugged gem](https://github.com/libgit2/rugged).
+
+### Requirements
+
+The rugged provider relies on the rugged Ruby gem. The rugged gem requires Ruby
+1.9 or greater, which in turn means that r10k must be run with Ruby 1.9 or
+greater to use this provider.
+
+### SSH Configuration
+
+Using the rugged provider with SSH is not yet implemented; see
+[RK-33](https://tickets.puppetlabs.com/browse/RK-33) for more information.
+
+Configuration
+-------------
+
+R10K will attempt to use the shellgit provider, then fall back to the rugged
+provider, and then hard fail if no Git provider is available.
+
+Manually specifying a Git provider is not yet implemented; see
+[RK-32](https://tickets.puppetlabs.com/browse/RK-32) for more information.

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -17,15 +17,19 @@ module R10K
     require 'r10k/git/working_dir'
 
     require 'r10k/git/shellgit'
+    require 'r10k/git/rugged'
 
-    @providers = {:shellgit => R10K::Git::ShellGit}
+    @providers = [
+      [:shellgit, R10K::Git::ShellGit],
+      [:rugged,   R10K::Git::Rugged],
+    ]
 
     def self.default
-      if R10K::Features.available?(:shellgit)
-        @providers[:shellgit]
-      else
-        raise R10K::Error, "No Git providers are functional"
+      _, lib = @providers.find { |(feature, lib)| R10K::Features.available?(feature) }
+      if lib.nil?
+        raise R10K::Error, "No Git providers are functional."
       end
+      lib
     end
 
     def self.provider

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'r10k/git'
+
+describe R10K::Git do
+  describe 'selecting the default provider' do
+    it 'returns shellgit when the git executable is present' do
+      expect(R10K::Features).to receive(:available?).with(:shellgit).and_return true
+      expect(described_class.default).to eq R10K::Git::ShellGit
+    end
+
+    it 'returns rugged when the git executable is absent and the rugged library is present' do
+      expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
+      expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
+      expect(described_class.default).to eq R10K::Git::Rugged
+    end
+
+    it 'raises an error when the git executable and rugged library are absent' do
+      expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
+      expect(R10K::Features).to receive(:available?).with(:rugged).and_return false
+      expect {
+        described_class.default
+      }.to raise_error(R10K::Error, 'No Git providers are functional.')
+    end
+  end
+end


### PR DESCRIPTION
R10K needs to be able to use the Rugged provider as a fallback in case
the Git executable is not present on the system. This commit updates the
`R10K::Git.default` method to probe for multiple Git providers rather
than hardcode for the presents of shellgit.
