### PR TITLE
(CODEMGMT-135) Specify "cachedir" in Tests

### DIFF
--- a/integration/files/r10k_conf.yaml.erb
+++ b/integration/files/r10k_conf.yaml.erb
@@ -1,3 +1,4 @@
+cachedir: '/var/cache/r10k'
 sources:
   <% for source in sources %>
     <%= source.repo_name %>:

--- a/integration/pre-suite/02_pe_r10k.rb
+++ b/integration/pre-suite/02_pe_r10k.rb
@@ -23,6 +23,7 @@ end
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   control:
     basedir: "#{env_path}"

--- a/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
+++ b/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
@@ -13,6 +13,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     dir: "#{env_path}"

--- a/integration/tests/git_source/git_source_git.rb
+++ b/integration/tests/git_source/git_source_git.rb
@@ -29,6 +29,7 @@ site_pp = create_site_pp(master_certname, '  include helloworld')
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/git_source/git_source_ssh.rb
+++ b/integration/tests/git_source/git_source_ssh.rb
@@ -16,6 +16,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/git_source/negative/neg_git_unauthorized_https.rb
+++ b/integration/tests/git_source/negative/neg_git_unauthorized_https.rb
@@ -12,6 +12,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/git_source/negative/neg_git_unauthorized_ssh.rb
+++ b/integration/tests/git_source/negative/neg_git_unauthorized_ssh.rb
@@ -17,6 +17,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -72,6 +72,7 @@ last_commit = git_last_commit(master, env_structs[:production].environments_path
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   control:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_basedir.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_basedir.rb
@@ -12,6 +12,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_remote.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_remote.rb
@@ -11,6 +11,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_branch_name_collision.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_branch_name_collision.rb
@@ -21,6 +21,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   control:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
@@ -22,6 +22,7 @@ test_files_path = File.join(git_environments_path, 'test_files')
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{tmpfs_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_read_only.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_read_only.rb
@@ -16,6 +16,7 @@ tmpfs_path = '/mnt/tmpfs'
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   broken:
     basedir: "#{tmpfs_path}"

--- a/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
@@ -21,6 +21,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 #In-line files
 r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
 sources:
   control:
     basedir: "#{env_path}"


### PR DESCRIPTION
Currently the integration tests do not specify the "cachedir" option in the
r10k configuration file. Updated affected tests to use said option.
