### PR TITLE
[git] (RK-62) Warn if rugged is missing features

### DIFF
--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -1,18 +1,38 @@
 require 'r10k/features'
 require 'r10k/errors'
 require 'r10k/settings'
+require 'r10k/logging'
 
 module R10K
   module Git
     require 'r10k/git/shellgit'
     require 'r10k/git/rugged'
 
+    extend R10K::Logging
+
     # A list of Git providers, sorted by priority. Providers have features that
     # must be available for them to be used, and a module which is the namespace
     # containing the implementation.
     @providers = [
-      [:shellgit, {:feature => :shellgit, :module => R10K::Git::ShellGit}],
-      [:rugged,   {:feature => :rugged,   :module => R10K::Git::Rugged}],
+      [ :shellgit,
+        {
+          :feature => :shellgit,
+          :module  => R10K::Git::ShellGit,
+        }
+      ],
+      [ :rugged,
+        {
+          :feature => :rugged,
+          :module  => R10K::Git::Rugged,
+          :on_set  => proc do
+            [:ssh, :https].each do |transport|
+              if !::Rugged.features.include?(transport)
+                logger.warn "Rugged has been compiled without support for #{transport}; Git repositories will not be reachable via #{transport}."
+              end
+            end
+          end
+        }
+      ],
     ]
 
     # Mark the current provider as invalid.
@@ -39,14 +59,13 @@ module R10K
     # Return the first available Git provider.
     #
     # @raise [R10K::Error] if no Git providers are functional.
-    # @return [Module] The namespace of the first available Git implementation.
-    #   Implementation classes should be looked up against this returned Module.
-    def self.default
-      _, attrs = @providers.find { |(_, hash)| R10K::Features.available?(hash[:feature]) }
-      if attrs.nil?
+    # @return [String] The name of the first available Git implementation.
+    def self.default_name
+      name, _ = @providers.find { |(_, hash)| R10K::Features.available?(hash[:feature]) }
+      if name.nil?
         raise R10K::Error, "No Git providers are functional."
       end
-      attrs[:module]
+      name
     end
 
     # Manually set the Git provider by name.
@@ -65,6 +84,9 @@ module R10K
         @provider = NULL_PROVIDER
         raise R10K::Error, "Git provider '#{name}' is not functional."
       end
+      if attrs[:on_set]
+        attrs[:on_set].call
+      end
       @provider = attrs[:module]
     end
 
@@ -75,10 +97,9 @@ module R10K
       when NULL_PROVIDER
         raise R10K::Error, "No Git provider set."
       when UNSET_PROVIDER
-        @provider = default
-      else
-        @provider
+        self.provider = default_name
       end
+      @provider
     end
 
     def self.cache

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -8,20 +8,20 @@ describe R10K::Git do
   describe 'selecting the default provider' do
     it 'returns shellgit when the git executable is present' do
       expect(R10K::Features).to receive(:available?).with(:shellgit).and_return true
-      expect(described_class.default).to eq R10K::Git::ShellGit
+      expect(described_class.default_name).to eq :shellgit
     end
 
     it 'returns rugged when the git executable is absent and the rugged library is present' do
       expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
       expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
-      expect(described_class.default).to eq R10K::Git::Rugged
+      expect(described_class.default_name).to eq :rugged
     end
 
     it 'raises an error when the git executable and rugged library are absent' do
       expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
       expect(R10K::Features).to receive(:available?).with(:rugged).and_return false
       expect {
-        described_class.default
+        described_class.default_name
       }.to raise_error(R10K::Error, 'No Git providers are functional.')
     end
 
@@ -37,7 +37,10 @@ describe R10K::Git do
     end
   end
 
-  describe 'explicitly setting the provider' do
+  # These tests will fail on Ruby 1.8.7 because they touch the Rugged provider,
+  # but any failures affecting 1.8.7 will affect other versions so we can
+  # use tests on 1.9+ to cover the same behavior in 1.8.7.
+  describe 'explicitly setting the provider', :if => (RUBY_VERSION != '1.8.7') do
     it "raises an error if the provider doesn't exist" do
       expect {
         described_class.provider = :nope
@@ -58,10 +61,10 @@ describe R10K::Git do
     end
   end
 
-  describe "retrieving the current provider" do
+  describe "retrieving the current provider", :if => (RUBY_VERSION != '1.8.7') do
     it "uses the default if a provider has not been set" do
-      expect(described_class).to receive(:default).and_return :def
-      expect(described_class.provider).to eq :def
+      expect(described_class).to receive(:default_name).and_return :rugged
+      expect(described_class.provider).to eq(R10K::Git::Rugged)
     end
 
     it "uses an explicitly set provider" do


### PR DESCRIPTION
If Rugged was compiled without SSH support and the SSH transport is
used, Rugged will throw a rather cryptic error. This commit adds an
`:on_set` hook for Git providers, uses that hook to check for the
features compiled into Rugged, and emits a warning if the https or ssh
feature is missing.
