### PR TITLE
(#106) use forge directive so r10k works with using local forges set in ...

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -24,6 +24,10 @@ class R10K::Module::Forge < R10K::Module::Base
 
   include R10K::Logging
 
+  def self.forge(forge)
+    @@forge = forge
+  end
+
   def initialize(title, dirname, args)
     super
     @metadata_file = R10K::Module::MetadataFile.new(path + 'metadata.json')
@@ -149,7 +153,7 @@ class R10K::Module::Forge < R10K::Module::Base
   #
   # @return [String] The stdout from the executed command
   def pmt(argv)
-    argv = ['puppet', 'module', '--modulepath', @dirname, '--color', 'false'] + argv
+    argv = ['puppet', 'module', '--module_repository', @@forge, '--modulepath', @dirname, '--color', 'false'] + argv
 
     subproc = R10K::Util::Subprocess.new(argv)
     subproc.raise_on_fail = true
@@ -161,7 +165,7 @@ class R10K::Module::Forge < R10K::Module::Base
   end
 
   def set_version_from_forge
-    repo = R10K::ModuleRepository::Forge.new
+    repo = R10K::ModuleRepository::Forge.new(@@forge)
     expected = repo.latest_version(title)
     @expected_version = R10K::SemVer.new(expected)
   end

--- a/lib/r10k/module_repository/forge.rb
+++ b/lib/r10k/module_repository/forge.rb
@@ -20,10 +20,10 @@ class R10K::ModuleRepository::Forge
   #   @return [Faraday]
   attr_reader :conn
 
-  def initialize(forge = 'forgeapi.puppetlabs.com')
+  def initialize(forge)
     if forge =~ /forge\.puppetlabs\.com/
       logger.warn("#{forge} does not support the latest puppet forge API. Please update to \"forge 'https://forgeapi.puppetlabs.com'\"")
-      forge = 'forgeapi.puppetlabs.com'
+      forge = 'https://forgeapi.puppetlabs.com'
     end
     @forge = forge
     @conn  = make_conn
@@ -70,7 +70,7 @@ class R10K::ModuleRepository::Forge
     # Force use of json_pure with multi_json on Ruby 1.8.7
     multi_json_opts = (RUBY_VERSION == "1.8.7" ? {:adapter => :json_pure} : {})
 
-    Faraday.new(:url => "https://#{@forge}") do |builder|
+    Faraday.new(:url => @forge) do |builder|
       builder.request(:multi_json, multi_json_opts)
       builder.response(:multi_json, multi_json_opts)
 

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -37,7 +37,7 @@ class Puppetfile
     @puppetfile_path = puppetfile || File.join(basedir, 'Puppetfile')
 
     @modules = []
-    @forge   = 'forgeapi.puppetlabs.com'
+    @forge   = 'https://forgeapi.puppetlabs.com'
   end
 
   def load
@@ -72,6 +72,7 @@ class Puppetfile
   # @param [String] name
   # @param [*Object] args
   def add_module(name, args)
+    R10K::Module::Forge.forge(forge)
     @modules << R10K::Module.new(name, @moduledir, args)
   end
 

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -208,6 +208,7 @@ describe R10K::Module::Forge do
   end
 
   describe "and the expected version is :latest", :vcr => true, :unless => (RUBY_VERSION == '1.8.7') do
+    described_class.forge('https://forgeapi.puppetlabs.com')
     subject { described_class.new('branan/eight_hundred', fixture_modulepath, :latest) }
 
     it "sets the expected version based on the latest forge version" do

--- a/spec/unit/module_repository/forge_spec.rb
+++ b/spec/unit/module_repository/forge_spec.rb
@@ -5,13 +5,13 @@ require 'r10k/module_repository/forge'
 describe R10K::ModuleRepository::Forge do
 
   it "uses the official forge by default" do
-    forge = described_class.new
-    expect(forge.forge).to eq 'forgeapi.puppetlabs.com'
+    forge = described_class.new('https://forgeapi.puppetlabs.com')
+    expect(forge.forge).to eq 'https://forgeapi.puppetlabs.com'
   end
 
   it "replaces old forge with forgeapi" do
     forge = described_class.new(forge='forge.puppetlabs.com')
-    expect(forge.forge).to eq 'forgeapi.puppetlabs.com'
+    expect(forge.forge).to eq 'https://forgeapi.puppetlabs.com'
   end
 
   it "can use a private forge" do
@@ -20,7 +20,7 @@ describe R10K::ModuleRepository::Forge do
   end
 
   describe "and the expected version is :latest", :vcr => true do
-    subject(:forge) { described_class.new }
+    subject(:forge) { described_class.new('https://forgeapi.puppetlabs.com') }
 
     before do
       forge.conn.builder.insert_before(Faraday::Adapter::NetHttp, VCR::Middleware::Faraday)
@@ -36,7 +36,7 @@ describe R10K::ModuleRepository::Forge do
   end
 
   describe "it handles errors from forgeapi.puppetlabs.com", :vcr => true do
-    subject(:forge) { described_class.new }
+    subject(:forge) { described_class.new('https://forgeapi.puppetlabs.com') }
 
     before do
       forge.conn.builder.insert_before(Faraday::Adapter::NetHttp, VCR::Middleware::Faraday)


### PR DESCRIPTION
I needed the ability to utilize a local forge. This patch attempts to add support for the forge directive, which should allow r10k users to use internal forges by setting them in the Puppetfile. If no forge is set, it will still default to https://forgeapi.puppetlabs.com.
