### PR TITLE
(CODEMGMT-187) Report file status back from unpacking

### DIFF
--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -89,7 +89,17 @@ module R10K
       # @return [void]
       def unpack(target_dir)
         logger.debug1 "Unpacking #{download_path} to #{target_dir} (with tmpdir #{unpack_path})"
-        PuppetForge::Unpacker.unpack(download_path.to_s, target_dir.to_s, unpack_path.to_s)
+        file_lists = PuppetForge::Unpacker.unpack(download_path.to_s, target_dir.to_s, unpack_path.to_s)
+        logger.debug2 "Valid files unpacked: #{file_lists[:valid]}"
+        if !file_lists[:symlinks].empty?
+          logger.warn "Symlinks in modules are unsupported. These files were created as copies of the original " + 
+                      "files, but are no longer symlinks: #{file_lists[:symlinks]}"
+        end
+        if !file_lists[:invalid].empty?
+          logger.warn "These files existed in the module's tar file, but are invalid filetypes and were not " +
+                      "unpacked: #{file_lists[:invalid]}"
+        end
+
       end
 
       # Remove all files created while downloading and unpacking the module.

--- a/lib/shared/puppet_forge/error.rb
+++ b/lib/shared/puppet_forge/error.rb
@@ -25,6 +25,4 @@ Could not install package
       MSG
     end
   end
-
 end
-

--- a/lib/shared/puppet_forge/tar/mini.rb
+++ b/lib/shared/puppet_forge/tar/mini.rb
@@ -5,13 +5,17 @@ module PuppetForge
   class Tar
     class Mini
 
-      SYMLINK_FLAG = 2
+      SYMLINK_FLAGS = [2]
       VALID_TAR_FLAGS = (0..7)
 
+      # @return [Hash{:symbol => Array<String>}] a hash with file-category keys pointing to lists of filenames.
       def unpack(sourcefile, destdir)
+        # directories need to be changed outside of the Minitar::unpack because directories don't have a :file_done action
         dirlist = []
+        file_lists = {}
         Zlib::GzipReader.open(sourcefile) do |reader|
-          Archive::Tar::Minitar.unpack(reader, destdir, find_valid_files(reader)) do |action, name, stats|
+          file_lists = validate_files(reader)
+          Archive::Tar::Minitar.unpack(reader, destdir, file_lists[:valid]) do |action, name, stats|
             case action
             when :file_done
               FileUtils.chmod('u+rw,g+r,a-st', "#{destdir}/#{name}")
@@ -24,6 +28,7 @@ module PuppetForge
           end
         end
         dirlist.each {|d| File.chmod(0755, d)}
+        file_lists
       end
 
       def pack(sourcedir, destfile)
@@ -34,27 +39,28 @@ module PuppetForge
 
       private
 
-      # Find all the valid files in tarfile.
+      # Categorize all the files in tarfile as :valid, :invalid, or :symlink.
       #
-      # Symlinks are not supported in modules
-      #
-      # This check was mainly added to ignore 'x' and 'g' flags from the PAX
-      # standard but will also ignore any other non-standard tar flags.
-      # tar format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Ftaf.htm
-      # pax format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Fpxarchfm.htm
-      def find_valid_files(tarfile)
-        Archive::Tar::Minitar.open(tarfile).collect do |entry|
+      # :invalid files include 'x' and 'g' flags from the PAX standard but and any other non-standard tar flags.
+      #   tar format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Ftaf.htm
+      #   pax format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Fpxarchfm.htm
+      # :symlinks are not supported in Puppet modules
+      # :valid files are any of those that can be used in modules
+      # @param tarfile name of the tarfile
+      # @return [Hash{:symbol => Array<String>}] a hash with file-category keys pointing to lists of filenames.
+      def validate_files(tarfile)
+        file_lists = {:valid => [], :invalid => [], :symlinks => []}
+        Archive::Tar::Minitar.open(tarfile).each do |entry|
           flag = entry.typeflag
