### PR TITLE
[CODEMGMT-27] Unpack/untar in r10k as library

### DIFF
--- a/lib/shared/puppet_forge/error.rb
+++ b/lib/shared/puppet_forge/error.rb
@@ -1,0 +1,30 @@
+module PuppetForge
+  class Error < RuntimeError
+    attr_accessor :original
+    def initialize(message, original=nil)
+      super(message)
+      @original = original
+    end
+  end
+
+  class ExecutionFailure < PuppetForge::Error
+  end
+
+  class InvalidPathInPackageError < PuppetForge::Error
+    def initialize(options)
+      @entry_path = options[:entry_path]
+      @directory  = options[:directory]
+      super "Attempt to install file into #{@entry_path.inspect} under #{@directory.inspect}"
+    end
+
+    def multiline
+      <<-MSG.strip
+Could not install package
+  Package attempted to install file into
+  #{@entry_path.inspect} under #{@directory.inspect}.
+      MSG
+    end
+  end
+
+end
+

--- a/lib/shared/puppet_forge/tar.rb
+++ b/lib/shared/puppet_forge/tar.rb
@@ -1,0 +1,10 @@
+
+module PuppetForge
+  class Tar
+    require 'shared/puppet_forge/tar/mini'
+
+    def self.instance
+      Mini.new
+    end
+  end
+end

--- a/lib/shared/puppet_forge/tar/mini.rb
+++ b/lib/shared/puppet_forge/tar/mini.rb
@@ -1,0 +1,75 @@
+require 'zlib'
+require 'archive/tar/minitar'
+
+module PuppetForge
+  class Tar
+    class Mini
+
+      SYMLINK_FLAG = 2
+      VALID_TAR_FLAGS = (0..7)
+
+      def unpack(sourcefile, destdir)
+        dirlist = []
+        Zlib::GzipReader.open(sourcefile) do |reader|
+          Archive::Tar::Minitar.unpack(reader, destdir, find_valid_files(reader)) do |action, name, stats|
+            case action
+            when :file_done
+              FileUtils.chmod('u+rw,g+r,a-st', "#{destdir}/#{name}")
+            when :file_start
+              validate_entry(destdir, name)
+            when :dir
+              validate_entry(destdir, name)
+              dirlist << "#{destdir}/#{name}"
+            end
+          end
+        end
+        dirlist.each {|d| File.chmod(0755, d)}
+      end
+
+      def pack(sourcedir, destfile)
+        Zlib::GzipWriter.open(destfile) do |writer|
+          Archive::Tar::Minitar.pack(sourcedir, writer)
+        end
+      end
+
+      private
+
+      # Find all the valid files in tarfile.
+      #
+      # Symlinks are not supported in modules
+      #
+      # This check was mainly added to ignore 'x' and 'g' flags from the PAX
+      # standard but will also ignore any other non-standard tar flags.
+      # tar format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Ftaf.htm
+      # pax format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Fpxarchfm.htm
+      def find_valid_files(tarfile)
+        Archive::Tar::Minitar.open(tarfile).collect do |entry|
+          flag = entry.typeflag
+          # Symlinks are not supported in modules and a warning is issued (flag '2' is a symlink)
+          if flag.nil? || flag =~ /[[:digit:]]/ && SYMLINK_FLAG == flag.to_i
+            # TODO: Error/Warn about symlinks here.
+            entry.name
+          elsif flag.nil? || flag =~ /[[:digit:]]/ && VALID_TAR_FLAGS.include?(flag.to_i)
+            entry.name
+          else
+            next
+          end
+        end
+      end
+
+      def validate_entry(destdir, path)
+        if Pathname.new(path).absolute?
+          raise PuppetForge::InvalidPathInPackageError, :entry_path => path, :directory => destdir
+        end
+
+        path = File.expand_path File.join(destdir, path)
+
+        if path !~ /\A#{Regexp.escape destdir}/
+          raise PuppetForge::InvalidPathInPackageError, :entry_path => path, :directory => destdir
+        end
+      end
+    end
+  end
+
+end
+

