### PR TITLE
(RK-33) User configurable git provider

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -52,6 +52,22 @@ The cachedir setting defaults to `~/.r10k`. If the HOME environment variable is
 unset r10k will assume that r10k is being run with the Puppet [`prerun_command`][prerun_command]
 setting and will set the cachedir default to `/root/.r10k`.
 
+### git
+
+The 'git' setting is a hash that contains Git specific settings.
+
+#### provider
+
+The provider option determines which Git provider should be used.
+
+```yaml
+git:
+  provider: rugged # one of shellgit, rugged
+```
+
+See the [git provider documentation](../git/providers.mkd) for more information
+regarding Git providers.
+
 Deployment options
 ------------------
 

--- a/doc/git/providers.mkd
+++ b/doc/git/providers.mkd
@@ -49,5 +49,13 @@ Configuration
 R10K will attempt to use the shellgit provider, then fall back to the rugged
 provider, and then hard fail if no Git provider is available.
 
-Manually specifying a Git provider is not yet implemented; see
-[RK-32](https://tickets.puppetlabs.com/browse/RK-32) for more information.
+The Git provider in use can be manually specified by specifying the desired
+provider in r10k.yaml.
+
+```yaml
+git:
+  provider: 'rugged'
+```
+
+Valid values are 'rugged' and 'shellgit'. If an invalid value is used r10k will
+raise an error.

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -1,5 +1,6 @@
 require 'r10k/deployment'
 require 'r10k/deployment/config/loader'
+require 'r10k/util/symbolize_keys'
 require 'yaml'
 
 module R10K
@@ -52,13 +53,20 @@ class Config
 
   private
 
-  # Apply config settings to the relevant classes after a config has been loaded.
-  #
-  # @note this is hack. And gross. And terribad. I am sorry.
+  # Apply global configuration settings.
   def apply_config_settings
     cachedir = setting(:cachedir)
     if cachedir
       R10K::Git::Cache.settings[:cache_root] = cachedir
+    end
+
+    git_settings = setting(:git)
+    if git_settings
+      R10K::Util::SymbolizeKeys.symbolize_keys!(git_settings)
+      provider = git_settings[:provider]
+      if provider
+        R10K::Git.provider = provider.to_sym
+      end
     end
   end
 

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -53,15 +53,18 @@ class Config
 
   private
 
+  def with_setting(key, &block)
+    value = setting(key)
+    block.call(value) unless value.nil?
+  end
+
   # Apply global configuration settings.
   def apply_config_settings
-    cachedir = setting(:cachedir)
-    if cachedir
+    with_setting(:cachedir) do |cachedir|
       R10K::Git::Cache.settings[:cache_root] = cachedir
     end
 
-    git_settings = setting(:git)
-    if git_settings
+    with_setting(:git) do |git_settings|
       R10K::Util::SymbolizeKeys.symbolize_keys!(git_settings)
       provider = git_settings[:provider]
       if provider

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -1,6 +1,7 @@
 require 'r10k/deployment'
 require 'r10k/deployment/config/loader'
 require 'r10k/util/symbolize_keys'
+require 'r10k/errors'
 require 'yaml'
 
 module R10K
@@ -73,7 +74,7 @@ class Config
     end
   end
 
-  class ConfigError < StandardError
+  class ConfigError < R10K::Error
   end
 end
 end

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -6,10 +6,34 @@ module R10K
     require 'r10k/git/shellgit'
     require 'r10k/git/rugged'
 
+    # A list of Git providers, sorted by priority. Providers have features that
+    # must be available for them to be used, and a module which is the namespace
+    # containing the implementation.
     @providers = [
-      [:shellgit, R10K::Git::ShellGit],
-      [:rugged,   R10K::Git::Rugged],
+      [:shellgit, {:feature => :shellgit, :module => R10K::Git::ShellGit}],
+      [:rugged,   {:feature => :rugged,   :module => R10K::Git::Rugged}],
     ]
+
+    # Mark the current provider as invalid.
+    #
+    # If a provider is set to an invalid provider, we need to make sure that
+    # the provider doesn't fall back to the default value, thereby ignoring the
+    # explicit value and silently continuing. If the current provider is
+    # assigned to this value, no provider will be used until the provider is
+    # either reset or assigned a valid provider.
+    #
+    # @api private
+    NULL_PROVIDER = Object.new
+
+    # Mark the current provider as unset.
+    #
+    # If the provider has never been set we need to indicate that there is no
+    # current value but the default value can be used. If the current provider
+    # is assigned to this value and the provider is looked up, the default
+    # provider will be looked up and used.
+    #
+    # @api private
+    UNSET_PROVIDER = Object.new
 
     # Return the first available Git provider.
     #
@@ -17,11 +41,11 @@ module R10K
     # @return [Module] The namespace of the first available Git implementation.
     #   Implementation classes should be looked up against this returned Module.
     def self.default
-      _, lib = @providers.find { |(feature, lib)| R10K::Features.available?(feature) }
-      if lib.nil?
+      _, attrs = @providers.find { |(_, hash)| R10K::Features.available?(hash[:feature]) }
+      if attrs.nil?
         raise R10K::Error, "No Git providers are functional."
       end
-      lib
+      attrs[:module]
     end
 
     # Manually set the Git provider by name.
@@ -31,20 +55,29 @@ module R10K
     # @raise [R10K::Error] if the requested Git provider isn't functional.
     # @return [void]
     def self.provider=(name)
-      _, lib = @providers.find { |(feature, lib)| feature == name }
-      if lib.nil?
+      _, attrs = @providers.find { |(providername, _)| name == providername }
+      if attrs.nil?
+        @provider = NULL_PROVIDER
         raise R10K::Error, "No Git provider named '#{name}'."
       end
-      if !R10K::Features.available?(name)
+      if !R10K::Features.available?(attrs[:feature])
+        @provider = NULL_PROVIDER
         raise R10K::Error, "Git provider '#{name}' is not functional."
       end
-      @provider = lib
+      @provider = attrs[:module]
     end
 
     # @return [Module] The namespace of the first available Git implementation.
     #   Implementation classes should be looked up against this returned Module.
     def self.provider
-      @provider ||= default
+      case @provider
+      when NULL_PROVIDER
+        raise R10K::Error, "No Git provider set."
+      when UNSET_PROVIDER
+        @provider = default
+      else
+        @provider
+      end
     end
 
     def self.cache
@@ -63,7 +96,9 @@ module R10K
     #
     # @api private
     def self.reset!
-      @provider = nil
+      @provider = UNSET_PROVIDER
     end
+
+    @provider = UNSET_PROVIDER
   end
 end

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -54,7 +54,7 @@ class R10K::Source::Git < R10K::Source::Base
     @remote           = options[:remote]
     @invalid_branches = (options[:invalid_branches] || 'correct_and_warn')
 
-    @cache  = R10K::Git::ShellGit::Cache.generate(@remote)
+    @cache  = R10K::Git.cache.generate(@remote)
   end
 
   # Update the git cache for this git source to get the latest list of environments.

--- a/spec/unit/deployment/config_spec.rb
+++ b/spec/unit/deployment/config_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe R10K::Deployment::Config do
+
+  describe "reading settings" do
+    # Try all permutations of string/symbol values as arguments to #setting and
+    # values in the config file
+    x = [:key, "key"]
+    matrix = x.product(x)
+
+    matrix.each do |(searchvalue, configvalue)|
+      it "treats #{searchvalue.inspect}:#{searchvalue.class} and #{configvalue.inspect}:#{configvalue.class} as equivalent" do
+        expect(YAML).to receive(:load_file).with('foo/bar').and_return(configvalue => 'some/cache')
+        subject = described_class.new('foo/bar')
+        expect(subject.setting(searchvalue)).to eq 'some/cache'
+      end
+    end
+  end
+end

--- a/spec/unit/deployment/config_spec.rb
+++ b/spec/unit/deployment/config_spec.rb
@@ -16,4 +16,22 @@ describe R10K::Deployment::Config do
       end
     end
   end
+
+  describe "applying global settings" do
+    describe "for the cachedir" do
+      it "sets the git cache root when given" do
+        expect(YAML).to receive(:load_file).with('foo/bar').and_return('cachedir' => 'some/cache')
+        expect(R10K::Git::Cache.settings).to receive(:[]=).with(:cache_root, 'some/cache')
+        described_class.new('foo/bar')
+      end
+    end
+
+    describe "for git" do
+      it "sets the git provider when given" do
+        expect(YAML).to receive(:load_file).with('foo/bar').and_return('git' => {'provider' => 'rugged'})
+        expect(R10K::Git).to receive(:provider=).with(:rugged)
+        described_class.new('foo/bar')
+      end
+    end
+  end
 end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'r10k/git'
 
 describe R10K::Git do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
   describe 'selecting the default provider' do
     it 'returns shellgit when the git executable is present' do
       expect(R10K::Features).to receive(:available?).with(:shellgit).and_return true
@@ -20,6 +23,42 @@ describe R10K::Git do
       expect {
         described_class.default
       }.to raise_error(R10K::Error, 'No Git providers are functional.')
+    end
+  end
+
+  describe 'explicitly setting the provider' do
+
+    it "raises an error if the provider doesn't exist" do
+      expect {
+        described_class.provider = :nope
+      }.to raise_error(R10K::Error, "No Git provider named 'nope'.")
+    end
+
+    it "raises an error if the provider isn't functional" do
+      expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
+      expect {
+        described_class.provider = :shellgit
+      }.to raise_error(R10K::Error, "Git provider 'shellgit' is not functional.")
+    end
+
+    it "sets the current provider if the provider exists and is functional" do
+      expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
+      described_class.provider = :rugged
+      expect(described_class.provider).to eq(R10K::Git::Rugged)
+    end
+  end
+
+  describe "retrieving the current provider" do
+    it "uses the default if a provider has not been set" do
+      expect(described_class).to receive(:default).and_return :def
+      expect(described_class.provider).to eq :def
+    end
+
+    it "uses an explicitly set provider" do
+      expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
+      described_class.provider = :rugged
+      expect(described_class).to_not receive(:default)
+      expect(described_class.provider).to eq R10K::Git::Rugged
     end
   end
 end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -24,10 +24,20 @@ describe R10K::Git do
         described_class.default
       }.to raise_error(R10K::Error, 'No Git providers are functional.')
     end
+
+    it "goes into an error state if an invalid provider was set" do
+      begin
+        described_class.provider = :nope
+      rescue R10K::Error
+      end
+
+      expect {
+        described_class.provider
+      }.to raise_error(R10K::Error, "No Git provider set.")
+    end
   end
 
   describe 'explicitly setting the provider' do
-
     it "raises an error if the provider doesn't exist" do
       expect {
         described_class.provider = :nope


### PR DESCRIPTION
This pull request allows users to specify which Git provider they want to use. Configuration is handled in r10k.yaml with the following:

``` yaml
git:
  provider: rugged # valid values are rugged, shellgit
[...]
```

This pull request is based on GH-339 and GH-351.
