### PR TITLE
[settings] Add a more complete settings subsystem

### DIFF
--- a/lib/r10k/settings/collection.rb
+++ b/lib/r10k/settings/collection.rb
@@ -130,6 +130,17 @@ module R10K
           end
         end
       end
+
+      # Recursively call all apply hooks on nested collections and definitions.
+      # @return [void]
+      def apply!
+        @collections.values.each do |coll|
+          coll.apply!
+        end
+        @definitions.values.each do |defn|
+          defn.apply!
+        end
+      end
     end
   end
 end

--- a/lib/r10k/settings/collection.rb
+++ b/lib/r10k/settings/collection.rb
@@ -1,0 +1,76 @@
+module R10K
+  module Settings
+    # Define a group of settings definitions and handle fetching and assigning
+    # values for those definitions.
+    #
+    # @example
+    #   definitions = [
+    #     R10K::Settings::Definition.new(:someval),
+    #     R10K::Settings::Definition.new(:somedefaultvalue, :default => "stuff")
+    #   ]
+    #   collection = R10K::Settings::Collection.new(:coll, definitions)
+    #
+    #   collection.get(:someval) #=> nil
+    #   collection.get(:somedefaultvalue) #=> "stuff"
+    #
+    #   collection.set(:someval, "newvalue")
+    #   collection.get(:someval) #=> "newvalue"
+    #
+    #   collection.get(:novalue) #=> ArgumentError, "Cannot get value of nonexistent setting novalue"
+    #
+    class Collection
+
+      # @!attribute [r] name
+      #   @return [Symbol] The name of this settings collection
+      attr_reader :name
+
+      # @!attribute [r] definitions
+      #   @return [Array<R10K::Settings::Definition>]
+      attr_reader :definitions
+
+      # @param name [Symbol]
+      # @param definition_list [Array<R10K::Settings::Definition>]
+      def initialize(name, definition_list)
+        @name = name
+        @definitions = {}
+
+        definition_list.each do |defn|
+          @definitions[defn.name] = defn
+        end
+      end
+
+      # Get the value of the given setting.
+      #
+      # @param name [Symbol] The name of the setting to look up
+      # @raise [ArgumentError] If the requested setting isn't defined
+      # @return [Object] The setting value
+      def get(name)
+        defn = @definitions[name]
+        if defn
+          defn.get
+        else
+          raise ArgumentError, "Cannot get value of nonexistent setting #{name}"
+        end
+      end
+
+      alias [] get
+
+      # Set the value of the given setting.
+      #
+      # @param name [Symbol] The name of the setting to look up
+      # @param value [Object] The value to set the setting to
+      # @raise [ArgumentError] If the requested setting isn't defined
+      # @return [void]
+      def set(name, value)
+        defn = @definitions[name]
+        if defn
+          defn.set(value)
+        else
+          raise ArgumentError, "Cannot set value of nonexistent setting #{name}"
+        end
+      end
+
+      alias []= set
+    end
+  end
+end

--- a/lib/r10k/settings/collection.rb
+++ b/lib/r10k/settings/collection.rb
@@ -35,6 +35,7 @@ module R10K
         @definitions = {}
 
         definition_list.each do |defn|
+          defn.collection = self
           @definitions[defn.name] = defn
         end
       end

--- a/lib/r10k/settings/collection.rb
+++ b/lib/r10k/settings/collection.rb
@@ -109,6 +109,23 @@ module R10K
       end
 
       alias []= set
+
+      # Recursively bulk assign values to this collection and any nested collections.
+      #
+      # @param values [Hash] A hash of values to assign to this collection and
+      #   any nested collections
+      # @return [void]
+      def assign(values)
+        values.each_pair do |name, value|
+          if @definitions[name]
+            @definitions[name].set(value)
+          elsif @collections[name]
+            @collections[name].assign(value)
+          else
+            raise ArgumentError, "Cannot set value of nonexistent setting #{name}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/r10k/settings/collection.rb
+++ b/lib/r10k/settings/collection.rb
@@ -1,3 +1,5 @@
+require 'r10k/util/symbolize_keys'
+
 module R10K
   module Settings
     # Define a group of settings definitions and optional nested collections and
@@ -116,6 +118,8 @@ module R10K
       #   any nested collections
       # @return [void]
       def assign(values)
+        values = values.dup
+        R10K::Util::SymbolizeKeys.symbolize_keys!(values)
         values.each_pair do |name, value|
           if @definitions[name]
             @definitions[name].set(value)

