### PR TITLE
Maint/master/source purgeable cleanup

### DIFF
--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -1,6 +1,5 @@
 require 'r10k/git'
 require 'r10k/environment'
-require 'r10k/util/purgeable'
 
 # This class implements a source for Git environments.
 #
@@ -99,24 +98,8 @@ class R10K::Source::Git < R10K::Source::Base
     envs
   end
 
-  include R10K::Util::Purgeable
-
-  def managed_directory
-    @basedir
-  end
-
-  def current_contents
-    dir = self.managed_directory
-    glob_part = @prefix ? @name.to_s() + '_*' : '*'
-    glob_exp = File.join(dir, glob_part)
-
-    Dir.glob(glob_exp).map do |fname|
-      File.basename fname
-    end
-  end
-
   # List all environments that should exist in the basedir for this source
-  # @note This implements a required method for the Purgeable mixin
+  # @note This is required by {R10K::Util::Basedir}
   # @return [Array<String>]
   def desired_contents
     environments.map {|env| env.dirname }

--- a/lib/r10k/source/svn.rb
+++ b/lib/r10k/source/svn.rb
@@ -1,6 +1,5 @@
 require 'r10k/svn'
 require 'r10k/environment'
-require 'r10k/util/purgeable'
 require 'r10k/util/setopts'
 
 # This class implements a source for SVN environments.
@@ -89,20 +88,8 @@ class R10K::Source::SVN < R10K::Source::Base
     end
   end
 
-  include R10K::Util::Purgeable
-
-  def managed_directory
-    @basedir
-  end
-
-  def current_contents
-    Dir.glob(File.join(@basedir, '*')).map do |fname|
-      File.basename fname
-    end
-  end
-
   # List all environments that should exist in the basedir for this source
-  # @note This implements a required method for the Purgeable mixin
+  # @note This is required by {R10K::Util::Basedir}
   # @return [Array<String>]
   def desired_contents
     @environments.map {|env| env.dirname }

--- a/lib/r10k/util/basedir.rb
+++ b/lib/r10k/util/basedir.rb
@@ -28,10 +28,10 @@ module R10K
       end
 
       # @param path [String] The path to the directory to manage
-      # @param sources [Array<R10K::Util::Purgeable>] A list of purgeable objects
+      # @param sources [Array<#desired_contents>] A list of objects that may create filesystem entries
       def initialize(path, sources)
         if sources.is_a? R10K::Deployment
-          raise ArgumentError, "Expected Array<Purgeable>, got R10K::Deployment"
+          raise ArgumentError, "Expected Array<#desired_contents>, got R10K::Deployment"
         end
         @path    = path
         @sources = sources


### PR DESCRIPTION
Source objects are no longer directly used as purgeable objects and purging is done with the `R10K::Util::Basedir` class; source classes need to implement the `#desired_contents` method but all other code relating to purging can be excised.
