### PR TITLE
(RK-25) Warn if old and new default configs exist

### DIFF
--- a/lib/r10k/deployment/config/loader.rb
+++ b/lib/r10k/deployment/config/loader.rb
@@ -1,10 +1,16 @@
+require 'r10k/logging'
 
 module R10K
   class Deployment
     class Config
       class Loader
 
+        include R10K::Logging
+
         attr_reader :loadpath
+
+        DEFAULT_LOCATION = '/etc/puppetlabs/r10k/r10k.yaml'
+        OLD_DEFAULT_LOCATION = '/etc/r10k.yaml'
 
         # Search for a deployment configuration file (r10k.yaml) in
         # /etc/puppetlabs/r10k/r10k.yaml
@@ -17,6 +23,13 @@ module R10K
 
         # @return [String] The path to the first valid configfile
         def search
+
+          # If both default files are present, issue a warning.
+          if (File.file? DEFAULT_LOCATION) && (File.file? OLD_DEFAULT_LOCATION)
+            logger.warn "Both #{DEFAULT_LOCATION} and #{OLD_DEFAULT_LOCATION} configuration files exist."
+            logger.warn "#{DEFAULT_LOCATION} will be used."
+          end
+
           first = @loadpath.find {|filename| File.file? filename}
         end
 
@@ -36,10 +49,10 @@ module R10K
           end
 
           # Add the AIO location for of r10k.yaml
-          @loadpath << '/etc/puppetlabs/r10k/r10k.yaml'
+          @loadpath << DEFAULT_LOCATION
 
-          # Add the old default location.
-          @loadpath << '/etc/r10k.yaml'
+          # Add the old default location last.
+          @loadpath << OLD_DEFAULT_LOCATION
 
           @loadpath
         end

--- a/spec/unit/deployment/config/loader_spec.rb
+++ b/spec/unit/deployment/config/loader_spec.rb
@@ -3,16 +3,40 @@ require 'r10k/deployment/config/loader'
 
 describe R10K::Deployment::Config::Loader do
 
-  it "includes /etc/puppetlabs/r10k/r10k.yaml in the loadpath" do
-    expect(subject.loadpath).to include("/etc/puppetlabs/r10k/r10k.yaml")
+  context "populate_loadpath" do
+    it "includes /etc/puppetlabs/r10k/r10k.yaml in the loadpath" do
+      expect(subject.loadpath).to include("/etc/puppetlabs/r10k/r10k.yaml")
+    end
+
+    it "includes /etc/r10k.yaml in the loadpath" do
+      expect(subject.loadpath).to include("/etc/r10k.yaml")
+    end
+
+    it "does not include /some/random/path/atomium/r10k.yaml in the loadpath" do
+      expect(subject.loadpath).not_to include("/some/random/path/atomium/r10k.yaml")
+    end
   end
 
-  it "includes /etc/r10k.yaml in the loadpath" do
-    expect(subject.loadpath).to include("/etc/r10k.yaml")
-  end
+  context "search" do
+    it "returns the correct default location" do
+      allow(File).to receive(:file?).and_return false
+      allow(File).to receive(:file?).with('/etc/puppetlabs/r10k/r10k.yaml').and_return true
+      allow(File).to receive(:file?).with('/etc/r10k.yaml').and_return true
+      expect(subject.search).to eq '/etc/puppetlabs/r10k/r10k.yaml'
+    end
 
-  it "does not include /some/random/path/atomium/r10k.yaml in the loadpath" do
-    expect(subject.loadpath).not_to include("/some/random/path/atomium/r10k.yaml")
-  end
+    it "issues a warning if both default locations are present" do
+      allow(File).to receive(:file?).and_return false
+      allow(File).to receive(:file?).with('/etc/puppetlabs/r10k/r10k.yaml').and_return true
+      allow(File).to receive(:file?).with('/etc/r10k.yaml').and_return true
 
+      logger = double("Logging")
+      allow(subject).to receive(:logger).and_return logger
+
+      expect(logger).to receive(:warn).with('Both /etc/puppetlabs/r10k/r10k.yaml and /etc/r10k.yaml configuration files exist.')
+      expect(logger).to receive(:warn).with('/etc/puppetlabs/r10k/r10k.yaml will be used.')
+
+      subject.search
+    end
+  end
 end


### PR DESCRIPTION
 Before this commit, there was no warning when both the old ond new default locations for the configuration file existed. With this commit, if /etc/r10k.yaml and /etc/puppetlabs/r10k/r10k.yaml, a warning will be issued.

NOTE! This PR depends on https://github.com/puppetlabs/r10k/pull/343
