### PR TITLE
(RK-103) Add proper handling of symlink unpack

### DIFF
--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -91,15 +91,14 @@ module R10K
         logger.debug1 "Unpacking #{download_path} to #{target_dir} (with tmpdir #{unpack_path})"
         file_lists = PuppetForge::Unpacker.unpack(download_path.to_s, target_dir.to_s, unpack_path.to_s)
         logger.debug2 "Valid files unpacked: #{file_lists[:valid]}"
-        if !file_lists[:symlinks].empty?
-          logger.warn "Symlinks in modules are unsupported. These files were created as copies of the original " + 
-                      "files, but are no longer symlinks: #{file_lists[:symlinks]}"
-        end
         if !file_lists[:invalid].empty?
           logger.warn "These files existed in the module's tar file, but are invalid filetypes and were not " +
                       "unpacked: #{file_lists[:invalid]}"
         end
-
+        if !file_lists[:symlinks].empty?
+          raise R10K::Error, "Symlinks are unsupported and were not unpacked from the module tarball. " + 
+                             "#{@forge_release.slug} contained these ignored symlinks: #{file_lists[:symlinks]}"
+        end
       end
 
       # Remove all files created while downloading and unpacking the module.

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -35,19 +35,18 @@ describe R10K::Forge::ModuleRelease do
       subject.unpack(target_dir)
     end
     
-    it "warns of symlinks during the unpacking process" do
+    it "raises an error if symlinks are present during the unpacking process after unpacking" do
       logger_dbl = double(Log4r::Logger)
       allow(subject).to receive(:logger).and_return(logger_dbl)
       expect(PuppetForge::Unpacker).to receive(:unpack).with(download_path.to_s, target_dir.to_s, unpack_path.to_s).\
           and_return(file_lists)
       expect(logger_dbl).to receive(:debug1)
       expect(logger_dbl).to receive(:debug2)
-      expect(logger_dbl).to receive(:warn).with("Symlinks in modules are unsupported. These files were created as "\
-                                                "copies of the original files, but are no longer symlinks: "\
-                                                "#{file_lists[:symlinks]}")
-      file_lists = subject.unpack(target_dir)
+      expect {
+        subject.unpack(target_dir)
+      }.to raise_error(R10K::Error, "Symlinks are unsupported and were not unpacked from the module tarball. " + 
+                                    "#{subject.forge_release.slug} contained these ignored symlinks: #{file_lists[:symlinks]}")
     end
-    
   end
 
   describe "#cleanup" do


### PR DESCRIPTION
Before this commit, an incorrect warning was issued for unpacking
symlinks from module tarballs. With this commit, an accurate error
message is issued and a non-zero exit code for r10k.
