### PR TITLE
(CODEMGMT-137) Create Tests for "rugged" Git Provider

### DIFF
--- a/integration/files/pre-suite/git_config.pp.erb
+++ b/integration/files/pre-suite/git_config.pp.erb
@@ -1,0 +1,13 @@
+class { 'git': }
+->
+git::config { 'user.name':
+  value => 'Tester',
+}
+->
+git::config { 'user.email':
+  value => 'tester@puppetlabs.com',
+}
+->
+file { '<%= git_repo_path %>':
+  ensure => directory
+}

--- a/integration/tests/basic_functionality/negative/neg_invalid_git_provider.rb
+++ b/integration/tests/basic_functionality/negative/neg_invalid_git_provider.rb
@@ -1,0 +1,44 @@
+test_name 'CODEMGMT-137 - C64161 - Specify Invalid Value for Git Provider'
+
+#Init
+env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
+
+git_repo_path = '/git_repos'
+git_control_remote = File.join(git_repo_path, 'environments.git')
+git_provider = 'invalid'
+
+r10k_config_path = get_r10k_config_file_path(master)
+r10k_config_bak_path = "#{r10k_config_path}.bak"
+
+#In-line files
+r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
+sources:
+  control:
+    basedir: "#{env_path}"
+    remote: "#{git_control_remote}"
+CONF
+
+#Verification
+error_message_regex = /ConfigError:.*Couldn't load config file/
+
+#Teardown
+teardown do
+  step 'Restore Original "r10k" Config'
+  on(master, "mv #{r10k_config_bak_path} #{r10k_config_path}")
+end
+
+#Setup
+step 'Backup a Valid "r10k" Config'
+on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
+
+step 'Update the "r10k" Config'
+create_remote_file(master, r10k_config_path, r10k_conf)
+
+#Tests
+step 'Attempt to Deploy via r10k'
+on(master, 'r10k deploy environment -v', :acceptable_exit_codes => 1) do |result|
+  assert_match(error_message_regex, result.stderr, 'Expected message not found!')
+end

--- a/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
@@ -1,16 +1,34 @@
+require 'erb'
 require 'git_utils'
 require 'r10k_utils'
 require 'master_manipulator'
-test_name 'CODEMGMT-92 - C59234 - Single Git Source Using "SSH" Transport Protocol'
+test_name 'CODEMGMT-137 - C64160 - Use "rugged" Git Provider with Authentication'
+
+confine(:to, :platform => ['el', 'ubuntu', 'sles'])
+
+if ENV['GIT_PROVIDER'] == 'shellgit'
+  skip_test('Skipping test because removing Git from the system affects other "shellgit" tests.')
+end
 
 #Init
+master_platform = fact_on(master, 'osfamily')
+master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
+
+git_repo_path = '/git_repos'
 git_control_remote = 'git@github.com:puppetlabs/codemgmt-92.git'
-git_provider = ENV['GIT_PROVIDER'] || 'shellgit'
+git_environments_path = '/root/environments'
+last_commit = git_last_commit(master, git_environments_path)
+git_provider = 'rugged'
 
 jenkins_key_path = File.file?("#{ENV['HOME']}/.ssh/id_rsa") ? "#{ENV['HOME']}/.ssh/id_rsa" : File.expand_path('~/.ssh/id_rsa-jenkins')
 ssh_private_key_path = '/root/.ssh/id_rsa-jenkins'
-ssh_config_path = '/root/.ssh/config'
+
+local_files_root_path = ENV['FILES'] || 'files'
+helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
+
+git_manifest_template_path = File.join(local_files_root_path, 'pre-suite', 'git_config.pp.erb')
+git_manifest = ERB.new(File.read(git_manifest_template_path)).result(binding)
 
 r10k_config_path = get_r10k_config_file_path(master)
 r10k_config_bak_path = "#{r10k_config_path}.bak"
@@ -22,34 +40,27 @@ git:
   provider: '#{git_provider}'
   private_key: '#{ssh_private_key_path}'
 sources:
-  broken:
+  control:
     basedir: "#{env_path}"
     remote: "#{git_control_remote}"
 CONF
 
-ssh_config = <<-CONF
-StrictHostKeyChecking no
-
-Host github.com
-    IdentityFile #{ssh_private_key_path}
-CONF
+#Manifest
+site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
+site_pp = create_site_pp(master_certname, '  include helloworld')
 
 #Verification
 notify_message_regex = /I am in the production environment/
 
 #Teardown
 teardown do
+  step 'Restore "git" Package'
+  on(master, puppet('apply'), :stdin => git_manifest, :acceptable_exit_codes => [0,2])
+
   step 'Restore Original "r10k" Config'
   on(master, "mv #{r10k_config_bak_path} #{r10k_config_path}")
 