-          # Symlinks are not supported in modules and a warning is issued (flag '2' is a symlink)
-          if flag.nil? || flag =~ /[[:digit:]]/ && SYMLINK_FLAG == flag.to_i
-            # TODO: Error/Warn about symlinks here.
-            entry.name
+          if flag.nil? || flag =~ /[[:digit:]]/ && SYMLINK_FLAGS.include?(flag.to_i)
+            file_lists[:symlinks] << entry.name
           elsif flag.nil? || flag =~ /[[:digit:]]/ && VALID_TAR_FLAGS.include?(flag.to_i)
-            entry.name
+            file_lists[:valid] << entry.name
           else
-            next
+            file_lists[:invalid] << entry.name 
           end
         end
+        file_lists
       end
 
       def validate_entry(destdir, path)

--- a/lib/shared/puppet_forge/unpacker.rb
+++ b/lib/shared/puppet_forge/unpacker.rb
@@ -8,10 +8,13 @@ module PuppetForge
     #
     # @param filename [String] the file to unpack
     # @param target [String] the target directory to unpack into
+    # @return [Hash{:symbol => Array<String>}] a hash with file-category keys pointing to lists of filenames.
+    #   The categories are :valid, :invalid and :symlink
     def self.unpack(filename, target, tmpdir)
       inst = self.new(filename, target, tmpdir)
-      inst.unpack
+      file_lists = inst.unpack
       inst.move_into(Pathname.new(target))
+      file_lists
     end
 
     # Set the owner/group of the target directory to those of the source

--- a/spec/unit/puppet_forge/tar/mini_spec.rb
+++ b/spec/unit/puppet_forge/tar/mini_spec.rb
@@ -3,11 +3,23 @@ require 'shared/puppet_forge/error'
 
 
 describe PuppetForge::Tar::Mini do
+  let(:entry_class) do
+    Class.new do
+      attr_accessor :typeflag, :name
+      def initialize(name, typeflag)
+        @name = name
+        @typeflag = typeflag
+      end
+    end
+  end
   let(:sourcefile) { '/the/module.tar.gz' }
   let(:destdir)    { File.expand_path '/the/dest/dir' }
   let(:sourcedir)  { '/the/src/dir' }
   let(:destfile)   { '/the/dest/file.tar.gz' }
   let(:minitar)    { described_class.new }
+  let(:tarfile_contents) { [entry_class.new('file', '0'), \
+                            entry_class.new('symlink', '2'), \
+                            entry_class.new('invalid', 'F')] }
 
   it "unpacks a tar file" do
     unpacks_the_entry(:file_start, 'thefile')
@@ -51,11 +63,25 @@ describe PuppetForge::Tar::Mini do
     minitar.pack(sourcedir, destfile)
   end
 
+  it "returns filenames in a tar separated into correct categories" do
+    reader = double('GzipReader')
+
+    expect(Zlib::GzipReader).to receive(:open).with(sourcefile).and_yield(reader)
+    expect(Archive::Tar::Minitar).to receive(:open).with(reader).and_return(tarfile_contents)
+    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, ['file']).and_yield(:file_start, 'thefile', nil)
+    
+    file_lists = minitar.unpack(sourcefile, destdir)
+
+    expect(file_lists[:valid]).to eq(['file'])
+    expect(file_lists[:invalid]).to eq(['invalid'])
+    expect(file_lists[:symlinks]).to eq(['symlink'])
+  end
+
   def unpacks_the_entry(type, name)
     reader = double('GzipReader')
 
     expect(Zlib::GzipReader).to receive(:open).with(sourcefile).and_yield(reader)
-    expect(minitar).to receive(:find_valid_files).with(reader).and_return([name])
+    expect(minitar).to receive(:validate_files).with(reader).and_return({:valid => [name]})
     expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, [name]).and_yield(type, name, nil)
   end
 end


### PR DESCRIPTION
Before this pull request, there were no errors raised and no logging possible from unpacking a module. This commit adds a hash of file lists which is returned from the unpacker giving the lists of vaild, invalid, and symlink files.
