### PR TITLE
Add --parallel option to `r10k puppetfile install`

### DIFF
--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -21,12 +21,13 @@ module R10K
             :moduledir  => :self,
             :puppetfile => :path,
             :trace      => :self,
+            :parallel   => :self
           })
         end
 
         def call
           pf = R10K::Puppetfile.new(@root, @moduledir, @path)
-          pf.accept(self)
+          pf.accept(self, @parallel.to_i)
           @ok
         end
 

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -31,6 +31,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage   'install'
           summary 'Install all modules from a Puppetfile'
 
+          required :p, :parallel, 'Number of module installations to conduct in parallel', argument: :required
+
           # @todo add --moduledir option
           # @todo add --puppetfile option
           # @todo add --no-purge option

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -2,6 +2,7 @@ require 'pathname'
 require 'r10k/module'
 require 'r10k/util/purgeable'
 require 'r10k/errors'
+require 'pmap'
 
 module R10K
 class Puppetfile
@@ -88,10 +89,16 @@ class Puppetfile
     @modules.map { |mod| mod.name }
   end
 
-  def accept(visitor)
+  def accept(visitor, parallel=1)
     visitor.visit(:puppetfile, self) do
-      modules.each do |mod|
-        mod.accept(visitor)
+      if parallel > 1
+        modules.peach(parallel) do |mod|
+          mod.accept(visitor)
+        end
+      else
+        modules.each do |mod|
+          mod.accept(visitor)
+        end
       end
     end
   end

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'colored',   '1.2'
   s.add_dependency 'cri',       '~> 2.6.1'
+  s.add_dependency 'pmap',     '~> 1.0.2'
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
This is a quick proof-of-concept for fixing #54 - it adds a `-p`/`--parallel` option, which is the number of modules from the Puppetfile to process in parallel.

The underlying implementation is the `pmap` convenience library (https://rubygems.org/gems/pmap), but could just as easily be something else (or an r10k-specific implementation).

Remaining work includes:
- Tests for the CLI interface additions?
- A default value for the CLI option itself? (rather than via a default parameter on `R10K::Puppetfile.accept`)
## Performance

The Puppetfile I'm most often using has somewhere around 100 modules listed. The install operation is completely IO bound, and doing it all serially takes almost four minutes(!)

``` sh
$ time bundle exec r10k puppetfile install

real  3m43.955s
user  0m4.142s
sys   0m4.789s
```

With a modest amount of parallelism, we get a **20 times faster** operation (11 seconds).

``` sh
$ time bundle exec r10k puppetfile install -p 32

real  0m11.055s
user  0m4.265s
sys   0m5.395s
```

I understand if we want to delay this fix until we cover things like the `deploy` subcommand. But #54 has been open for a couple of years now. And I'd describe this performance improvement as necessary, not a nice-to-have, however we implement it.
