### PR TITLE
[logging] Centralize "default" log level handling

### DIFF
--- a/lib/r10k/action/cri_runner.rb
+++ b/lib/r10k/action/cri_runner.rb
@@ -41,21 +41,10 @@ module R10K
 
       # @return [Hash] The adapted options for the runner
       def handle_opts(opts)
-        # Translate from the Cri verbose logging option to the internal logging setting.
-        loglevel = opts.delete(:verbose)
-        case loglevel
-        when String, Numeric
-          opts[:loglevel] = loglevel
-        when TrueClass
-          opts[:loglevel] = 'INFO'
-        when NilClass
-          # pass
-        else
-          # When the type is unsure just pass it in as-is and let the internals
-          # raise the appropriate errors.
-          opts[:loglevel] = loglevel
+        if opts[:verbose]
+          # Translate from the Cri verbose logging option to the internal logging setting.
+          opts[:loglevel] = opts.delete(:verbose)
         end
-
         @opts = opts
       end
 

--- a/lib/r10k/cli.rb
+++ b/lib/r10k/cli.rb
@@ -31,14 +31,7 @@ module R10K::CLI
       flag :t, :trace, 'Display stack traces on application crash'
 
       loglevels = R10K::Logging::LOG_LEVELS.reverse.map(&:downcase).join(", ")
-      optional :v, :verbose, "Set log verbosity. Valid values: #{loglevels}" do |value, cmd|
-        case value
-        when true
-          R10K::Logging.level = 'INFO'
-        when String
-          R10K::Logging.level = value
-        end
-      end
+      optional :v, :verbose, "Set log verbosity. Valid values: #{loglevels}"
 
       required :c, :config, 'Specify a global configuration file (deprecated, use `r10k deploy -c`)' do |value, cmd|
         logger.warn "Calling `r10k --config <action>` as a global option is deprecated; use r10k <action> --config"

--- a/lib/r10k/logging.rb
+++ b/lib/r10k/logging.rb
@@ -25,13 +25,30 @@ module R10K::Logging
   end
 
   class << self
-    def parse_level(string)
-      Integer(string)
-    rescue
-      const = string.upcase.to_sym
-      begin
-        Log4r.const_get(const)
-      rescue NameError
+
+    # Convert the input to a valid Log4r log level
+    #
+    # @param input [String, TrueClass] The level to parse. If TrueClass then
+    #   Log4r::INFO will be returned (indicating a generic raised verbosity),
+    #   if a string it will be parsed either as a numeric value or a textual
+    #   log level.
+    # @api private
+    # @return [Integer, NilClass] The numeric log level, or nil if the log
+    #   level is invalid.
+    def parse_level(input)
+      case input
+      when TrueClass
+        Log4r::INFO
+      when /\A\d+\Z/
+        Integer(input)
+      when String
+        const_name = input.upcase
+        if LOG_LEVELS.include?(const_name)
+          begin
+            Log4r.const_get(const_name.to_sym)
+          rescue NameError
+          end
+        end
       end
     end
 

--- a/spec/unit/action/cri_runner_spec.rb
+++ b/spec/unit/action/cri_runner_spec.rb
@@ -30,12 +30,6 @@ describe R10K::Action::CriRunner do
       output = {:value => :yep, :loglevel => 'DEBUG'}
       expect(cri_runner.handle_opts(input)).to eq(output)
     end
-
-    it "sets the non-argument form of :verbose to :loglevel => 'INFO'" do
-      input = {:value => :yep, :verbose => true}
-      output = {:value => :yep, :loglevel => 'INFO'}
-      expect(cri_runner.handle_opts(input)).to eq(output)
-    end
   end
 
   describe "handling arguments" do

--- a/spec/unit/logging_spec.rb
+++ b/spec/unit/logging_spec.rb
@@ -4,6 +4,14 @@ require 'r10k/logging'
 describe R10K::Logging do
 
   describe "parsing a log level" do
+    it "parses 'true:TrueClass' as INFO" do
+      expect(described_class.parse_level(true)).to eq Log4r::INFO
+    end
+
+    it "parses 'true:String' as nil" do
+      expect(described_class.parse_level("true")).to be_nil
+    end
+
     it "parses a numeric string as an integer" do
       expect(described_class.parse_level('2')).to eq 2
     end


### PR DESCRIPTION
If a user specifies '--verbose' without a level, Cri will set the
verbosity as "true:TrueClass" and pass this along. This was originally
handled in the CLI code but it was far removed from logging, and if the
log level was invalid an exception would be thrown during argument
parsing.

This commit adds handling of 'true' as a log level and removes the
extra code path.

This is based on #373.