--- a/lib/r10k/settings/collection_dsl.rb
+++ b/lib/r10k/settings/collection_dsl.rb
@@ -1,0 +1,60 @@
+require 'r10k/settings/collection'
+require 'r10k/settings/collection_maker'
+
+module R10K
+  module Settings
+    # Define a simple DSL for creating settings collections.
+    #
+    # This adds a R10K::Settings::CollectionMaker instance to inheriting classes,
+    # delegates the necessary methods to the maker instance, and automatically
+    # populates new instances with the appropriate definitions.
+    #
+    # Inheriting classes should define #initialize with an arity of zero and
+    # call the superclass with the name of the collection.
+    #
+    # @example
+    #   class SomeCollection < R10K::Settings::CollectionDSL
+    #     def initialize
+    #       super(:collection_name)
+    #     end
+    #
+    #     add_setting(
+    #       :my_setting,
+    #       {
+    #         :desc => "The description for my setting",
+    #         :default => "some default",
+    #       }
+    #     )
+    #
+    #     add_collection(R10K::Settings:AnotherCollection)
+    #   end
+    #
+    #   collection = R10K::Settings::SomeCollection.new
+    #   collection.get(:my_setting) #=> "some default"
+    #
+    # @abstract
+    class CollectionDSL < R10K::Settings::Collection
+      class << self
+
+        # @!attribute [r] maker
+        #   @api private
+        #   @return [R10K::Settings::CollectionMaker]
+        attr_accessor :maker
+
+        # Add a new maker instance to each subclass.
+        def inherited(klass)
+          klass.maker = R10K::Settings::CollectionMaker.new
+        end
+
+        extend Forwardable
+
+        def_delegators :@maker, :add_setting, :add_collection, :definitions, :collections
+        private :add_setting, :add_collection
+      end
+
+      def initialize(name)
+        super(name, self.class.definitions, self.class.collections)
+      end
+    end
+  end
+end

--- a/lib/r10k/settings/collection_maker.rb
+++ b/lib/r10k/settings/collection_maker.rb
@@ -1,0 +1,46 @@
+require 'r10k/settings/collection'
+require 'r10k/settings/definition'
+
+module R10K
+  module Settings
+    # Defines an API for gathering information to make a new Collection
+    #
+    # This class defines an interface for creating definition information which
+    # allows this class to define a "template" for Collection instances. It
+    # generates definition instances instead of having instances being handed
+    # to them to make sure that collections created from this don't accidentally
+    # reuse the same definition instances.
+    class CollectionMaker
+
+      # @!attribute [r] stored_definitions
+      #   @return [Array<Array<Symbol, Hash>>] A list of stored settings definitions
+      attr_reader :stored_definitions
+
+      def initialize
+        @stored_definitions = []
+      end
+
+      # Add a new setting definition
+      #
+      # @param name [Symbol] The name of the new definition
+      # @param opts [Hash] Information for this new setting. The exact set of
+      #   valid keys depends on the class set by the :type key.
+      #
+      # @options opts [Class] :type The class for this Definition; defaults
+      #   to {R10K::Settings::Definition}.
+      # @return [void]
+      def add_setting(name, opts)
+        @stored_definitions << [name, opts]
+      end
+
+      # @return [Array<R10K::Settings::Definition>] A unique list of definition instances
+      #   that can be passed to {R10K::Settings::Collection#initialize}
+      def definitions
+        @stored_definitions.map do |(name, opts)|
+          defn_type = opts.delete(:type) || R10K::Settings::Definition
+          defn_type.new(name, opts)
+        end
+      end
+    end
+  end
+end

--- a/lib/r10k/settings/collection_maker.rb
+++ b/lib/r10k/settings/collection_maker.rb
@@ -16,8 +16,13 @@ module R10K
       #   @return [Array<Array<Symbol, Hash>>] A list of stored settings definitions
       attr_reader :stored_definitions
 
+      # @!attribute [r] stored_collections
+      #   @return [Array<Class>] A list of stored collection classes
+      attr_reader :stored_collections
+
       def initialize
         @stored_definitions = []
+        @stored_collections = []
       end
 
       # Add a new setting definition
@@ -33,12 +38,29 @@ module R10K
         @stored_definitions << [name, opts]
       end
 
+      # Add a new nested collection
+      #
+      # @param klass [Class] The class of the nested collection to create. This
+      #   class should define #initialize with an arity of zero so that new
+      #   instances can be generated without an initializer list.
+      def add_collection(klass)
+        @stored_collections << klass
+      end
+
       # @return [Array<R10K::Settings::Definition>] A unique list of definition instances
       #   that can be passed to {R10K::Settings::Collection#initialize}
       def definitions
         @stored_definitions.map do |(name, opts)|
           defn_type = opts.delete(:type) || R10K::Settings::Definition
           defn_type.new(name, opts)
