### PR TITLE
[runner/pump] reduce minimum wait delay

### DIFF
--- a/lib/r10k/util/subprocess/runner/pump.rb
+++ b/lib/r10k/util/subprocess/runner/pump.rb
@@ -22,7 +22,7 @@ class R10K::Util::Subprocess::Runner::Pump
     @thread = nil
     @string = ''
     @run    = true
-    @min_delay = 0.001
+    @min_delay = 0.05
     @max_delay = 1.0
   end
 

--- a/spec/unit/util/subprocess/runner/pump_spec.rb
+++ b/spec/unit/util/subprocess/runner/pump_spec.rb
@@ -47,11 +47,12 @@ describe R10K::Util::Subprocess::Runner::Pump do
 
   describe "backing off" do
     it "does not back off more than the max delay time" do
-      subject.max_delay = 0.005
+      max_delay = subject.min_delay * 2
+      subject.max_delay = max_delay
       subject.start
-      sleep 0.1
+      sleep max_delay * 2
 
-      Timeout.timeout(0.01) do
+      Timeout.timeout(max_delay * 1.5) do
         subject.halt!
       end
 


### PR DESCRIPTION
The pump loop uses IO.select to sleep between reads, which means that
we'll restart the loop as soon as data becomes available. This means
that we can be much less aggressive in how we poll the IO instance.
