### PR TITLE
(CODEMGMT-130) Update Test to use Acceptance Forge

### DIFF
--- a/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
@@ -24,6 +24,9 @@ teardown do
 end
 
 #Setup
+step 'Stub Forge on Master'
+stub_forge_on(master)
+
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)
 


### PR DESCRIPTION
A module was missing from the acceptance forge which prevented a test from
using the acceptance forge. Fixed!