+        end
+      end
+
+      # @return [Array<R10K::Settings::Collection>] A unique list of nested collection
+      #   instances that can be passed to {R10K::Settings::Collection#initialize}
+      def collections
+        @stored_collections.map do |klass|
+          klass.new
         end
       end
     end

--- a/lib/r10k/settings/definition.rb
+++ b/lib/r10k/settings/definition.rb
@@ -36,6 +36,7 @@ module R10K
     class Definition
 
       require 'r10k/settings/enum_definition'
+      require 'r10k/settings/path_definition'
 
       include R10K::Util::Setopts
 

--- a/lib/r10k/settings/definition.rb
+++ b/lib/r10k/settings/definition.rb
@@ -66,6 +66,11 @@ module R10K
       #     value is not valid.
       attr_reader :validate
 
+      # @!attribute [rw] collection
+      #   @return [R10K::Settings::Collection] The settings collection that
+      #     this definition belongs to.
+      attr_accessor :collection
+
       # @param name [Symbol] The name of the setting for this definition.
       # @param opts [Hash]
       def initialize(name, opts = {})

--- a/lib/r10k/settings/definition.rb
+++ b/lib/r10k/settings/definition.rb
@@ -39,6 +39,13 @@ module R10K
     #   defn.set("myvalue") #=> nil
     #   defn.get #=> myvalue:Symbol
     #
+    # @example Using an apply hook
+    #   apply = lambda { |value| $globalstate = value }
+    #   defn = R10K::Settings::Definition.new(:globalstate, :apply => apply)
+    #   defn.set(:hello)
+    #   $globalstate #=> nil
+    #   defn.apply
+    #   $globalstate #=> :hello
     #
     class Definition
 
@@ -78,6 +85,11 @@ module R10K
       #     new setting value. This proc should raise an exception if the new
       #     value is not valid.
       attr_reader :validate
+
+      # @!attribute [rw] apply
+      #   @return [Proc] An optional proc that can be used to apply this setting
+      #     to the system.
+      attr_reader :apply
 
       # @!attribute [rw] collection
       #   @return [R10K::Settings::Collection] The settings collection that
@@ -127,6 +139,15 @@ module R10K
         @value = newvalue
       end
 
+      # Invoke the apply hook if one has been set on this definition.
+      #
+      # @return [void]
+      def apply!
+        if @apply
+          @apply.call(value)
+        end
+      end
+
       private
 
       # Subclasses may define additional params that are accepted at
@@ -138,6 +159,7 @@ module R10K
           :default  => true,
           :validate => true,
           :filter   => true,
+          :apply    => true,
         }
       end
     end

--- a/lib/r10k/settings/definition.rb
+++ b/lib/r10k/settings/definition.rb
@@ -1,0 +1,117 @@
+require 'r10k/util/setopts'
+
+module R10K
+  module Settings
+
+    # Define a single setting and additional attributes like descriptions,
+    # default values, and validation.
+    #
+    # @example A basic setting with documentation
+    #   defn = R10K::Settings::Definition.new(:basic, :desc => "Documentation for a simple setting")
+    #   defn.get #=> nil
+    #   defn.set(:myval)
+    #   defn.get #=> :myval
+    #
+    # @example Specifying a default value
+    #   defn = R10K::Settings::Definition.new(:defaultvalue, :default => :somedefault)
+    #   defn.get #=> :somedefault
+    #   defn.set(:myval)
+    #   defn.get #=> :myval
+    #
+    # @example Specifying a default lambda
+    #   defn = R10K::Settings::Definition.new(:defaultlambda, :default => lambda { |defn| "The default value for #{defn.name} is 'hello'" }
+    #   defn.get #=> "The default value for defaultlambda is 'hello'"
+    #
+    # @example Adding a validation hook
+    #   validator = lambda do |newvalue|
+    #     if !newvalue.is_a?(String)
+    #       raise ArgumentError, "#{newvalue} isn't a string"
+    #     end
+    #   end
+    #
+    #   defn = R10K::Settings::Definition.new(:defaultlambda, :validate => validator)
+    #   defn.set("a string") #=> nil
+    #   defn.set(123) #=> ArgumentError
+    #
+    class Definition
+
+      include R10K::Util::Setopts
+
+      # @!attribute [r] name
+      #   @return [String] The name of this setting
+      attr_reader :name
+
+      # @!attribute [r] value
+      #   @return [Object] An explicitly set value. This should only be used if
+      #     an optional default value should not be used; otherwise use {#set}.
+      attr_reader :value
+
+      # @!attribute [r] desc
+      #   @return [String] An optional documentation string for this setting.
+      attr_reader :desc
+
+      # @!attribute [rw] default
+      #   @return [Proc, Object] An optional proc or object for this setting.
+      #     If no value has been set, the default will be called and the result
+      #     returned if it's a proc, otherwise the default value will simply be
+      #     returned.
+      attr_reader :default
+
+      # @!attribute [rw] validate
+      #   @return [Proc] An optional proc that will be called before storing a
+      #     new setting value. This proc should raise an exception if the new
+      #     value is not valid.
+      attr_reader :validate
+
+      # @param name [Symbol] The name of the setting for this definition.
+      # @param opts [Hash]
+      def initialize(name, opts = {})
+        @name = name
+        setopts(opts, allowed_initialize_opts)
+      end
+
+      # Get the value of this setting.
+      #
+      # If an explicit value has been set it will be returned; otherwise if a
+      # default value has been set and is a proc it will be evaluated and the
+      # result will be returned, otherwise the default will be returned.
+      #
+      # @return [Object] The manually set value if given, else the default value
+      def get
+        if @value.nil?
+          @default.is_a?(Proc) ? @default.call : @default
+        else
+          @value
+        end
+      end
+
+      # Assign a value to this setting.
+      #
+      # If a validate hook has been assigned, that will be invoked before the
+      # setting is stored.
+      #
+      # @param newvalue [Object] The new setting to apply
+      #
+      # @return [void]
+      def set(newvalue)
+        if @validate
+          @validate.call(newvalue)
+        end
+        @value = newvalue
+      end
+
+      private
+
+      # Subclasses may define additional params that are accepted at
+      # initialization; they should override this method to add any additional
+      # fields that should be respected.
+      def allowed_initialize_opts
+        {
+          :desc     => true,
+          :default  => true,
+          :validate => true,
+        }
+      end
+    end
+  end
+end