--- a/lib/shared/puppet_forge/unpacker.rb
+++ b/lib/shared/puppet_forge/unpacker.rb
@@ -1,0 +1,65 @@
+require 'pathname'
+require 'shared/puppet_forge/error'
+require 'shared/puppet_forge/tar'
+
+module PuppetForge
+  class Unpacker
+    # Unpack a tar file into a specified directory
+    #
+    # @param filename [String] the file to unpack
+    # @param target [String] the target directory to unpack into
+    def self.unpack(filename, target, tmpdir)
+      inst = self.new(filename, target, tmpdir)
+      inst.unpack
+      inst.move_into(Pathname.new(target))
+    end
+
+    # Set the owner/group of the target directory to those of the source
+    # Note: don't call this function on Microsoft Windows
+    #
+    # @param source [Pathname] source of the permissions
+    # @param target [Pathname] target of the permissions change
+    def self.harmonize_ownership(source, target)
+        FileUtils.chown_R(source.stat.uid, source.stat.gid, target)
+    end
+
+    # @param filename [String] the file to unpack
+    # @param target [String] the target directory to unpack into
+    def initialize(filename, target, tmpdir)
+      @filename = filename
+      @target = target
+      @tmpdir = tmpdir
+    end
+
+    # @api private
+    def unpack
+      begin
+        PuppetForge::Tar.instance.unpack(@filename, @tmpdir)
+      rescue PuppetForge::ExecutionFailure => e
+        raise RuntimeError, "Could not extract contents of module archive: #{e.message}"
+      end
+    end
+
+    # @api private
+    def move_into(dir)
+      dir.rmtree if dir.exist?
+      FileUtils.mv(root_dir, dir)
+    ensure
+      FileUtils.rmtree(@tmpdir)
+    end
+
+    # @api private
+    def root_dir
+      return @root_dir if @root_dir
+
+      # Grab the first directory containing a metadata.json file
+      metadata_file = Dir["#{@tmpdir}/**/metadata.json"].sort_by(&:length)[0]
+
+      if metadata_file
+        @root_dir = Pathname.new(metadata_file).dirname
+      else
+        raise "No valid metadata.json found!"
+      end
+    end
+  end
+end

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -29,7 +29,7 @@ describe R10K::Forge::ModuleRelease do
   end
 
   describe '#unpack' do
-    it "unpacks the module tarball in `download_path` into `unpack_pack`", :pending => "Module unpack code" do
+    it "unpacks the module tarball in `download_path` into `unpack_path`" do
       expect(PuppetForge::Unpacker).to receive(:unpack).with(download_path, unpack_path)
       subject.unpack
     end

