### PR TITLE
[logging] Use more appropriate log formatters at different log levels

### DIFF
--- a/lib/r10k/logging.rb
+++ b/lib/r10k/logging.rb
@@ -42,6 +42,12 @@ module R10K::Logging
       end
       outputter.level = level
       @level = level
+
+      if level < Log4r::INFO
+        outputter.formatter = debug_formatter
+      else
+        outputter.formatter = default_formatter
+      end
     end
 
     # @!attribute [r] level
@@ -61,6 +67,10 @@ module R10K::Logging
 
     def default_formatter
       Log4r::PatternFormatter.new(:pattern => '%l\t -> %m')
+    end
+
+    def debug_formatter
+      Log4r::PatternFormatter.new(:pattern => '[%d - %l] %m')
     end
 
     def default_outputter

--- a/spec/unit/logging_spec.rb
+++ b/spec/unit/logging_spec.rb
@@ -36,5 +36,25 @@ describe R10K::Logging do
         described_class.level = 'deblag'
       }.to raise_error(ArgumentError, /Invalid log level/)
     end
+
+    describe "switching the formatter" do
+      before do
+        allow(described_class.outputter).to receive(:level=)
+      end
+
+      it "switches to the debug formatter if the new log level is debug or greater" do
+        debug_formatter = double('debug formatter')
+        expect(described_class).to receive(:debug_formatter).and_return(debug_formatter)
+        expect(described_class.outputter).to receive(:formatter=).with(debug_formatter)
+        described_class.level = 'debug'
+      end
+
+      it "switches to the default formatter if the new log level is info or less" do
+        default_formatter = double('default formatter')
+        expect(described_class).to receive(:default_formatter).and_return(default_formatter)
+        expect(described_class.outputter).to receive(:formatter=).with(default_formatter)
+        described_class.level = 'info'
+      end
+    end
   end
 end


### PR DESCRIPTION
At lower log levels it makes sense to keep log chatter at an appropriate
minimum, while at higher levels log messages benefit from having more
context. This commit adds a debug level formatter which adds more
information to log messages and enables it when the log level is DEBUG
or higher.

Based on #373.
