### PR TITLE
(RK-66) Log environment destruction messages at INFO level

### DIFF
--- a/lib/r10k/util/basedir.rb
+++ b/lib/r10k/util/basedir.rb
@@ -53,10 +53,10 @@ module R10K
 
       def purge!
         @sources.each do |source|
-          logger.debug1 "Source #{source.name} in #{@path} claimed contents #{source.desired_contents.inspect}"
+          logger.debug1 "Source #{source.name} in #{@path} manages contents #{source.desired_contents.inspect}"
         end
         if !stale_contents.empty?
-          logger.debug "No sources in #{@path} claimed contents #{stale_contents.inspect}"
+          logger.debug "The path #{@path} has unmanaged contents #{stale_contents.inspect}"
         end
         super
       end

--- a/lib/r10k/util/purgeable.rb
+++ b/lib/r10k/util/purgeable.rb
@@ -46,11 +46,11 @@ module R10K
       # Forcibly remove all unmanaged content in `self.managed_directory`
       def purge!
         if stale_contents.empty?
-          logger.debug1 "No stale contents in #{managed_directory}, nothing to purge"
+          logger.debug1 "No unmanaged contents in #{managed_directory}, nothing to purge"
         else
           stale_contents.each do |fname|
             fpath = File.join(self.managed_directory, fname)
-            logger.debug "Removing stale path #{fpath}"
+            logger.info "Removing unmanaged path #{fpath}"
             FileUtils.rm_rf(fpath, :secure => true)
           end
         end


### PR DESCRIPTION
Environment creation is logged at the INFO level, while environment destruction was logged at the DEBUG level which was inconsistent. This reconciles that difference.
