### PR TITLE
(CODEMGMT-148) Add Gemfile for Integration Tests

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -1,0 +1,3 @@
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+gem 'beaker', '~> 2.7.1'


### PR DESCRIPTION
It is necessary for the CI environment to have a Gemfile present that includes
Beaker for running the r10k integration tests.
