### PR TITLE
(RK-79) Bump minimum version of faraday_middleware-multi_json

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday',                       '~> 0.9.0'
   s.add_dependency 'faraday_middleware',            '~> 0.9.0'
-  s.add_dependency 'faraday_middleware-multi_json', '~> 0.0.5'
+  s.add_dependency 'faraday_middleware-multi_json', '~> 0.0.6'
 
   s.add_dependency 'semantic_puppet', '~> 0.1.0'
 


### PR DESCRIPTION
Without this commit, using the multi_json faraday middleware will
produce this error:

```
/var/lib/gems/1.9.1/gems/faraday-0.9.0/lib/faraday.rb:99:in `method_missing': undefined method `register_middleware' for #<Faraday::Connection:0x0000000262a2f8> (NoMethodError)
        from /var/lib/gems/1.9.1/gems/faraday_middleware-multi_json-0.0.5/lib/faraday_middleware/multi_json.rb:28:in `<top (required)>'
```

Faraday 0.9.0 changed the API for registering middleware, and
faraday_middleware-multi_json 0.0.6 must be used because of the new API.
