### PR TITLE
(RK-31) Remove upward config file search

### DIFF
--- a/lib/r10k/deployment/config/loader.rb
+++ b/lib/r10k/deployment/config/loader.rb
@@ -9,13 +9,11 @@ module R10K
 
         attr_reader :loadpath
 
-        DEFAULT_LOCATION = '/etc/puppetlabs/r10k/r10k.yaml'
-        OLD_DEFAULT_LOCATION = '/etc/r10k.yaml'
+        CONFIG_FILE = 'r10k.yaml'
+        DEFAULT_LOCATION = File.join('/etc/puppetlabs/r10k', CONFIG_FILE)
+        OLD_DEFAULT_LOCATION = File.join('/etc', CONFIG_FILE)
 
-        # Search for a deployment configuration file (r10k.yaml) in
-        # /etc/puppetlabs/r10k/r10k.yaml
-        # /etc/r10k.yaml
-        # and current directory
+        # Search for a deployment configuration file (r10k.yaml) in several locations
         def initialize
           @loadpath = []
           populate_loadpath
@@ -37,16 +35,8 @@ module R10K
 
         def populate_loadpath
 
-          # Scan all parent directories for r10k
-          dir_components = Dir.getwd.split(File::SEPARATOR)
-
-          dir_components.each_with_index do |dirname, index|
-            full_path = [''] # Shim case for root directory
-            full_path << dir_components[0...index]
-            full_path << dirname << 'r10k.yaml'
-
-            @loadpath << File.join(full_path)
-          end
+          # Add the current directory for r10k.yaml
+          @loadpath << File.join(Dir.getwd, CONFIG_FILE)
 
           # Add the AIO location for of r10k.yaml
           @loadpath << DEFAULT_LOCATION

--- a/spec/unit/deployment/config/loader_spec.rb
+++ b/spec/unit/deployment/config/loader_spec.rb
@@ -3,38 +3,44 @@ require 'r10k/deployment/config/loader'
 
 describe R10K::Deployment::Config::Loader do
 
-  context "populate_loadpath" do
-    it "includes /etc/puppetlabs/r10k/r10k.yaml in the loadpath" do
-      expect(subject.loadpath).to include("/etc/puppetlabs/r10k/r10k.yaml")
+  context 'populate_loadpath' do
+    it 'includes /etc/puppetlabs/r10k/r10k.yaml in the loadpath' do
+      expect(subject.loadpath).to include('/etc/puppetlabs/r10k/r10k.yaml')
     end
 
-    it "includes /etc/r10k.yaml in the loadpath" do
-      expect(subject.loadpath).to include("/etc/r10k.yaml")
+    it 'includes /etc/r10k.yaml in the loadpath' do
+      expect(subject.loadpath).to include('/etc/r10k.yaml')
     end
 
-    it "does not include /some/random/path/atomium/r10k.yaml in the loadpath" do
-      expect(subject.loadpath).not_to include("/some/random/path/atomium/r10k.yaml")
+    it 'does include the current working directory in the loadpath' do
+      allow(Dir).to receive(:getwd).and_return '/some/random/path/westvletren'
+      expect(subject.loadpath).to include('/some/random/path/westvletren/r10k.yaml')
     end
+
+    it 'does not include /some/random/path/atomium/r10k.yaml in the loadpath' do
+      expect(subject.loadpath).not_to include('/some/random/path/atomium/r10k.yaml')
+    end
+
   end
 
-  context "search" do
-    it "returns the correct default location" do
+  context 'search' do
+    it 'returns the correct default location' do
       allow(File).to receive(:file?).and_return false
       allow(File).to receive(:file?).with('/etc/puppetlabs/r10k/r10k.yaml').and_return true
       allow(File).to receive(:file?).with('/etc/r10k.yaml').and_return true
       expect(subject.search).to eq '/etc/puppetlabs/r10k/r10k.yaml'
     end
 
-    it "issues a warning if both default locations are present" do
+    it 'issues a warning if both default locations are present' do
       allow(File).to receive(:file?).and_return false
       allow(File).to receive(:file?).with('/etc/puppetlabs/r10k/r10k.yaml').and_return true
       allow(File).to receive(:file?).with('/etc/r10k.yaml').and_return true
 
-      logger = double("Logging")
-      allow(subject).to receive(:logger).and_return logger
+      logger_dbl = double('Logging')
+      allow(subject).to receive(:logger).and_return logger_dbl
 
-      expect(logger).to receive(:warn).with('Both /etc/puppetlabs/r10k/r10k.yaml and /etc/r10k.yaml configuration files exist.')
-      expect(logger).to receive(:warn).with('/etc/puppetlabs/r10k/r10k.yaml will be used.')
+      expect(logger_dbl).to receive(:warn).with('Both /etc/puppetlabs/r10k/r10k.yaml and /etc/r10k.yaml configuration files exist.')
+      expect(logger_dbl).to receive(:warn).with('/etc/puppetlabs/r10k/r10k.yaml will be used.')
 
       subject.search
     end


### PR DESCRIPTION
Before this commit, r10k would look for a configuration file starting at the root directory and proceeding down to the current directory. With this commit, r10k only searches the current directory.

Note: This PR depends on https://github.com/puppetlabs/r10k/pull/344 and https://github.com/puppetlabs/r10k/pull/343
