### PR TITLE
[module/forge] Update code to not generate a Ruby 2.2 warning

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -55,7 +55,7 @@ class R10K::Module::Forge < R10K::Module::Base
 
   # @return [R10K::SemVer] The expected version that the module
   def expected_version
-    if @expected_version == :latest
+    if @expected_version.is_a?(Symbol) && @expected_version == :latest
       set_version_from_forge
     end
     @expected_version


### PR DESCRIPTION
In some cases, this code was comparing a SemVer object with :latest.
The code in SemVer#<=> throws an exception in this case (tries to create
a SemVer object with :latest) and Ruby used to silently treat this as
<=> returning nil. This behavior has been deprecated in Ruby 2.2.

On ruby 2.2, this is the deprecation warning that gets generated

```
/opt/puppet/vendor/bundle/ruby/2.2.0/gems/r10k-1.4.1/lib/r10k/module/forge.rb:58: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
/opt/puppet/vendor/bundle/ruby/2.2.0/gems/r10k-1.4.1/lib/r10k/module/forge.rb:58: warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison.
```

An alternative fix would be to make SemVer#<=> rescue exceptions from SemVer.new and return nil.
