### PR TITLE
Add colored log levels, --color command line argument

### DIFF
--- a/lib/r10k/action/cri_runner.rb
+++ b/lib/r10k/action/cri_runner.rb
@@ -45,6 +45,14 @@ module R10K
           # Translate from the Cri verbose logging option to the internal logging setting.
           opts[:loglevel] = opts.delete(:verbose)
         end
+
+        # Colored logging is only appropriate for CLI interactions, so we
+        # handle this while we're still in CLI specific code.
+        use_color = opts.delete(:color)
+        if use_color
+          R10K::Logging.use_color = use_color
+        end
+
         @opts = opts
       end
 

--- a/lib/r10k/cli.rb
+++ b/lib/r10k/cli.rb
@@ -33,6 +33,8 @@ module R10K::CLI
       loglevels = R10K::Logging::LOG_LEVELS.reverse.map(&:downcase).join(", ")
       optional :v, :verbose, "Set log verbosity. Valid values: #{loglevels}"
 
+      flag nil, :color, 'Enable colored log messages'
+
       required :c, :config, 'Specify a global configuration file (deprecated, use `r10k deploy -c`)' do |value, cmd|
         logger.warn "Calling `r10k --config <action>` as a global option is deprecated; use r10k <action> --config"
       end

--- a/lib/r10k/logging.rb
+++ b/lib/r10k/logging.rb
@@ -1,4 +1,5 @@
 require 'r10k'
+require 'forwardable'
 
 require 'log4r'
 require 'log4r/configurator'
@@ -67,6 +68,9 @@ module R10K::Logging
         outputter.formatter = default_formatter
       end
     end
+
+    extend Forwardable
+    def_delegators :@outputter, :use_color, :use_color=
 
     # @!attribute [r] level
     #   @return [Integer] The current log level. Lower numbers correspond

--- a/lib/r10k/logging.rb
+++ b/lib/r10k/logging.rb
@@ -2,6 +2,7 @@ require 'r10k'
 
 require 'log4r'
 require 'log4r/configurator'
+require 'r10k/logging/terminaloutputter'
 
 module R10K::Logging
 
@@ -91,7 +92,7 @@ module R10K::Logging
     end
 
     def default_outputter
-      Log4r::StderrOutputter.new('console', :level => self.level, :formatter => formatter)
+      R10K::Logging::TerminalOutputter.new('terminal', $stderr, :level => self.level, :formatter => formatter)
     end
   end
 

--- a/lib/r10k/logging/terminaloutputter.rb
+++ b/lib/r10k/logging/terminaloutputter.rb
@@ -1,0 +1,36 @@
+require 'colored'
+require 'r10k/logging'
+require 'log4r/outputter/iooutputter'
+
+module R10K
+  module Logging
+    class TerminalOutputter < Log4r::IOOutputter
+
+      COLORS = [
+        nil,
+        :cyan,
+        :cyan,
+        :green,
+        nil,
+        nil,
+        :yellow,
+        :red,
+        :red,
+      ]
+
+      attr_accessor :use_color
+
+      private
+
+      def format(logevent)
+        string = super
+        if @use_color
+          color = COLORS[logevent.level]
+          color ? string.send(color) : string
+        else
+          string
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/logging/terminaloutputter_spec.rb
+++ b/spec/unit/logging/terminaloutputter_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'stringio'
+require 'r10k/logging/terminaloutputter'
+
+describe R10K::Logging::TerminalOutputter do
+
+  let(:stream) { StringIO.new }
+
+  let(:formatter) do
+    Class.new(Log4r::Formatter) do
+      def format(logevent)
+        logevent.data
+      end
+    end
+  end
+
+  subject do
+    described_class.new('test', stream, :level => 0, :formatter => formatter).tap do |o|
+      o.use_color = true
+    end
+  end
+
+  tests = [
+    [:debug2, :cyan],
+    [:debug1, :cyan],
+    [:debug,  :green],
+    [:info,   nil],
+    [:notice, nil],
+    [:warn,   :yellow],
+    [:error,  :red],
+    [:fatal,  :red],
+  ]
+
+  tests.each_with_index do |(level, color), index|
+    # Note for the unwary - using a loop in this manner shows strange
+    # behavior with variable closure. The describe block is needed to retain
+    # the loop variables for each test; without this the let helpers are
+    # overwritten and the last set of helpers are used for all tests.
+    describe "at level #{level}" do
+      let(:message) { "level #{level}: #{color}" }
+
+      let(:event) do
+        Log4r::LogEvent.new(index + 1, Log4r::Logger.new('test::logger'), nil, message)
+      end
+
+      it "logs messages as #{color ? color : "uncolored"}" do
+        output = color.nil? ? message : message.send(color)
+        subject.send(level, event)
+        expect(stream.string).to eq output
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a log4r outputter that adds color for different log levels, in order to help break up the visual output when high volumes of logs are put out and draw out warnings and errors from non-essential messages. Color output is disabled by default and can be enabled by passing the `--color` flag to r10k.