--- a/lib/r10k/settings/definition.rb
+++ b/lib/r10k/settings/definition.rb
@@ -82,7 +82,7 @@ module R10K
       # @return [Object] The manually set value if given, else the default value
       def get
         if @value.nil?
-          @default.is_a?(Proc) ? @default.call : @default
+          @default.is_a?(Proc) ? @default.call(self) : @default
         else
           @value
         end

--- a/lib/r10k/settings/definition.rb
+++ b/lib/r10k/settings/definition.rb
@@ -35,6 +35,8 @@ module R10K
     #
     class Definition
 
+      require 'r10k/settings/enum_definition'
+
       include R10K::Util::Setopts
 
       # @!attribute [r] name

--- a/lib/r10k/settings/enum_definition.rb
+++ b/lib/r10k/settings/enum_definition.rb
@@ -1,0 +1,31 @@
+require 'r10k/settings/definition'
+
+module R10K
+  module Settings
+    # Define a setting with a list of valid values.
+    #
+    # @example
+    #   defn = R10K::Settings::EnumDefinition.new(:list, :enum => ['one', 'two', 'three'])
+    #   defn.set('two') #=> nil
+    #   defn.set(:invalid) #=> ArgumentError, "Definition list expects one of ['one', 'two', 'three'], got :invalid"
+    class EnumDefinition < R10K::Settings::Definition
+
+      # @!attribute [r] enum
+      #   @return [Array] A list of valid values for this definition.
+      attr_reader :enum
+
+      def set(newvalue)
+        if !enum.include?(newvalue)
+          raise ArgumentError, "Definition #{@name} expects one of #{enum.inspect}, got #{newvalue.inspect}"
+        end
+        super
+      end
+
+      private
+
+      def allowed_initialize_opts
+        super.merge(:enum => true)
+      end
+    end
+  end
+end

--- a/lib/r10k/settings/path_definition.rb
+++ b/lib/r10k/settings/path_definition.rb
@@ -1,0 +1,40 @@
+require 'r10k/settings/definition'
+
+module R10K
+  module Settings
+    # Define a setting for setting filesystem paths and validating that paths are
+    # readable or writable.
+    #
+    # @example Ensuring a path is readable and writable
+    #   defn = R10K::Settings::PathDefinition.new(:mypath, :readable => true, :writable => true)
+    #   defn.set("/some/unreadable/path") #=> ArgumentError, "/some/unreadable/path is not readable"
+    #   defn.set("/proc/cmdline") #=> ArgumentError, "/some/unreadable/path is not writable"
+    #
+    class PathDefinition < R10K::Settings::Definition
+
+      # @!attribute [r] readable
+      #   @return [true, false] If the path should be validated as readable when set
+      attr_reader :readable
+
+      # @!attribute [r] writable
+      #   @return [true, false] If the path should be validated as writable when set
+      attr_reader :writable
+
+      def set(newvalue)
+        if @readable && !File.readable?(newvalue)
+          raise ArgumentError, "#{newvalue} is not readable"
+        end
+        if @writable && !File.writable?(newvalue)
+          raise ArgumentError, "#{newvalue} is not writable"
+        end
+        super
+      end
+
+      private
+
+      def allowed_initialize_opts
+        super.merge(:readable => true, :writable => true)
+      end
+    end
+  end
+end

