### PR TITLE
(CODEMGMT-18) Update Integration Pre-suites for PE r10k

### DIFF
--- a/integration/lib/r10k_utils.rb
+++ b/integration/lib/r10k_utils.rb
@@ -1,5 +1,24 @@
 require 'git_utils'
 
+# Retrieve the file path for the "r10k.yaml" configuration file.
+#
+# ==== Attributes
+#
+# * +master+ - The Puppet master on which r10k is installed.
+#
+# ==== Returns
+#
+# +string+ - Absolute file path to "r10k.yaml" config file.
+#
+# ==== Examples
+#
+# get_r10k_config_file_path(master)
+def get_r10k_config_file_path(master)
+  confdir = on(master, puppet('config print confdir')).stdout.rstrip
+
+  return File.join(File.dirname(confdir), 'r10k', 'r10k.yaml')
+end
+
 # Verify that a pristine "production" environment exists on the master.
 # (And only the "production" environment!)
 #

--- a/integration/test_run_scripts/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/all_tests-pe-centos6.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/all_tests-pe-rhel7.sh
+++ b/integration/test_run_scripts/all_tests-pe-rhel7.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/all_tests-pe-sles11.sh
+++ b/integration/test_run_scripts/all_tests-pe-sles11.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/all_tests-pe-ubuntu1204.sh
+++ b/integration/test_run_scripts/all_tests-pe-ubuntu1204.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/all_tests-pe-ubuntu1404.sh
+++ b/integration/test_run_scripts/all_tests-pe-ubuntu1404.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/basic_functionality/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/basic_functionality/all_tests-pe-centos6.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "basic_functionality" ]; then
   cd ../../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/user_scenario/basic_workflow/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/user_scenario/basic_workflow/all_tests-pe-centos6.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "basic_workflow" ]; then
   cd ../../../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/user_scenario/complex_workflow/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/user_scenario/complex_workflow/all_tests-pe-centos6.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "complex_workflow" ]; then
   cd ../../../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
+++ b/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
@@ -8,7 +8,7 @@ env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_repo_path = '/git_repos'
 git_control_remote = File.join(git_repo_path, 'environments.git')
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files

--- a/integration/tests/basic_functionality/negative/neg_deploy_with_missing_r10k_yaml.rb
+++ b/integration/tests/basic_functionality/negative/neg_deploy_with_missing_r10k_yaml.rb
@@ -4,7 +4,7 @@ require 'master_manipulator'
 test_name 'CODEMGMT-84 - C59270 - Attempt to Deploy with Missing r10k Configuration File'
 
 #Init
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #Verification

--- a/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
@@ -12,7 +12,7 @@ env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 local_files_root_path = ENV['FILES'] || 'files'
 helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #Sources and environments structures

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -10,7 +10,7 @@ env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 local_files_root_path = ENV['FILES'] || 'files'
 helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #Verification

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_basedir.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_basedir.rb
@@ -7,7 +7,7 @@ env_path = '/asuyiyuyabvusayd2784782gh8hexistasdfaiasdhfa78v87va8vajkb3vwkasv7as
 git_repo_path = '/git_repos'
 git_control_remote = File.join(git_repo_path, 'environments.git')
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_remote.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_remote.rb
@@ -6,7 +6,7 @@ test_name 'CODEMGMT-42 - C59224 - Attempt to Deploy from Non-existent Git Remote
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_control_remote = '/does/not/exist'
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_branch_name_collision.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_branch_name_collision.rb
@@ -16,7 +16,7 @@ git_alt_repo_name = 'environments_alt'
 git_alt_control_remote = File.join(git_alt_repo_path, "#{git_alt_repo_name}.git")
 git_alt_environments_path = File.join('/root', git_alt_repo_name)
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
@@ -9,7 +9,7 @@ git_control_remote = File.join(git_repo_path, "#{git_repo_name}.git")
 git_environments_path = '/root/environments'
 last_commit = git_last_commit(master, git_environments_path)
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 tmpfs_path = '/mnt/tmpfs'

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_read_only.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_read_only.rb
@@ -9,7 +9,7 @@ git_control_remote = File.join(git_repo_path, "#{git_repo_name}.git")
 git_environments_path = '/root/environments'
 last_commit = git_last_commit(master, git_environments_path)
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 tmpfs_path = '/mnt/tmpfs'

--- a/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
@@ -16,7 +16,7 @@ last_commit = git_last_commit(master, git_environments_path)
 local_files_root_path = ENV['FILES'] || 'files'
 helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files


### PR DESCRIPTION
Currently the integration test pre-suites install r10k from a gem. The
pre-suites were updated to use the r10k that is included with PE 3.8. Also,
the "test_run_scripts" were updated to use the PE "ci-ready" builds instead
of the stable release.
