### PR TITLE
(CODEMGMT-129) Git Provider Switch for Integration Tests

### DIFF
--- a/integration/files/r10k_conf.yaml.erb
+++ b/integration/files/r10k_conf.yaml.erb
@@ -1,4 +1,6 @@
 cachedir: '/var/cache/r10k'
+git:
+  provider: '<%= git_provider %>'
 sources:
   <% for source in sources %>
     <%= source.repo_name %>:

--- a/integration/pre-suite/02_pe_r10k.rb
+++ b/integration/pre-suite/02_pe_r10k.rb
@@ -12,6 +12,7 @@ r10k_config_path = get_r10k_config_file_path(master)
 git_repo_path = '/git_repos'
 git_repo_name = 'environments'
 git_control_remote = File.join(git_repo_path, "#{git_repo_name}.git")
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 pe_major = on(master, 'facter -p pe_major_version').stdout.rstrip
 pe_minor = on(master, 'facter -p pe_minor_version').stdout.rstrip
@@ -24,6 +25,8 @@ end
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   control:
     basedir: "#{env_path}"

--- a/integration/test_run_scripts/all_tests-rugged-pe-centos6.sh
+++ b/integration/test_run_scripts/all_tests-rugged-pe-centos6.sh
@@ -8,10 +8,11 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=rugged
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/ubuntu-1404-64mda \
+  --config configs/pe/centos-6-64mda \
   --debug \
   --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \

--- a/integration/test_run_scripts/all_tests-rugged-pe-rhel7.sh
+++ b/integration/test_run_scripts/all_tests-rugged-pe-rhel7.sh
@@ -3,18 +3,18 @@ SCRIPT_PATH=$(pwd)
 BASENAME_CMD="basename ${SCRIPT_PATH}"
 SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
 
-if [ $SCRIPT_BASE_PATH = "basic_workflow" ]; then
-  cd ../../../
+if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
+  cd ../
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
-export GIT_PROVIDER=shellgit
+export GIT_PROVIDER=rugged
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/centos-6-64mda \
+  --config configs/pe/redhat-7-64mda \
   --debug \
-  --tests tests/user_scenario/basic_workflow \
+  --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \
   --pre-suite pre-suite \
   --load-path lib

--- a/integration/test_run_scripts/all_tests-rugged-pe-sles11.sh
+++ b/integration/test_run_scripts/all_tests-rugged-pe-sles11.sh
@@ -8,10 +8,11 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=rugged
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/ubuntu-1204-64mda \
+  --config configs/pe/sles-11-64mda \
   --debug \
   --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \

--- a/integration/test_run_scripts/all_tests-rugged-pe-ubuntu1204.sh
+++ b/integration/test_run_scripts/all_tests-rugged-pe-ubuntu1204.sh
@@ -3,18 +3,18 @@ SCRIPT_PATH=$(pwd)
 BASENAME_CMD="basename ${SCRIPT_PATH}"
 SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
 
-if [ $SCRIPT_BASE_PATH = "basic_workflow" ]; then
-  cd ../../../
+if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
+  cd ../
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
-export GIT_PROVIDER=shellgit
+export GIT_PROVIDER=rugged
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/centos-6-64mda \
+  --config configs/pe/ubuntu-1204-64mda \
   --debug \
-  --tests tests/user_scenario/basic_workflow \
+  --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \
   --pre-suite pre-suite \
   --load-path lib

--- a/integration/test_run_scripts/all_tests-rugged-pe-ubuntu1404.sh
+++ b/integration/test_run_scripts/all_tests-rugged-pe-ubuntu1404.sh
@@ -8,10 +8,11 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=rugged
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/centos-6-64mda \
+  --config configs/pe/ubuntu-1404-64mda \
   --debug \
   --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \

--- a/integration/test_run_scripts/all_tests-shellgit-pe-centos6.sh
+++ b/integration/test_run_scripts/all_tests-shellgit-pe-centos6.sh
@@ -3,8 +3,8 @@ SCRIPT_PATH=$(pwd)
 BASENAME_CMD="basename ${SCRIPT_PATH}"
 SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
 
-if [ $SCRIPT_BASE_PATH = "basic_workflow" ]; then
-  cd ../../../
+if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
+  cd ../
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
@@ -14,7 +14,7 @@ beaker \
   --preserve-hosts onfail \
   --config configs/pe/centos-6-64mda \
   --debug \
-  --tests tests/user_scenario/basic_workflow \
+  --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \
   --pre-suite pre-suite \
   --load-path lib

--- a/integration/test_run_scripts/all_tests-shellgit-pe-rhel7.sh
+++ b/integration/test_run_scripts/all_tests-shellgit-pe-rhel7.sh
@@ -8,6 +8,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/all_tests-shellgit-pe-sles11.sh
+++ b/integration/test_run_scripts/all_tests-shellgit-pe-sles11.sh
@@ -3,8 +3,8 @@ SCRIPT_PATH=$(pwd)
 BASENAME_CMD="basename ${SCRIPT_PATH}"
 SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
 