--- a/spec/unit/settings/collection_dsl_spec.rb
+++ b/spec/unit/settings/collection_dsl_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'r10k/settings/collection_dsl'
+
+describe R10K::Settings::CollectionDSL do
+
+  it 'creates a collection maker for inheriting classes' do
+    expect(Class.new(described_class).maker).to be_a_kind_of R10K::Settings::CollectionMaker
+  end
+
+  it 'creates separate collection makers for each inheriting class' do
+    class1 = Class.new(described_class)
+    class2 = Class.new(described_class)
+    expect(class1.maker).to_not eq class2.maker
+  end
+
+  describe 'generating a collection' do
+    let(:nested_collection_class) do
+      k = Class.new(described_class)
+      k.class_eval do
+        def initialize
+          super(:nested)
+        end
+
+        add_setting(
+          :nestedsetting,
+          {
+            :desc => 'some nested setting'
+          }
+        )
+      end
+      k
+    end
+
+    let(:base_collection_class) do
+      k = Class.new(described_class)
+      k.class_eval do
+        def initialize
+          super(:base)
+        end
+
+        add_setting(
+          :topsetting,
+          {
+            :desc => 'some top level setting'
+          }
+        )
+      end
+      # We can't access nested_collection_class inside of the above
+      # #class_eval'd class, but collection settings can only be set in the
+      # #class_eval scope. To get around that we just use a send to add the
+      # collection in the scope that has access.
+      k.send(:add_collection, nested_collection_class)
+      k
+    end
+
+    subject { base_collection_class.new }
+
+    it 'creates all supplied definitions' do
+      expect(subject.definitions.size).to eq 1
+      defn = subject.definitions[:topsetting]
+      expect(defn.desc).to eq 'some top level setting'
+    end
+
+    it 'creates all nested collections' do
+      expect(subject.collections.size).to eq 1
+      nested = subject.collections[:nested]
+      expect(nested).to be_a_kind_of(nested_collection_class)
+    end
+  end
+end

--- a/spec/unit/settings/collection_maker_spec.rb
+++ b/spec/unit/settings/collection_maker_spec.rb
@@ -38,4 +38,22 @@ describe R10K::Settings::CollectionMaker do
       expect(defn.default).to eq 'two'
     end
   end
+
+  describe '#add_collection' do
+    let(:collection_class) { double('collection_class') }
+
+    it 'stores a copy of the collection class' do
+      subject.add_collection(collection_class)
+      expect(subject.stored_collections).to eq([collection_class])
+    end
+  end
+
+  describe '#collections' do
+    let(:collection_instance) { double('collection instance') }
+    let(:collection_class) { double('collection class', :new => collection_instance) }
+    it 'creates an instance for each stored collection' do
+      subject.add_collection(collection_class)
+      expect(subject.collections).to eq([collection_instance])
+    end
+  end
 end

--- a/spec/unit/settings/collection_maker_spec.rb
+++ b/spec/unit/settings/collection_maker_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'r10k/settings/collection_maker'
+
+describe R10K::Settings::CollectionMaker do
+  describe '#add_setting' do
+    it 'stores the setting name and options' do
+      subject.add_setting(:somename, :desc => 'some setting', :default => true)
+      expect(subject.stored_definitions).to eq([[:somename, {:desc => 'some setting', :default => true}]])
+    end
+  end
+
+  describe '#definitions' do
+    it 'creates a Definition class for each stored definition' do
+      subject.add_setting(:somename, :desc => 'some setting', :default => true)
+      defn = subject.definitions.first
+
+      expect(defn.name).to eq :somename
+      expect(defn.desc).to eq 'some setting'
+      expect(defn.default).to eq true
+    end
+
+    it 'uses a custom Definition class if the :type option is given' do
+      subject.add_setting(
+        :enumsetting,
+        {
+          :desc => 'some enum setting',
+          :type => R10K::Settings::EnumDefinition,
+          :enum => %w[one two three],
+          :default => 'two',
+        }
+      )
+
+      defn = subject.definitions.first
+
+      expect(defn.name).to eq :enumsetting
+      expect(defn.desc).to eq 'some enum setting'
+      expect(defn.enum).to eq %w[one two three]
+      expect(defn.default).to eq 'two'
+    end
+  end
+end

--- a/spec/unit/settings/collection_spec.rb
+++ b/spec/unit/settings/collection_spec.rb
@@ -5,9 +5,7 @@ require 'r10k/settings/collection'
 describe R10K::Settings::Collection do
 
   let(:definition_list) do
