### PR TITLE
(RK-24) Add the AIO location for r10k.yaml

### DIFF
--- a/lib/r10k/deployment/config/loader.rb
+++ b/lib/r10k/deployment/config/loader.rb
@@ -1,43 +1,49 @@
 
 module R10K
-class Deployment
-class Config
-class Loader
-  # Search for a deployment configuration file (r10k.yaml) in all parent
-  # directories and in /etc/r10k.yaml
+  class Deployment
+    class Config
+      class Loader
 
-  def initialize
-    @loadpath = []
+        attr_reader :loadpath
 
-    populate_loadpath
-  end
+        # Search for a deployment configuration file (r10k.yaml) in
+        # /etc/puppetlabs/r10k/r10k.yaml
+        # /etc/r10k.yaml
+        # and current directory
+        def initialize
+          @loadpath = []
+          populate_loadpath
+        end
 
-  # @return [String] The path to the first valid configfile
-  def search
-    first = @loadpath.find {|filename| File.file? filename}
-  end
+        # @return [String] The path to the first valid configfile
+        def search
+          first = @loadpath.find {|filename| File.file? filename}
+        end
 
-  private
+        private
 
-  def populate_loadpath
+        def populate_loadpath
 
-    # Scan all parent directories for r10k
-    dir_components = Dir.getwd.split(File::SEPARATOR)
+          # Scan all parent directories for r10k
+          dir_components = Dir.getwd.split(File::SEPARATOR)
 
-    dir_components.each_with_index do |dirname, index|
-      full_path = [''] # Shim case for root directory
-      full_path << dir_components[0...index]
-      full_path << dirname << 'r10k.yaml'
+          dir_components.each_with_index do |dirname, index|
+            full_path = [''] # Shim case for root directory
+            full_path << dir_components[0...index]
+            full_path << dirname << 'r10k.yaml'
 
-      @loadpath << File.join(full_path)
+            @loadpath << File.join(full_path)
+          end
+
+          # Add the AIO location for of r10k.yaml
+          @loadpath << '/etc/puppetlabs/r10k/r10k.yaml'
+
+          # Add the old default location.
+          @loadpath << '/etc/r10k.yaml'
+
+          @loadpath
+        end
+      end
     end
-
-    # Always check /etc/r10k.yaml
-    @loadpath << '/etc/r10k.yaml'
-
-    @loadpath
   end
-end
-end
-end
 end

--- a/spec/unit/deployment/config/loader_spec.rb
+++ b/spec/unit/deployment/config/loader_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'r10k/deployment/config/loader'
+
+describe R10K::Deployment::Config::Loader do
+
+  it "includes /etc/puppetlabs/r10k/r10k.yaml in the loadpath" do
+    expect(subject.loadpath).to include("/etc/puppetlabs/r10k/r10k.yaml")
+  end
+
+  it "includes /etc/r10k.yaml in the loadpath" do
+    expect(subject.loadpath).to include("/etc/r10k.yaml")
+  end
+
+  it "does not include /some/random/path/atomium/r10k.yaml in the loadpath" do
+    expect(subject.loadpath).not_to include("/some/random/path/atomium/r10k.yaml")
+  end
+
+end


### PR DESCRIPTION
Before this commit, the AIO location for r10k.yaml was not searched for
a configuration file. This commit adds /etc/puppetlabs/r10k/r10k.yaml to
the search path, and adds spec tests for the two expected paths to
r10k.yaml
