### PR TITLE
REVIEW: (RK-38) Provide SSH configuration for rugged provider

### DIFF
--- a/doc/git/providers.mkd
+++ b/doc/git/providers.mkd
@@ -40,8 +40,15 @@ greater to use this provider.
 
 ### SSH Configuration
 
-Using the rugged provider with SSH is not yet implemented; see
-[RK-33](https://tickets.puppetlabs.com/browse/RK-33) for more information.
+In order to use rugged with SSH based Git repositories, the 'private_key' option
+must be provided. An optional 'username' field can be provided when the Git
+remote URL does not provide a username.
+
+```yaml
+git:
+  private_key: '/root/.ssh/id_rsa'
+  username: 'git'
+```
 
 Configuration
 -------------

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -71,6 +71,14 @@ class Config
       if provider
         R10K::Git.provider = provider.to_sym
       end
+
+      if git_settings[:private_key]
+        R10K::Git.settings[:private_key] = git_settings[:private_key]
+      end
+
+      if git_settings[:username]
+        R10K::Git.settings[:username] = git_settings[:username]
+      end
     end
   end
 

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -1,5 +1,6 @@
 require 'r10k/features'
 require 'r10k/errors'
+require 'r10k/settings'
 
 module R10K
   module Git
@@ -100,5 +101,10 @@ module R10K
     end
 
     @provider = UNSET_PROVIDER
+
+    extend R10K::Settings::Mixin::ClassMethods
+
+    def_setting_attr :private_key
+    def_setting_attr :username
   end
 end

--- a/lib/r10k/git/errors.rb
+++ b/lib/r10k/git/errors.rb
@@ -3,16 +3,11 @@ require 'r10k/errors'
 module R10K
   module Git
 
-    class GitError < R10K::Error; end
-
-    class UnresolvableRefError < GitError
-
-      attr_reader :ref
+    class GitError < R10K::Error
       attr_reader :git_dir
 
       def initialize(mesg, options = {})
         super
-        @ref     = @options[:ref]
         @git_dir = @options[:git_dir]
       end
 
@@ -22,6 +17,17 @@ module R10K
           msg << " at #{@git_dir}"
         end
         msg
+      end
+    end
+
+
+    class UnresolvableRefError < GitError
+
+      attr_reader :ref
+
+      def initialize(mesg, options = {})
+        super
+        @ref = @options[:ref]
       end
     end
   end

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -39,8 +39,9 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
   #
   # @return [void]
   def fetch
+    options = {:credentials => credentials}
     refspecs = ['+refs/*:refs/*']
-    with_repo { |repo| repo.fetch('origin', refspecs) }
+    with_repo { |repo| repo.fetch('origin', refspecs, options) }
   end
 
   def exist?

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -38,7 +38,7 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
     # repository. However alternate databases can be handled when an existing
     # repository is loaded, so loading a cloned repo will correctly use
     # alternate object database.
-    options = {}
+    options = {:credentials => credentials}
     options.merge!(:alternates => [File.join(opts[:reference], 'objects')]) if opts[:reference]
     @_rugged_repo = ::Rugged::Repository.clone_at(remote, @path.to_s, options)
 
@@ -67,8 +67,9 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   end
 
   def fetch(remote = 'origin')
+    options = {:credentials => credentials}
     refspecs = ["+refs/heads/*:refs/remotes/#{remote}/*"]
-    with_repo { |repo| repo.fetch(remote, refspecs) }
+    with_repo { |repo| repo.fetch(remote, refspecs, options) }
   end
 
   def exist?

--- a/spec/unit/deployment/config_spec.rb
+++ b/spec/unit/deployment/config_spec.rb
@@ -32,6 +32,18 @@ describe R10K::Deployment::Config do
         expect(R10K::Git).to receive(:provider=).with(:rugged)
         described_class.new('foo/bar')
       end
+
+      it "sets the git ssh username when given" do
+        expect(YAML).to receive(:load_file).with('foo/bar').and_return('git' => {'username' => 'grit'})
+        expect(R10K::Git.settings).to receive(:[]=).with(:username, 'grit')
+        described_class.new('foo/bar')
+      end
+
+      it "sets the git private key when given" do
+        expect(YAML).to receive(:load_file).with('foo/bar').and_return('git' => {'private_key' => '/home/user/.ssh/id_rsa'})
+        expect(R10K::Git.settings).to receive(:[]=).with(:private_key, '/home/user/.ssh/id_rsa')
+        described_class.new('foo/bar')
+      end
     end
   end
 end


### PR DESCRIPTION
This adds the needed functionality for Git to use SSH as a transport for Git repositories. It adds configuration options to r10k.yaml as follows:

``` yaml
git:
  private_key: '/root/.ssh/id_rsa'
  username: 'git' # Optional
```