-    [
-      R10K::Settings::Definition.new(:somedefn, :default => lambda { |defn| "default value: #{defn.name}" })
-    ]
+    [R10K::Settings::Definition.new(:somedefn, :default => lambda { |defn| "default value: #{defn.name}" })]
   end
 
   subject { described_class.new(:somecollection, definition_list) }
@@ -40,6 +38,39 @@ describe R10K::Settings::Collection do
       expect {
         subject.set(:nosetting, :nope)
       }.to raise_error(ArgumentError, "Cannot set value of nonexistent setting nosetting")
+    end
+  end
+end
+
+describe R10K::Settings::Collection, "with a nested collection" do
+
+  subject do
+    described_class.new(
+      :toplevel, [R10K::Settings::Definition.new(:toplevel_defn, :default => lambda { |defn| "default value: #{defn.name}" })],
+      [
+        described_class.new(
+          :nested,
+          [R10K::Settings::Definition.new(:nested_defn, :default => lambda { |defn| "#{defn.collection.parent.get(:toplevel_defn)} + nested" })]
+        )
+      ]
+    )
+  end
+
+  it 'links up nested collections and definitions' do
+    expect(subject.get(:nested).get(:nested_defn)).to eq "default value: toplevel_defn + nested"
+  end
+
+  describe '#get' do
+    it 'returns the collection with that name' do
+      expect(subject.get(:nested)).to eq subject.collections[:nested]
+    end
+  end
+
+  describe '#set' do
+    it 'raises an error when trying to replace a collection' do
+      expect {
+        subject.set(:nested, Object.new)
+      }.to raise_error(ArgumentError, "Cannot set value of nested collection nested; set individual values on the nested collection instead.")
     end
   end
 end

--- a/spec/unit/settings/collection_spec.rb
+++ b/spec/unit/settings/collection_spec.rb
@@ -40,6 +40,19 @@ describe R10K::Settings::Collection do
       }.to raise_error(ArgumentError, "Cannot set value of nonexistent setting nosetting")
     end
   end
+
+  describe '#assign' do
+    it "sets each setting name/value pair" do
+      subject.assign({:somedefn => "bulk assigned value"})
+      expect(subject.get(:somedefn)).to eq "bulk assigned value"
+    end
+
+    it "raises an error if an invalid setting was given" do
+      expect {
+        subject.assign({:invalid => "bulk assigned value"})
+      }.to raise_error(ArgumentError, "Cannot set value of nonexistent setting invalid")
+    end
+  end
 end
 
 describe R10K::Settings::Collection, "with a nested collection" do
@@ -71,6 +84,14 @@ describe R10K::Settings::Collection, "with a nested collection" do
       expect {
         subject.set(:nested, Object.new)
       }.to raise_error(ArgumentError, "Cannot set value of nested collection nested; set individual values on the nested collection instead.")
+    end
+  end
+
+  describe '#assign' do
+    it "recursively sets each setting name/value pair" do
+      subject.assign({:toplevel_defn => "top level value", :nested => {:nested_defn => "nested value"}})
+      expect(subject[:toplevel_defn]).to eq 'top level value'
+      expect(subject[:nested][:nested_defn]).to eq 'nested value'
     end
   end
 end

--- a/spec/unit/settings/collection_spec.rb
+++ b/spec/unit/settings/collection_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'r10k/settings/definition'
+require 'r10k/settings/collection'
+
+describe R10K::Settings::Collection do
+
+  let(:definition_list) do
+    [
+      R10K::Settings::Definition.new(:somedefn, :default => lambda { |defn| "default value: #{defn.name}" })
+    ]
+  end
+
+  subject { described_class.new(:somecollection, definition_list) }
+
+  describe '#initialize' do
+    it 'sets itself as the collection of each definition' do
+      expect(subject.definitions[:somedefn].collection).to eq subject
+    end
+  end
+
+  describe '#get' do
+    it 'returns the definition value when the definition exists' do
+      expect(subject.get(:somedefn)).to eq "default value: somedefn"
+    end
+
+    it "raises an exception when the definition doesn't exist" do
+      expect {
+        subject.get(:nosetting)
+      }.to raise_error(ArgumentError, "Cannot get value of nonexistent setting nosetting")
+    end
+  end
+
+  describe '#set' do
+    it 'sets the definition value when the definition exists' do
+      subject.set(:somedefn, :newvalue)
+      expect(subject.definitions[:somedefn].value).to eq :newvalue
+    end
+
+    it "raises an exception when the definition doesn't exist" do
+      expect {
+        subject.set(:nosetting, :nope)
+      }.to raise_error(ArgumentError, "Cannot set value of nonexistent setting nosetting")
+    end
+  end
+end

