### PR TITLE
(CODEMGMT-166) Fix Broken Tests

### DIFF
--- a/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
@@ -8,6 +8,8 @@ confine(:to, :platform => ['el', 'ubuntu', 'sles'])
 
 if ENV['GIT_PROVIDER'] == 'shellgit'
   skip_test('Skipping test because removing Git from the system affects other "shellgit" tests.')
+elsif fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+  skip_test('This version of EL is not supported by this test case!')
 end
 
 #Init

--- a/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
@@ -8,6 +8,8 @@ confine(:to, :platform => ['el', 'ubuntu', 'sles'])
 
 if ENV['GIT_PROVIDER'] == 'shellgit'
   skip_test('Skipping test because removing Git from the system affects other "shellgit" tests.')
+elsif fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+  skip_test('This version of EL is not supported by this test case!')
 end
 
 #Init

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
@@ -2,6 +2,10 @@ require 'git_utils'
 require 'r10k_utils'
 test_name 'CODEMGMT-86 - C59265 - Attempt to Deploy Environment to Disk with Insufficient Free Space'
 
+if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+  skip_test('This version of EL is not supported by this test case!')
+end
+
 #Init
 git_repo_path = '/git_repos'
 git_repo_name = 'environments'

--- a/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
@@ -3,6 +3,10 @@ require 'r10k_utils'
 require 'master_manipulator'
 test_name 'CODEMGMT-62 - C59239 - Single Environment with 10,000 Files'
 
+if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+  skip_test('This version of EL is not supported by this test case!')
+end
+
 #Init
 master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
 environment_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip

--- a/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
@@ -3,6 +3,10 @@ require 'r10k_utils'
 require 'master_manipulator'
 test_name 'CODEMGMT-62 - C59242 - Single Environment with Large Binary Files'
 
+if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+  skip_test('This version of EL is not supported by this test case!')
+end
+
 #Init
 master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip
 environment_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip


### PR DESCRIPTION
Turns out that CentOS 5 makes some of the integration tests cranky. The tests
have been updated to skip on incompatible platforms.
