### PR TITLE
[forge] (RK-96) forge module status is incorrect when previously a git checkout

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -83,6 +83,7 @@ class R10K::Module::Forge < R10K::Module::Base
   # @return [Symbol] :absent If the directory doesn't exist
   # @return [Symbol] :mismatched If the module is not a forge module, or
   #   isn't the right forge module
+  # @return [Symbol] :mismatched If the module was previously a git checkout
   # @return [Symbol] :outdated If the installed module is older than expected
   # @return [Symbol] :insync If the module is in the desired state
   def status
@@ -92,6 +93,10 @@ class R10K::Module::Forge < R10K::Module::Base
     elsif not File.exist?(@path + 'metadata.json')
       # The directory exists but doesn't have a metadata file; it probably
       # isn't a forge module.
+      return :mismatched
+    end
+
+    if File.directory?(@path + '.git')
       return :mismatched
     end
 

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -185,6 +185,12 @@ describe R10K::Module::Forge do
       expect(subject.status).to eq :mismatched
     end
 
+    it "is :mismatched if module was previously a git checkout" do
+      allow(File).to receive(:directory?).and_return true
+
+      expect(subject.status).to eq :mismatched
+    end
+
     it "is :mismatched if the metadata author doesn't match the expected author" do
       allow(subject).to receive(:exist?).and_return true
 


### PR DESCRIPTION
Return mismatched status when a forge module was previsously a git
module.
