### PR TITLE
[shared/puppet_forge] Add support for downloading forge modules

### DIFF
--- a/lib/shared/puppet_forge/connection.rb
+++ b/lib/shared/puppet_forge/connection.rb
@@ -1,0 +1,50 @@
+require 'shared/puppet_forge/version'
+
+require 'faraday'
+require 'faraday_middleware'
+
+module PuppetForge
+  # Provide a common mixin for adding a HTTP connection to classes.
+  #
+  # This module provides a common method for creating HTTP connections as well
+  # as reusing a single connection object between multiple classes. Including
+  # classes can invoke #conn to get a reasonably configured HTTP connection.
+  # Connection objects can be passed with the #conn= method.
+  #
+  # @example
+  #   class HTTPThing
+  #     include PuppetForge::Connection
+  #   end
+  #   thing = HTTPThing.new
+  #   thing.conn = thing.make_connection('https://non-standard-forge.site')
+  #
+  # @api private
+  module Connection
+
+    attr_writer :conn
+
+    # @return [Faraday::Connection] An existing Faraday connection if one was
+    #   already set, otherwise a new Faraday connection.
+    def conn
+      @conn ||= make_connection('https://forgeapi.puppetlabs.com')
+    end
+
+    # Generate a new Faraday connection for the given URL.
+    #
+    # @param url [String] the base URL for this connection
+    # @return [Faraday::Connection]
+    def make_connection(url, adapter_args = nil)
+      adapter_args ||= [Faraday.default_adapter]
+      options = {:headers => {:user_agent => USER_AGENT}}
+
+      Faraday.new(url, options) do |builder|
+        builder.response(:json, :content_type => /\bjson$/)
+        builder.response(:raise_error)
+
+        builder.adapter(*adapter_args)
+      end
+    end
+
+    USER_AGENT = "PuppetForge/#{PuppetForge::VERSION} Faraday/#{Faraday::VERSION} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})"
+  end
+end

--- a/lib/shared/puppet_forge/v3.rb
+++ b/lib/shared/puppet_forge/v3.rb
@@ -1,0 +1,13 @@
+module PuppetForge
+  module V3
+    # Normalize a module name to use a hyphen as the separator between the
+    # author and module.
+    #
+    # @example
+    #   PuppetForge::V3.normalize_name('my/module') #=> 'my-module'
+    #   PuppetForge::V3.normalize_name('my-module') #=> 'my-module'
+    def self.normalize_name(name)
+      name.tr('/', '-')
+    end
+  end
+end

--- a/lib/shared/puppet_forge/v3/module.rb
+++ b/lib/shared/puppet_forge/v3/module.rb
@@ -1,0 +1,31 @@
+require 'shared/puppet_forge/v3'
+require 'shared/puppet_forge/v3/module_release'
+require 'shared/puppet_forge/connection'
+
+module PuppetForge
+  module V3
+    # Represents metadata for a single Forge module and provides access to
+    # the releases of a module.
+    class Module
+
+      include PuppetForge::Connection
+
+      # @!attribute [r] full_name
+      #   @return [String] The hyphen separated full name of this module
+      attr_reader :full_name
+
+      # @param full_name [String] The name of this module, will be normalized to
+      #   a hyphen separated name.
+      def initialize(full_name)
+        @full_name = PuppetForge::V3.normalize_name(full_name)
+      end
+
+      # Get a specific release of this module off of the forge.
+      #
+      # @return [ModuleRelease] a release object of the given version for this module.
+      def release(version)
+        PuppetForge::V3::ModuleRelease.new(@full_name, version).tap { |mr| mr.conn = conn }
+      end
+    end
+  end
+end

--- a/lib/shared/puppet_forge/v3/module_release.rb
+++ b/lib/shared/puppet_forge/v3/module_release.rb
@@ -1,0 +1,73 @@
+require 'shared/puppet_forge/v3'
+require 'shared/puppet_forge/connection'
+
+module PuppetForge
+  module V3
+    # Access metadata and downloads for a specific module release.
+    class ModuleRelease
+
+      include PuppetForge::Connection
+
+      # @!attribute [r] full_name
+      #   @return [String] The hyphen delimited name of this module
+      attr_reader :full_name
+
+      # @!attribute [r] version
+      #   @return [String] The version of this module
+      attr_reader :version
+
+      # @param full_name [String] The name of the module, will be normalized
+      #   to a hyphen delimited name.
+      # @param version [String]
+      def initialize(full_name, version)
+        @full_name = PuppetForge::V3.normalize_name(full_name)
+        @version   = version
+      end
+
+      # @return [Hash] The complete Forge resposne for this release.
+      def data
+        @data ||= conn.get(resource_url).body
+      end
+
+      # @return [String] The unique identifier for this module release.
+      def slug
+        "#{full_name}-#{version}"
+      end
+
+      # Download this module release to the specified path.
+      #
+      # @param path [Pathname]
+      # @return [void]
+      def download(path)
+        resp = conn.get(file_url)
+        path.open('wb') { |fh| fh.write(resp.body) }
+      end
+
+      # Verify that a downloaded module matches the checksum in the metadata for this release.
+      #
+      # @param path [Pathname]
+      # @return [void]
+      def verify(path)
+        expected_md5 = data['file_md5']
+        file_md5     = Digest::MD5.file(path).hexdigest
+        if expected_md5 != file_md5
+          raise ChecksumMismatch.new("Expected #{path} checksum to be #{expected_md5}, got #{file_md5}")
+        end
+      end
+
+      private
+
+      def file_url
+        "/v3/files/#{slug}.tar.gz"
+      end
+
+      def resource_url
+        "/v3/releases/#{slug}"
+      end
+
+      class ChecksumMismatch < StandardError
+
+      end
+    end
+  end
+end

