### PR TITLE
(RK-39) Wrap and raise rugged errors

### DIFF
--- a/lib/r10k/errors.rb
+++ b/lib/r10k/errors.rb
@@ -27,8 +27,16 @@ module R10K
     # @overload initialize(mesg, options)
     #   @param mesg [String] The exception mesg
     #   @param options [Hash] A set of options to store on the exception
+    #
+    # @options options [Array<String>] :backtrace
     def initialize(mesg, options = {})
       super(mesg)
+
+      bt = options.delete(:backtrace)
+      if bt
+        set_backtrace(bt)
+      end
+
       @options = options
     end
   end

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -1,5 +1,6 @@
 require 'r10k/git/rugged'
 require 'r10k/git/rugged/base_repository'
+require 'r10k/git/errors'
 
 class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
 
@@ -34,6 +35,8 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
       config['remote.origin.mirror'] = 'true'
       fetch
     end
+  rescue Rugged::SshError, Rugged::NetworkError => e
+    raise R10K::Git::GitError.new(e.message, :git_dir => git_dir, :backtrace => e.backtrace)
   end
 
   # Fetch refs and objects from the origin remote
@@ -45,6 +48,8 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     refspecs = ['+refs/*:refs/*']
     results = with_repo { |repo| repo.fetch('origin', refspecs, options) }
     report_transfer(results, 'origin')
+  rescue Rugged::SshError, Rugged::NetworkError => e
+    raise R10K::Git::GitError.new(e.message, :git_dir => git_dir, :backtrace => e.backtrace)
   end
 
   def exist?

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -1,5 +1,6 @@
 require 'r10k/git/rugged'
 require 'r10k/git/rugged/base_repository'
+require 'r10k/git/errors'
 
 class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
 
@@ -52,6 +53,8 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
       # won't populate the working directory.
       checkout(opts[:ref])
     end
+  rescue Rugged::SshError, Rugged::NetworkError => e
+    raise R10K::Git::GitError.new(e.message, :git_dir => git_dir, :backtrace => e.backtrace)
   end
 
   # Check out the given Git ref
@@ -74,7 +77,8 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
     refspecs = ["+refs/heads/*:refs/remotes/#{remote}/*"]
     results = with_repo { |repo| repo.fetch(remote, refspecs, options) }
     report_transfer(results, remote)
-    nil
+  rescue Rugged::SshError, Rugged::NetworkError => e
+    raise R10K::Git::GitError.new(e.message, :git_dir => git_dir, :backtrace => e.backtrace)
   end
 
   def exist?


### PR DESCRIPTION
Without this PR, if a clone or fetch fails in the rugged provider, the raised error will not report which repository had the issue, making it very hard to debug the failure. This PR adds exception handling to methods invoking network operations to add debugging context to the message.