-if [ $SCRIPT_BASE_PATH = "basic_workflow" ]; then
-  cd ../../../
+if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
+  cd ../
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
@@ -12,9 +12,9 @@ export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/centos-6-64mda \
+  --config configs/pe/sles-11-64mda \
   --debug \
-  --tests tests/user_scenario/basic_workflow \
+  --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \
   --pre-suite pre-suite \
   --load-path lib

--- a/integration/test_run_scripts/all_tests-shellgit-pe-ubuntu1204.sh
+++ b/integration/test_run_scripts/all_tests-shellgit-pe-ubuntu1204.sh
@@ -8,10 +8,11 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/sles-11-64mda \
+  --config configs/pe/ubuntu-1204-64mda \
   --debug \
   --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \

--- a/integration/test_run_scripts/all_tests-shellgit-pe-ubuntu1404.sh
+++ b/integration/test_run_scripts/all_tests-shellgit-pe-ubuntu1404.sh
@@ -3,8 +3,8 @@ SCRIPT_PATH=$(pwd)
 BASENAME_CMD="basename ${SCRIPT_PATH}"
 SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
 
-if [ $SCRIPT_BASE_PATH = "basic_workflow" ]; then
-  cd ../../../
+if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
+  cd ../
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
@@ -12,9 +12,9 @@ export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \
-  --config configs/pe/centos-6-64mda \
+  --config configs/pe/ubuntu-1404-64mda \
   --debug \
-  --tests tests/user_scenario/basic_workflow \
+  --tests tests \
   --keyfile ~/.ssh/id_rsa-acceptance \
   --pre-suite pre-suite \
   --load-path lib