-  step 'Remove Jenkins SSH Key'
-  on(master, "rm -rf #{ssh_private_key_path}")
-
-  step 'Remove SSH Config'
-  on(master, "rm -rf #{ssh_config_path}")
-
-  step 'Restore Original "production" Environment via r10k'
-  on(master, 'r10k deploy environment -v')
+  clean_up_r10k(master, last_commit, git_environments_path)
 end
 
 #Setup
@@ -63,13 +74,18 @@ end
 step 'Update the "r10k" Config'
 create_remote_file(master, r10k_config_path, r10k_conf)
 
-step 'Configure SSH to Use SSH Key for "github.com"'
-create_remote_file(master, ssh_config_path, ssh_config)
-on(master, "chmod 600 #{ssh_config_path}")
-
 step 'Copy SSH Key to Master'
 scp_to(master, jenkins_key_path, ssh_private_key_path)
 on(master, "chmod 600 #{ssh_private_key_path}")
+
+step 'Remove "git" Package from System'
+if master_platform == 'RedHat'
+  on(master, 'yum remove -y git')
+elsif master_platform == 'Debian'
+  on(master, 'apt-get remove -y git')
+elsif master_platform == 'SLES'
+  on(master, 'zypper remove -y git-core git')
+end
 
 #Tests
 step 'Deploy "production" Environment via r10k'

--- a/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
@@ -1,0 +1,101 @@
+require 'erb'
+require 'git_utils'
+require 'r10k_utils'
+require 'master_manipulator'
+test_name 'CODEMGMT-137 - C64159 - Use "rugged" Git Provider without Authentication'
+
+confine(:to, :platform => ['el', 'ubuntu', 'sles'])
+
+if ENV['GIT_PROVIDER'] == 'shellgit'
+  skip_test('Skipping test because removing Git from the system affects other "shellgit" tests.')
+end
+
+#Init
+master_platform = fact_on(master, 'osfamily')
+master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
+env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
+
+git_repo_path = '/git_repos'
+git_repo_name = 'environments'
+git_control_remote = File.join(git_repo_path, "#{git_repo_name}.git")
+git_environments_path = '/root/environments'
+last_commit = git_last_commit(master, git_environments_path)
+git_provider = 'rugged'
+
+local_files_root_path = ENV['FILES'] || 'files'
+helloworld_module_path = File.join(local_files_root_path, 'modules', 'helloworld')
+
+git_manifest_template_path = File.join(local_files_root_path, 'pre-suite', 'git_config.pp.erb')
+git_manifest = ERB.new(File.read(git_manifest_template_path)).result(binding)
+
+r10k_config_path = get_r10k_config_file_path(master)
+r10k_config_bak_path = "#{r10k_config_path}.bak"
+
+#In-line files
+r10k_conf = <<-CONF
+cachedir: '/var/cache/r10k'
+git:
+  provider: '#{git_provider}'
+sources:
+  control:
+    basedir: "#{env_path}"
+    remote: "#{git_control_remote}"
+CONF
+
+#Manifest
+site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
+site_pp = create_site_pp(master_certname, '  include helloworld')
+
+#Verification
+notify_message_regex = /I am in the production environment/
+
+#Teardown
+teardown do
+  step 'Restore "git" Package'
+  on(master, puppet('apply'), :stdin => git_manifest, :acceptable_exit_codes => [0,2])
+
+  step 'Restore Original "r10k" Config'
+  on(master, "mv #{r10k_config_bak_path} #{r10k_config_path}")
+
+  clean_up_r10k(master, last_commit, git_environments_path)
+end
+
+#Setup
+step 'Backup Current "r10k" Config'
+on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
+
+step 'Update the "r10k" Config'
+create_remote_file(master, r10k_config_path, r10k_conf)
+
+step 'Checkout "production" Branch'
+git_on(master, 'checkout production', git_environments_path)
+
+step 'Copy "helloworld" Module to "production" Environment Git Repo'
+scp_to(master, helloworld_module_path, File.join(git_environments_path, "site", 'helloworld'))
+
+step 'Inject New "site.pp" to the "production" Environment'
+inject_site_pp(master, site_pp_path, site_pp)
+
+step 'Push Changes'
+git_add_commit_push(master, 'production', 'Update site.pp and add module.', git_environments_path)
+
+step 'Remove "git" Package from System'
+if master_platform == 'RedHat'
+  on(master, 'yum remove -y git')
+elsif master_platform == 'Debian'
+  on(master, 'apt-get remove -y git')
+elsif master_platform == 'SLES'
+  on(master, 'zypper remove -y git-core git')
+end
+
+#Tests
+step 'Deploy "production" Environment via r10k'
+on(master, 'r10k deploy environment -v')
+
+agents.each do |agent|
+  step "Run Puppet Agent"
+  on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
+  end
+end


### PR DESCRIPTION
Add integration tests for "rugged" Git provider that validate that a user
can use the provider on a system without Git installed.

Note: to run these tests requires a particular SSH key for accessing a private GitHub repo.
