### PR TITLE
[module/forge] (RK-83) Allow '-' as a module name separator

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -14,7 +14,7 @@ class R10K::Module::Forge < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    !!(name.match %r[\w+/\w+])
+    !!(name.match %r[\w+[/-]\w+])
   end
 
   # @!attribute [r] metadata

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -15,15 +15,11 @@ describe R10K::Module::Forge do
     end
 
     it "should implement 'branan-eight_hundred', '8.0.0'" do
-      expect(described_class).to be_implement('branan/eight_hundred', '8.0.0')
+      expect(described_class).to be_implement('branan-eight_hundred', '8.0.0')
     end
 
     it "should fail with an invalid title" do
       expect(described_class).to_not be_implement('branan!eight_hundred', '8.0.0')
-    end
-
-    it "should fail with an invalid version" do
-      expect(described_class).to_not be_implement('branan-eight_hundred', 'not a semantic version')
     end
   end
 

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -9,21 +9,21 @@ describe R10K::Module do
     end
   end
 
-  describe 'delegating to R10K::Module::Git' do
-    it "accepts name matching 'username/modulename' and no args" do
-      obj = R10K::Module.new('bar/quux', '/modulepath', [])
-      expect(obj).to be_a_kind_of(R10K::Module::Forge)
-    end
-
-    it "accepts name matching 'username/modulename' and a semver argument" do
-      obj = R10K::Module.new('bar/quux', '/modulepath', '10.0.0')
-      expect(obj).to be_a_kind_of(R10K::Module::Forge)
+  describe 'delegating to R10K::Module::Forge' do
+    [
+      ['bar/quux', []],
+      ['bar-quux', []],
+      ['bar/quux', ['8.0.0']],
+    ].each do |scenario|
+      it "accepts a name matching #{scenario[0]} and args #{scenario[1].inspect}" do
+        expect(R10K::Module.new(scenario[0], '/modulepath', scenario[1])).to be_a_kind_of(R10K::Module::Forge)
+      end
     end
   end
 
   it "raises an error if delegation fails" do
     expect {
-      R10K::Module.new('bar-quux', '/modulepath', ["NOPE NOPE NOPE NOPE!"])
+      R10K::Module.new('bar!quux', '/modulepath', ["NOPE NOPE NOPE NOPE!"])
     }.to raise_error RuntimeError, /doesn't have an implementation/
   end
 end


### PR DESCRIPTION
Hyphens and forward slashes are used mostly interchangeably as the
module name separator, but the existing name matching code only allowed
forward slashes. Right now the hyphen is the preferred character, which
meant that users couldn't use the preferred pattern for Forge modules.
This commit adds hyphens as a valid separator character to remedy this.