--- a/lib/shared/puppet_forge/version.rb
+++ b/lib/shared/puppet_forge/version.rb
@@ -1,0 +1,3 @@
+module PuppetForge
+  VERSION = '2.0.0.alpha'
+end

--- a/spec/unit/puppet_forge/connection_spec.rb
+++ b/spec/unit/puppet_forge/connection_spec.rb
@@ -1,0 +1,31 @@
+require 'shared/puppet_forge/connection'
+
+describe PuppetForge::Connection do
+
+  let(:extended) { Object.new.extend(described_class) }
+
+  describe 'creating a new connection' do
+
+    let(:faraday_stubs) { Faraday::Adapter::Test::Stubs.new }
+
+    subject { extended.make_connection('https://some.site/url', [:test, faraday_stubs]) }
+
+    it 'parses response bodies with a JSON content-type into a hash' do
+      faraday_stubs.get('/json') { [200, {'Content-Type' => 'application/json'}, '{"hello": "world"}'] }
+      expect(subject.get('/json').body).to eq('hello' => 'world')
+    end
+
+    it 'returns the response body as-is when the content-type is not JSON' do
+      faraday_stubs.get('/binary') { [200, {'Content-Type' => 'application/octet-stream'}, 'I am a big bucket of binary data'] }
+      expect(subject.get('/binary').body).to eq('I am a big bucket of binary data')
+    end
+
+    it 'raises errors when the request has an error status code' do
+      faraday_stubs.get('/error') { [503, {}, "The server caught fire and cannot service your request right now"] }
+
+      expect {
+        subject.get('/error')
+      }.to raise_error(Faraday::ClientError, "the server responded with status 503")
+    end
+  end
+end

--- a/spec/unit/puppet_forge/v3/module_release_spec.rb
+++ b/spec/unit/puppet_forge/v3/module_release_spec.rb
@@ -1,0 +1,68 @@
+require 'shared/puppet_forge/v3/module_release'
+
+describe PuppetForge::V3::ModuleRelease do
+
+  subject { described_class.new('username-modulename', '3.1.4') }
+
+  let(:faraday_stubs) { Faraday::Adapter::Test::Stubs.new }
+
+  let(:conn) do
+    Faraday.new do |builder|
+      builder.adapter :test, faraday_stubs
+    end
+  end
+
+  before do
+    subject.conn = conn
+  end
+
+  it "creates a slug from the full_name and version" do
+    expect(subject.slug).to eq 'username-modulename-3.1.4'
+  end
+
+
+  describe '#data' do
+    it 'returns the body of the response' do
+      faraday_stubs.get('/v3/releases/username-modulename-3.1.4') { [200, {}, {'metadata' => 'yep'}] }
+      expect(subject.data).to eq('metadata' => 'yep')
+    end
+  end
+
+  describe '#download' do
+    it 'downloads the file to the provided path' do
+      faraday_stubs.get('/v3/files/username-modulename-3.1.4.tar.gz') { [200, {}, "I'm a file!"] }
+
+      path = Pathname.new('/some/path')
+      io   = instance_double('IO')
+
+      expect(path).to receive(:open).with('wb').and_yield io
+      expect(io).to receive(:write).with("I'm a file!")
+
+      subject.download(path)
+    end
+  end
+
+  describe '#verify' do
+    let(:digest) { instance_double('Digest::MD5') }
+
+    let(:path) { Pathname.new('/some/path') }
+
+    it "returns without error when the checksum matches" do
+      expect(Digest::MD5).to receive(:file).with(path).and_return(digest)
+      expect(digest).to receive(:hexdigest).and_return('823fe0a11fc0ef23a5853e2791880c9b')
+      expect(subject).to receive(:data).and_return('file_md5' => '823fe0a11fc0ef23a5853e2791880c9b')
+
+      subject.verify(path)
+    end
+
+    it "raises an error when the checksum doesn't match" do
+      expect(Digest::MD5).to receive(:file).with(path).and_return(digest)
+      expect(digest).to receive(:hexdigest).and_return('00000000000000000000000000000000')
+      expect(subject).to receive(:data).and_return('file_md5' => '823fe0a11fc0ef23a5853e2791880c9b')
+
+      expect {
+        subject.verify(path)
+      }.to raise_error(PuppetForge::V3::ModuleRelease::ChecksumMismatch, 'Expected /some/path checksum to be 823fe0a11fc0ef23a5853e2791880c9b, got 00000000000000000000000000000000')
+    end
+  end
+end

--- a/spec/unit/puppet_forge/v3/module_spec.rb
+++ b/spec/unit/puppet_forge/v3/module_spec.rb
@@ -1,0 +1,19 @@
+require 'shared/puppet_forge/v3/module'
+
+describe PuppetForge::V3::Module do
+  subject { described_class.new('authorname-modulename') }
+
+  describe '#release' do
+    it 'creates a release object for the module with the given version' do
+      release = subject.release('3.1.4')
+      expect(release.slug).to eq 'authorname-modulename-3.1.4'
+    end
+
+    it 'passes along the module connection object' do
+      conn = Object.new
+      subject.conn = conn
+      release = subject.release('3.1.4')
+      expect(release.conn).to eq conn
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the scaffording for direct integration with the Puppet
Forge. Right now this is limited to downloading modules but this will
expand as more functionality is needed.