--- a/spec/unit/puppet_forge/tar/mini_spec.rb
+++ b/spec/unit/puppet_forge/tar/mini_spec.rb
@@ -1,0 +1,61 @@
+require 'shared/puppet_forge/tar/mini'
+require 'shared/puppet_forge/error'
+
+
+describe PuppetForge::Tar::Mini do
+  let(:sourcefile) { '/the/module.tar.gz' }
+  let(:destdir)    { File.expand_path '/the/dest/dir' }
+  let(:sourcedir)  { '/the/src/dir' }
+  let(:destfile)   { '/the/dest/file.tar.gz' }
+  let(:minitar)    { described_class.new }
+
+  it "unpacks a tar file" do
+    unpacks_the_entry(:file_start, 'thefile')
+
+    minitar.unpack(sourcefile, destdir)
+  end
+
+  it "does not allow an absolute path" do
+    unpacks_the_entry(:file_start, '/thefile')
+
+    expect {
+      minitar.unpack(sourcefile, destdir)
+    }.to raise_error(PuppetForge::InvalidPathInPackageError,
+                     "Attempt to install file into \"/thefile\" under \"#{destdir}\"")
+  end
+
+  it "does not allow a file to be written outside the destination directory" do
+    unpacks_the_entry(:file_start, '../../thefile')
+
+    expect {
+      minitar.unpack(sourcefile, destdir)
+    }.to raise_error(PuppetForge::InvalidPathInPackageError,
+                     "Attempt to install file into \"#{File.expand_path('/the/thefile')}\" under \"#{destdir}\"")
+  end
+
+  it "does not allow a directory to be written outside the destination directory" do
+    unpacks_the_entry(:dir, '../../thedir')
+
+    expect {
+      minitar.unpack(sourcefile, destdir)
+    }.to raise_error(PuppetForge::InvalidPathInPackageError,
+                     "Attempt to install file into \"#{File.expand_path('/the/thedir')}\" under \"#{destdir}\"")
+  end
+
+  it "packs a tar file" do
+    writer = double('GzipWriter')
+
+    expect(Zlib::GzipWriter).to receive(:open).with(destfile).and_yield(writer)
+    expect(Archive::Tar::Minitar).to receive(:pack).with(sourcedir, writer)
+
+    minitar.pack(sourcedir, destfile)
+  end
+
+  def unpacks_the_entry(type, name)
+    reader = double('GzipReader')
+
+    expect(Zlib::GzipReader).to receive(:open).with(sourcefile).and_yield(reader)
+    expect(minitar).to receive(:find_valid_files).with(reader).and_return([name])
+    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, [name]).and_yield(type, name, nil)
+  end
+end

--- a/spec/unit/puppet_forge/tar_spec.rb
+++ b/spec/unit/puppet_forge/tar_spec.rb
@@ -1,0 +1,9 @@
+require 'shared/puppet_forge/tar'
+
+describe PuppetForge::Tar do
+
+  it "returns an instance of minitar" do
+    expect(described_class.instance).to be_a_kind_of PuppetForge::Tar::Mini
+  end
+
+end

--- a/spec/unit/puppet_forge/unpacker_spec.rb
+++ b/spec/unit/puppet_forge/unpacker_spec.rb
@@ -1,0 +1,41 @@
+require 'json'
+require 'tmpdir'
+require 'shared/puppet_forge/unpacker'
+
+describe PuppetForge::Unpacker do
+
+  let(:source)      { Dir.mktmpdir("source") }
+  let(:target)      { Dir.mktmpdir("unpacker") }
+  let(:module_name) { 'myusername-mytarball' }
+  let(:filename)    { Dir.mktmpdir("module") + "/module.tar.gz" }
+  let(:working_dir) { Dir.mktmpdir("working_dir") }
+  let(:trash_dir)   { Dir.mktmpdir("trash_dir") }
+
+  it "attempts to untar file to temporary location" do
+
+    minitar = double('PuppetForge::Tar::Mini')
+
+    expect(minitar).to receive(:unpack).with(filename, anything()) do |src, dest|
+      FileUtils.mkdir(File.join(dest, 'extractedmodule'))
+      File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
+        file.puts JSON.generate('name' => module_name, 'version' => '1.0.0')
+      end
+      true
+    end
+
+    expect(PuppetForge::Tar).to receive(:instance).and_return(minitar)
+    PuppetForge::Unpacker.unpack(filename, target, trash_dir)
+    expect(File).to be_directory(target)
+  end
+
+  it "attempts to set the ownership of a target dir to a source dir's owner" do
+
+    source_path = Pathname.new(source)
+    target_path = Pathname.new(target)
+
+    expect(FileUtils).to receive(:chown_R).with(source_path.stat.uid, source_path.stat.gid, target_path)
+
+    PuppetForge::Unpacker.harmonize_ownership(source_path, target_path)
+  end
+
+end


### PR DESCRIPTION
This commit adds the library code which can unpack/untar module
tarballs. This unpacking code is not completely generic in that at a low
level it warns about symlinks in tarballs.
