### PR TITLE
[git/stateful_repository] (RK-86) Correctly sync branches

### DIFF
--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -30,7 +30,7 @@ class R10K::Git::StatefulRepository
   end
 
   def sync
-    @cache.sync if sync?
+    @cache.sync if sync_cache?
 
     sha = @cache.resolve(@ref)
 
@@ -70,12 +70,11 @@ class R10K::Git::StatefulRepository
     end
   end
 
-  private
-
-  def sync?
+  # @api private
+  def sync_cache?
     return true if !@cache.exist?
-    return true if !(sha = @cache.resolve(@ref))
-    return true if !([:commit, :tag].include? @cache.ref_type(sha))
+    return true if !@cache.resolve(@ref)
+    return true if !([:commit, :tag].include? @cache.ref_type(@ref))
     return false
   end
 end

--- a/spec/unit/git/stateful_repository_spec.rb
+++ b/spec/unit/git/stateful_repository_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'r10k/git'
+require 'r10k/git/stateful_repository'
+
+describe R10K::Git::StatefulRepository do
+
+  let(:remote) { 'git://some.site/some-repo.git' }
+
+  subject { described_class.new('0.9.x', remote, '/some/nonexistent/basedir', 'some-dirname') }
+
+  describe "determining if the cache needs to be synced" do
+
+    let(:cache) { double('cache') }
+
+    before { expect(R10K::Git.cache).to receive(:generate).with(remote).and_return(cache) }
+
+    it "is true if the cache is absent" do
+      expect(cache).to receive(:exist?).and_return false
+      expect(subject.sync_cache?).to eq true
+    end
+
+    it "is true if the ref is unresolvable" do
+      expect(cache).to receive(:exist?).and_return true
+      expect(cache).to receive(:resolve).with('0.9.x')
+      expect(subject.sync_cache?).to eq true
+    end
+
+    it "is true if the ref is not a tag or commit" do
+      expect(cache).to receive(:exist?).and_return true
+      expect(cache).to receive(:resolve).with('0.9.x').and_return('93456ec7dc0f6fd3ac193b4df64f6544615dfbc9')
+      expect(cache).to receive(:ref_type).with('0.9.x').and_return(:branch)
+      expect(subject.sync_cache?).to eq true
+    end
+
+    it "is false otherwise" do
+      expect(cache).to receive(:exist?).and_return true
+      expect(cache).to receive(:resolve).with('0.9.x').and_return('93456ec7dc0f6fd3ac193b4df64f6544615dfbc9')
+      expect(cache).to receive(:ref_type).with('0.9.x').and_return(:tag)
+      expect(subject.sync_cache?).to eq false
+    end
+
+  end
+end


### PR DESCRIPTION
R10k 1.5.0 added an optimization for avoiding syncing the Git cache
unless necessary, but accidentally treated all refs as commits, causing
branches to not be updated. This only affected Git modules as
environments/sources would always force a sync. This commit resolves the
issue by checking the type of the ref, not the type of the resolved sha,
when determining if the cache needs to be updated.