--- a/spec/unit/settings/collection_spec.rb
+++ b/spec/unit/settings/collection_spec.rb
@@ -100,3 +100,32 @@ describe R10K::Settings::Collection, "with a nested collection" do
     end
   end
 end
+
+describe R10K::Settings::Collection, "with apply hooks" do
+
+  let(:collector) { Hash.new }
+
+  subject do
+    described_class.new(
+      :toplevel, [R10K::Settings::Definition.new(:toplevel_defn, :apply => lambda { |_| collector[:toplevel_defn] = 'set'})],
+      [
+        described_class.new(
+          :nested,
+          [R10K::Settings::Definition.new(:nested_defn, :apply => lambda { |_| collector[:nested_defn] = 'also set' })]
+        )
+      ]
+    )
+  end
+
+  describe '#apply!' do
+    it "calls #apply! on all definitions" do
+      subject.apply!
+      expect(collector[:toplevel_defn]).to eq 'set'
+    end
+
+    it "calls #apply! on all nested collections" do
+      subject.apply!
+      expect(collector[:nested_defn]).to eq 'also set'
+    end
+  end
+end

--- a/spec/unit/settings/collection_spec.rb
+++ b/spec/unit/settings/collection_spec.rb
@@ -47,6 +47,11 @@ describe R10K::Settings::Collection do
       expect(subject.get(:somedefn)).to eq "bulk assigned value"
     end
 
