### PR TITLE
[feature] (RK-73) Add logging for feature detection

### DIFF
--- a/lib/r10k/feature.rb
+++ b/lib/r10k/feature.rb
@@ -1,6 +1,10 @@
+require 'r10k/logging'
+
 module R10K
   # Detect whether a given feature is present or absent
   class Feature
+
+    include R10K::Logging
 
     # @attribute [r] name
     #   @return [Symbol] The name of this feature
@@ -15,21 +19,38 @@ module R10K
     def initialize(name, opts = {}, &block)
       @name      = name
       @libraries = Array(opts.delete(:libraries))
-      @block     = block || lambda { true }
+      @block     = block
     end
 
     # @return [true, false] Is this feature available?
     def available?
-      @libraries.all? { |lib| library_available?(lib) } && !!@block.call
+      logger.debug1 { "Testing to see if feature #{@name} is available." }
+      rv = @libraries.all? { |lib| library_available?(lib) } && proc_available?
+      msg = rv ? "is" : "is not"
+      logger.debug1 { "Feature #{@name} #{msg} available." }
+      rv
     end
 
     private
 
     def library_available?(lib)
+      logger.debug2 { "Attempting to load library '#{lib}' for feature #{@name}" }
       require lib
       true
-    rescue ScriptError
+    rescue ScriptError => e
+      logger.debug2 { "Error while loading library #{lib} for feature #{@name}: #{e.message}" }
       false
+    end
+
+    def proc_available?
+      if @block
+        logger.debug2 { "Evaluating proc #{@block.inspect} to test for feature #{@name}" }
+        output = @block.call
+        logger.debug2 { "Proc #{@block.inspect} for feature #{@name} returned #{output.inspect}" }
+        !!output
+      else
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
Right now determining if a feature is available is entirely opaque; if a
feature failed to load there's no indication why.  For instance, the
rugged provider tries to load the 'rugged' gem - if that fails for any
reason (such as a missing shared object) the error is masked and r10k
will pretend that the rugged library is not present.

This commit adds log messages so that if a feature is unavailable the
failure can be divined by checking the debug level logging.
