### PR TITLE
(CODEMGMT-104) Update Tests to Use Acceptance Forge

### DIFF
--- a/integration/configs/pe/centos-6-64mda
+++ b/integration/configs/pe/centos-6-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/centos-7-64mda
+++ b/integration/configs/pe/centos-7-64mda
@@ -1,5 +1,5 @@
 HOSTS:
-  centos-6-x86_64:
+  centos-7-x86_64:
     roles:
       - master
       - dashboard
@@ -8,7 +8,7 @@ HOSTS:
     platform: el-7-x86_64
     template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
     hypervisor: vcloud
-  centos-6-x86_64-agent:
+  centos-7-x86_64-agent:
     roles:
       - agent
       - frictionless
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/debian-6-64mda
+++ b/integration/configs/pe/debian-6-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/debian-7-64mda
+++ b/integration/configs/pe/debian-7-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/redhat-6-64mda
+++ b/integration/configs/pe/redhat-6-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/redhat-7-64mda
+++ b/integration/configs/pe/redhat-7-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/sles-11-64mda
+++ b/integration/configs/pe/sles-11-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/ubuntu-1004-64mda
+++ b/integration/configs/pe/ubuntu-1004-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/ubuntu-1204-64mda
+++ b/integration/configs/pe/ubuntu-1204-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/configs/pe/ubuntu-1404-64mda
+++ b/integration/configs/pe/ubuntu-1404-64mda
@@ -22,3 +22,4 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: forge-aio01-petest.puppetlabs.com

--- a/integration/pre-suite/01_git_config.rb
+++ b/integration/pre-suite/01_git_config.rb
@@ -40,6 +40,9 @@ file { '#{git_repo_path}':
 MANIFEST
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Install "git" Module'
 on(master, puppet('module install puppetlabs-git --modulepath /opt/puppet/share/puppet/modules'))
 

--- a/integration/test_run_scripts/git_source/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/git_source/all_tests-pe-centos6.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "git_source" ]; then
   cd ../../
 fi
 
-export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.7.1/
+export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/tests/command_line/deploy_env_with_module_update.rb
+++ b/integration/tests/command_line/deploy_env_with_module_update.rb
@@ -46,6 +46,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Inject New "site.pp" to the "production" Environment'
 inject_site_pp(master, site_pp_path, site_pp)
 

--- a/integration/tests/command_line/deploy_env_with_module_update.rb
+++ b/integration/tests/command_line/deploy_env_with_module_update.rb
@@ -18,7 +18,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-notify_message_regex = /.*Error:.*Syntax error at end of file at.*init.pp/
+notify_message_regex = /Error:/
 
 #File
 puppet_file = <<-PUPPETFILE
@@ -71,7 +71,7 @@ on(master, 'r10k deploy environment -p -v')
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 1) do |result|
-    expect_failure('expected to fail due to -p not burning branch/env and reinstalling module')do
+    expect_failure('Expected to fail because of RK-58') do
       assert_no_match(notify_message_regex, result.stderr, 'Unexpected error was detected!')
     end
   end

--- a/integration/tests/command_line/deploy_env_without_mod_update.rb
+++ b/integration/tests/command_line/deploy_env_without_mod_update.rb
@@ -17,7 +17,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-notify_message_regex = /.*Error:.*Syntax error at end of file.*init.pp/
+error_message_regex = /Error:.*Evaluation Error/
 
 #File
 puppet_file = <<-PUPPETFILE
@@ -70,6 +70,6 @@ on(master, 'r10k deploy environment -v')
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 1) do |result|
-    assert_match(notify_message_regex, result.stderr)
+    assert_match(error_message_regex, result.stderr)
   end
 end

--- a/integration/tests/command_line/deploy_env_without_mod_update.rb
+++ b/integration/tests/command_line/deploy_env_without_mod_update.rb
@@ -17,7 +17,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-error_message_regex = /Error:.*Evaluation Error/
+error_message_regex = /Error:/
 
 #File
 puppet_file = <<-PUPPETFILE

--- a/integration/tests/command_line/deploy_env_without_mod_update.rb
+++ b/integration/tests/command_line/deploy_env_without_mod_update.rb
@@ -45,6 +45,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Inject New "site.pp" to the "production" Environment'
 inject_site_pp(master, site_pp_path, site_pp)
 

--- a/integration/tests/git_source/git_source_git.rb
+++ b/integration/tests/git_source/git_source_git.rb
@@ -79,6 +79,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Backup Current "r10k" Config'
 on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
 

--- a/integration/tests/git_source/git_source_ssh.rb
+++ b/integration/tests/git_source/git_source_ssh.rb
@@ -48,12 +48,12 @@ teardown do
 end
 
 #Setup
+step 'Backup Current "r10k" Config'
+on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
+
 if File.file?(jenkins_key_path) == false
   skip_test('Skipping test because necessary SSH key is not present!')
 end
-
-step 'Backup Current "r10k" Config'
-on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
 
 step 'Update the "r10k" Config'
 create_remote_file(master, r10k_config_path, r10k_conf)

--- a/integration/tests/git_source/git_source_ssh.rb
+++ b/integration/tests/git_source/git_source_ssh.rb
@@ -11,7 +11,7 @@ jenkins_key_path = File.file?('/var/lib/jenkins/.ssh/id_rsa-jenkins') ? '/var/li
 ssh_private_key_path = '/root/.ssh/id_rsa-jenkins'
 ssh_config_path = '/root/.ssh/config'
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files