--- a/integration/test_run_scripts/basic_functionality/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/basic_functionality/all_tests-pe-centos6.sh
@@ -8,6 +8,7 @@ if [ $SCRIPT_BASE_PATH = "basic_functionality" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/command_line/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/command_line/all_tests-pe-centos6.sh
@@ -8,6 +8,7 @@ if [ $SCRIPT_BASE_PATH = "command_line" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/git_source/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/git_source/all_tests-pe-centos6.sh
@@ -8,6 +8,7 @@ if [ $SCRIPT_BASE_PATH = "git_source" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/test_run_scripts/user_scenario/complex_workflow/all_tests-pe-centos6.sh
+++ b/integration/test_run_scripts/user_scenario/complex_workflow/all_tests-pe-centos6.sh
@@ -8,6 +8,7 @@ if [ $SCRIPT_BASE_PATH = "complex_workflow" ]; then
 fi
 
 export pe_dist_dir=http://neptune.puppetlabs.lan/3.8/ci-ready/
+export GIT_PROVIDER=shellgit
 
 beaker \
   --preserve-hosts onfail \

--- a/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
+++ b/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
@@ -7,6 +7,7 @@ test_name 'CODEMGMT-84 - C59271 - Attempt to Deploy with Invalid r10k Config'
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_repo_path = '/git_repos'
 git_control_remote = File.join(git_repo_path, 'environments.git')
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
@@ -14,6 +15,8 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   broken:
     dir: "#{env_path}"

--- a/integration/tests/git_source/git_source_git.rb
+++ b/integration/tests/git_source/git_source_git.rb
@@ -15,6 +15,7 @@ env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 
 git_control_remote = 'git://localhost/environments.git'
 git_environments_path = '/root/environments'
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 last_commit = git_last_commit(master, git_environments_path)
 
 local_files_root_path = ENV['FILES'] || 'files'
@@ -30,6 +31,8 @@ site_pp = create_site_pp(master_certname, '  include helloworld')
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/git_source/git_source_ssh.rb
+++ b/integration/tests/git_source/git_source_ssh.rb
@@ -6,6 +6,7 @@ test_name 'CODEMGMT-92 - C59234 - Single Git Source Using "SSH" Transport Protoc
 #Init
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_control_remote = 'git@github.com:puppetlabs/codemgmt-92.git'
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 jenkins_key_path = File.file?('/var/lib/jenkins/.ssh/id_rsa-jenkins') ? '/var/lib/jenkins/.ssh/id_rsa-jenkins' : File.expand_path('~/.ssh/id_rsa-jenkins')
 ssh_private_key_path = '/root/.ssh/id_rsa-jenkins'
@@ -17,6 +18,9 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
+  private_key: '#{ssh_private_key_path}'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/git_source/negative/neg_git_unauthorized_https.rb
+++ b/integration/tests/git_source/negative/neg_git_unauthorized_https.rb
@@ -6,6 +6,7 @@ test_name 'CODEMGMT-101 - C59236 - Attempt to Deploy Environment with Unauthoriz
 #Init
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_control_remote = 'https://bad:user@github.com/puppetlabs/codemgmt-92.git'
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
@@ -13,6 +14,8 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/git_source/negative/neg_git_unauthorized_ssh.rb
+++ b/integration/tests/git_source/negative/neg_git_unauthorized_ssh.rb
@@ -7,6 +7,7 @@ test_name 'CODEMGMT-101 - C59237 - Attempt to Deploy Environment with Unauthoriz
 #Init
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_control_remote = 'git@github.com:puppetlabs/codemgmt-92.git'
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 unauthorized_rsa_key = OpenSSL::PKey::RSA.new(2048)
 ssh_private_key_path = '/root/.ssh/unauthorized_key'
@@ -18,6 +19,9 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
+  private_key: '#{ssh_private_key_path}'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
@@ -56,7 +56,7 @@ end
 #ERB Template
 r10k_conf_template_path = File.join(local_files_root_path, 'r10k_conf.yaml.erb')
 r10k_conf = ERB.new(File.read(r10k_conf_template_path)).result(binding)
-binding.pry
+
 #Teardown
 last_commit = git_last_commit(master, sources.first.environments_path)
 teardown do

--- a/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
@@ -9,6 +9,8 @@ test_name 'CODEMGMT-85 - C59240 - Multiple Sources with Multiple Branches'
 master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
+
 local_files_root_path = ENV['FILES'] || 'files'
 helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
 
@@ -54,7 +56,7 @@ end
 #ERB Template
 r10k_conf_template_path = File.join(local_files_root_path, 'r10k_conf.yaml.erb')
 r10k_conf = ERB.new(File.read(r10k_conf_template_path)).result(binding)
-
+binding.pry
 #Teardown
 last_commit = git_last_commit(master, sources.first.environments_path)
 teardown do

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -7,6 +7,8 @@ test_name 'CODEMGMT-85 - C59227 - Multiple Environments with Multiple Sources an
 master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
+
 local_files_root_path = ENV['FILES'] || 'files'
 helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
 
@@ -73,6 +75,8 @@ last_commit = git_last_commit(master, env_structs[:production].environments_path
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   control:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_basedir.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_basedir.rb
@@ -6,6 +6,7 @@ test_name 'CODEMGMT-42 - C59225 - Attempt to Deploy to Base Directory with Inval
 env_path = '/asuyiyuyabvusayd2784782gh8hexistasdfaiasdhfa78v87va8vajkb3vwkasv7as8vba87vb87asdhfajsbdzxmcbvawbvr7av6baskudvbausdgasycyu7abywfegasfsauydgfasf7uas67vbexistasdfaiasdhfa78v87va8vajkb3vwkasv7as8vba87vb87asdhfajsbdzxmcbvawbvr7av6baskudvbausdgasycyu7abywfegasfsauydgfasf7uas67vb'
 git_repo_path = '/git_repos'
 git_control_remote = File.join(git_repo_path, 'environments.git')
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
@@ -13,6 +14,8 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_remote.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_remote.rb
@@ -5,6 +5,7 @@ test_name 'CODEMGMT-42 - C59224 - Attempt to Deploy from Non-existent Git Remote
 #Init
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
 git_control_remote = '/does/not/exist'
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
@@ -12,6 +13,8 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   broken:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_branch_name_collision.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_branch_name_collision.rb
@@ -10,6 +10,7 @@ git_repo_path = '/git_repos'
 git_repo_name = 'environments'
 git_control_remote = File.join(git_repo_path, "#{git_repo_name}.git")
 git_environments_path = File.join('/root', git_repo_name)
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 git_alt_repo_path = '/git_repos_alt'
 git_alt_repo_name = 'environments_alt'
@@ -22,6 +23,8 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   control:
     basedir: "#{env_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
@@ -8,6 +8,7 @@ git_repo_name = 'environments'
 git_control_remote = File.join(git_repo_path, "#{git_repo_name}.git")
 git_environments_path = '/root/environments'
 last_commit = git_last_commit(master, git_environments_path)
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
@@ -23,6 +24,8 @@ test_files_path = File.join(git_environments_path, 'test_files')
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   broken:
     basedir: "#{tmpfs_path}"

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_read_only.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_read_only.rb
@@ -8,6 +8,7 @@ git_repo_name = 'environments'
 git_control_remote = File.join(git_repo_path, "#{git_repo_name}.git")
 git_environments_path = '/root/environments'
 last_commit = git_last_commit(master, git_environments_path)
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
@@ -17,6 +18,8 @@ tmpfs_path = '/mnt/tmpfs'
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   broken:
     basedir: "#{tmpfs_path}"

--- a/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
@@ -11,6 +11,7 @@ env_path = '/tmp/puppet/temp/environments'
 git_environments_path = '/root/environments'
 git_repo_path = '/git_repos'
 git_control_remote = File.join(git_repo_path, 'environments.git')
+git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
 
 last_commit = git_last_commit(master, git_environments_path)
 local_files_root_path = ENV['FILES'] || 'files'
@@ -22,6 +23,8 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 #In-line files
 r10k_conf = <<-CONF
 cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
 sources:
   control:
     basedir: "#{env_path}"


### PR DESCRIPTION
There is a new option in the configuration file for r10k that allows the user
to change the Git provider. The integration tests have been altered to allow
for dynamic switching between providers. The "test_run_scripts" have been
updated to all the tester to choose which Git provider to use for testing.