+    it "converts string keys to symbol keys when assigning" do
+      subject.assign({'somedefn' => "string keyed value"})
+      expect(subject.get(:somedefn)).to eq "string keyed value"
+    end
+
     it "raises an error if an invalid setting was given" do
       expect {
         subject.assign({:invalid => "bulk assigned value"})

--- a/spec/unit/settings/definition_spec.rb
+++ b/spec/unit/settings/definition_spec.rb
@@ -18,6 +18,12 @@ describe R10K::Settings::Definition do
       subject = described_class.new(:setting, :validate => blk)
       expect(subject.validate).to eq blk
     end
+
+    it 'accepts the :filter option' do
+      blk = lambda { |input| "I'm a filter" }
+      subject = described_class.new(:setting, :filter => blk)
+      expect(subject.filter).to eq blk
+    end
   end
 
   describe 'with a collection' do
@@ -35,6 +41,13 @@ describe R10K::Settings::Definition do
       subject = described_class.new(:setting)
       subject.set("I'm the value")
       expect(subject.value).to eq "I'm the value"
+    end
+
+    it 'calls the filter hook and stores the filtered value when given' do
+      filter = lambda { |input| input.upcase }
+      subject = described_class.new(:setting, :filter => filter)
+      subject.set('loud noises')
+      expect(subject.get).to eq 'LOUD NOISES'
     end
 
     it 'calls the validate hook when given' do

--- a/spec/unit/settings/definition_spec.rb
+++ b/spec/unit/settings/definition_spec.rb
@@ -20,6 +20,16 @@ describe R10K::Settings::Definition do
     end
   end
 
+  describe 'with a collection' do
+    subject = described_class.new(:setting)
+
+    it "can store and retrieve a collection for this definition" do
+      collection = Object.new
+      subject.collection = collection
+      expect(subject.collection).to eq collection
+    end
+  end
+
   describe "#set" do
     it 'stores the provided value' do
       subject = described_class.new(:setting)

--- a/spec/unit/settings/definition_spec.rb
+++ b/spec/unit/settings/definition_spec.rb
@@ -24,6 +24,12 @@ describe R10K::Settings::Definition do
       subject = described_class.new(:setting, :filter => blk)
       expect(subject.filter).to eq blk
     end
+
+    it 'accepts the :apply option' do
+      blk = lambda { |_| "I'm the apply hook" }
+      subject = described_class.new(:setting, :apply => blk)
+      expect(subject.apply).to eq blk
+    end
   end
 
   describe 'with a collection' do
@@ -74,6 +80,21 @@ describe R10K::Settings::Definition do
     it 'returns the result of the default when the default is a proc' do
       subject = described_class.new(:setting, :default => lambda { |defn| "I'm the result of the default lambda for the #{defn.name} definition" })
       expect(subject.get).to eq "I'm the result of the default lambda for the setting definition"
+    end
+  end
+
+  describe '#apply!' do
+    it "calls the apply hook if an apply hook was given" do
+      state = nil
+      blk = lambda { |defn| state = "I'm the apply hook" }
+      subject = described_class.new(:setting, :apply => blk)
+      subject.apply!
+      expect(state).to eq "I'm the apply hook"
+    end
+
+    it "is a noop if no apply hook was given" do
+      subject = described_class.new(:setting)
+      subject.apply!
     end
   end
 end

--- a/spec/unit/settings/definition_spec.rb
+++ b/spec/unit/settings/definition_spec.rb
@@ -49,8 +49,8 @@ describe R10K::Settings::Definition do
     end
 
     it 'returns the result of the default when the default is a proc' do
-      subject = described_class.new(:setting, :default => lambda { "I'm the result of the default lambda" })
-      expect(subject.get).to eq "I'm the result of the default lambda"
+      subject = described_class.new(:setting, :default => lambda { |defn| "I'm the result of the default lambda for the #{defn.name} definition" })
+      expect(subject.get).to eq "I'm the result of the default lambda for the setting definition"
     end
   end
 end

--- a/spec/unit/settings/definition_spec.rb
+++ b/spec/unit/settings/definition_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'r10k/settings/definition'
+
+describe R10K::Settings::Definition do
+  describe "#initialize" do
+    it 'accepts the :desc option' do
+      subject = described_class.new(:setting, :desc => "I'm a description")
+      expect(subject.desc).to eq "I'm a description"
+    end
+
+    it 'accepts the :default option' do
+      subject = described_class.new(:setting, :default => "I'm a default")
+      expect(subject.default).to eq "I'm a default"
+    end
+
+    it 'accepts the :validate option' do
+      blk = lambda { "I'm a lambda" }
+      subject = described_class.new(:setting, :validate => blk)
+      expect(subject.validate).to eq blk
+    end
+  end
+
+  describe "#set" do
+    it 'stores the provided value' do
+      subject = described_class.new(:setting)
+      subject.set("I'm the value")
+      expect(subject.value).to eq "I'm the value"
+    end
+
+    it 'calls the validate hook when given' do
+      subject = described_class.new(:setting, :validate => lambda { |_| raise ArgumentError, "Validation failed" })
+      expect {
+        subject.set("I'm the value")
+      }.to raise_error(ArgumentError, "Validation failed")
+    end
+  end
+
+  describe "#get" do
+    it 'returns the value when set' do
+      subject = described_class.new(:setting)
+      subject.set("I'm the value")
+      expect(subject.get).to eq "I'm the value"
+    end
+
+    it 'returns the default when the default is not a proc' do
+      default = Object.new
+      subject = described_class.new(:setting, :default => default)
+      expect(subject.get).to eq default
+    end
+
+    it 'returns the result of the default when the default is a proc' do
+      subject = described_class.new(:setting, :default => lambda { "I'm the result of the default lambda" })
+      expect(subject.get).to eq "I'm the result of the default lambda"
+    end
+  end
+end

--- a/spec/unit/settings/enum_definition_spec.rb
+++ b/spec/unit/settings/enum_definition_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'r10k/settings/enum_definition'
+
+describe R10K::Settings::EnumDefinition do
+  describe '#initialize' do
+    it 'accepts the :enum option' do
+      subject = described_class.new(:setting, :enum => ['one', 'two'])
+      expect(subject.enum).to eq ['one', 'two']
+    end
+  end
+
+  describe '#set' do
+    subject { described_class.new(:setting, :enum => ['one', 'two']) }
+    it 'raises an error if the new value is not in the enum' do
+      expect {
+        subject.set('three')
+      }.to raise_error(ArgumentError, "Definition setting expects one of #{['one', 'two'].inspect}, got \"three\"")
+    end
+
+    it "doesn't raise an error if the new value is in the enum" do
+      subject.set('two')
+      expect(subject.value).to eq 'two'
+    end
+  end
+end

--- a/spec/unit/settings/path_definition_spec.rb
+++ b/spec/unit/settings/path_definition_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'r10k/settings/path_definition'
+
+describe R10K::Settings::PathDefinition do
+
+  describe '#initialize' do
+    [:readable, :writable].each do |setting|
+      it "accepts the #{setting} option" do
+        subject = described_class.new(:setting, setting => true)
+        expect(subject.send(setting)).to eq true
+      end
+    end
+  end
+
+  describe '#set' do
+    [:readable, :writable].each do |setting|
+      it "raises an error when #{setting} is true and the path is not readable" do
+        subject = described_class.new(:setting, setting => true)
+        expect(File).to receive("#{setting}?".to_sym).with('/some/path').and_return false
+        expect {
+          subject.set('/some/path')
+        }.to raise_error(ArgumentError, "/some/path is not #{setting}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a more comprehensive mechanism for configuring application state; the original attempt with the `R10K::Settings::Container` class fell short and didn't solve any problems that it set out to solve. This pull request adds individual settings definitions classes, a collection class to hold groups of settings, and glue code to make  it easy to define settings classes.