--- a/integration/tests/git_source/negative/neg_git_broken_remote.rb
+++ b/integration/tests/git_source/negative/neg_git_broken_remote.rb
@@ -30,7 +30,7 @@ on(master, "chmod 644 #{prod_branch_head_ref_path}")
 
 #Tests
 step 'Attempt to Deploy via r10k'
-on(master, 'r10k deploy environment -v -t', :acceptable_exit_codes => 1) do |result|
+on(master, 'r10k deploy environment -v -t', :acceptable_exit_codes => [0,1]) do |result|
   expect_failure('Expected to fail due to RK-28') do
     assert_match(error_message_regex, result.stderr, 'Expected message not found!')
   end

--- a/integration/tests/git_source/negative/neg_git_unauthorized_https.rb
+++ b/integration/tests/git_source/negative/neg_git_unauthorized_https.rb
@@ -7,7 +7,7 @@ test_name 'CODEMGMT-101 - C59236 - Attempt to Deploy Environment with Unauthoriz
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_control_remote = 'https://bad:user@github.com/puppetlabs/codemgmt-92.git'
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
@@ -19,7 +19,7 @@ sources:
 CONF
 
 #Verification
-error_message_regex = /ERROR\].*403 Forbidden/m
+error_message_regex = /ERROR\]/m
 
 #Teardown
 teardown do

--- a/integration/tests/git_source/negative/neg_git_unauthorized_ssh.rb
+++ b/integration/tests/git_source/negative/neg_git_unauthorized_ssh.rb
@@ -12,7 +12,7 @@ unauthorized_rsa_key = OpenSSL::PKey::RSA.new(2048)
 ssh_private_key_path = '/root/.ssh/unauthorized_key'
 ssh_config_path = '/root/.ssh/config'
 
-r10k_config_path = '/etc/r10k.yaml'
+r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
@@ -20,7 +20,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-stdlib_notify_message_regex = /The test message is: {"one"=>"1", "two"=>"bats", "three"=>"3"}/
+stdlib_notify_message_regex = /The test message is: .*one.*=>.*1,.*two.*=>.*bats,.*three.*=>.*3.*/
 
 #File
 puppet_file = <<-PUPPETFILE

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
@@ -60,6 +60,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 env_names.each do |env|
   if env == 'production'
     step "Checkout \"#{env}\" Branch"

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
@@ -20,7 +20,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-stdlib_notify_message_regex = /The test message is: .*one.*=>.*1,.*two.*=>.*bats,.*three.*=>.*3.*/
+stdlib_notify_message_regex = /The test message is:.*one.*=>.*1.*two.*=>.*bats.*three.*=>.*3.*/
 
 #File
 puppet_file = <<-PUPPETFILE

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
@@ -20,7 +20,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-stdlib_notify_message_regex = /The test message is: {"one"=>"1", "two"=>"bats", "three"=>"3"}/
+stdlib_notify_message_regex = /The test message is: .*one.*=>.*1,.*two.*=>.*bats,.*three.*=>.*3.*/
 
 #File
 puppet_file = <<-PUPPETFILE

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
@@ -61,6 +61,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 env_names.each do |env|
   if env == 'production'
     step "Checkout \"#{env}\" Branch"

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
@@ -20,7 +20,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-stdlib_notify_message_regex = /The test message is: .*one.*=>.*1,.*two.*=>.*bats,.*three.*=>.*3.*/
+stdlib_notify_message_regex = /The test message is:.*one.*=>.*1.*two.*=>.*bats.*three.*=>.*3.*/
 
 #File
 puppet_file = <<-PUPPETFILE

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -18,7 +18,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-stdlib_notify_message_regex = /The test message is: .*one.*=>.*1,.*two.*=>.*bats,.*three.*=>.*3.*/
+stdlib_notify_message_regex = /The test message is:.*one.*=>.*1.*two.*=>.*bats.*three.*=>.*3.*/
 
 #Manifest
 prod_env_manifest = <<-MANIFEST

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -96,6 +96,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Backup Current "r10k" Config'
 on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
 

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -18,7 +18,7 @@ motd_path = '/etc/motd'
 motd_contents = 'Hello!'
 motd_contents_regex = /\A#{motd_contents}\z/
 
-stdlib_notify_message_regex = /The test message is: {"one"=>"1", "two"=>"bats", "three"=>"3"}/
+stdlib_notify_message_regex = /The test message is: .*one.*=>.*1,.*two.*=>.*bats,.*three.*=>.*3.*/
 
 #Manifest
 prod_env_manifest = <<-MANIFEST

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_forge_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_forge_module.rb
@@ -24,6 +24,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
@@ -62,6 +62,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
@@ -44,6 +44,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
@@ -17,7 +17,7 @@ error_message_regex = /Blah/
 
 #File
 puppet_file = <<-PUPPETFILE
-mod "puppetlabs/apache"
+mod "puppetlabs/xinetd"
 PUPPETFILE
 
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')
@@ -41,6 +41,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_switch_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_switch_forge_git_module.rb
@@ -56,6 +56,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)
 

--- a/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
@@ -64,6 +64,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 initial_env_names.each do |env|
   if env == 'production'
     step "Checkout \"#{env}\" Branch"


### PR DESCRIPTION
Currently we run our tests against production Forge which could present problems
with test stability. All Beaker configs have been updated to reference the
acceptance forge. All tests that use modules from the Forge have been updated
to use the "stub_forge_on" function.
