### PR TITLE
[logging] Use log4r logger repository

### DIFF
--- a/lib/r10k/logging.rb
+++ b/lib/r10k/logging.rb
@@ -14,9 +14,14 @@ module R10K::Logging
   end
 
   def logger
-    unless @logger
-      @logger = Log4r::Logger.new(self.logger_name)
-      @logger.add R10K::Logging.outputter
+    if @logger.nil?
+      name = logger_name
+      if Log4r::Logger[name]
+        @logger = Log4r::Logger[name]
+      else
+        @logger = Log4r::Logger.new(name)
+        @logger.add(R10K::Logging.outputter)
+      end
     end
     @logger
   end


### PR DESCRIPTION
The intention of the `#logger` method was to provide a single logger per
class to add context for the log messages, but reuse a single instance
per class to cut down on object overhead. However this does not happen
automatically, and the existing code was creating many more logger
instances than what was intended, which had a nontrivial overhead.

When a log4r logger is created, it's automatically stored by log4r in an
internal repository for later use. The logger has to be explicitly
created as requesting a logger with a given name will return nil if that
logger hasn't been created, but can be retrieved afterwards. This commit
modifies the `#logger` method to try to retrieve the class logger from
the log4r repository first, and if that fails generate a new logger.
