### PR TITLE
(RK-108) Add configuration option for forge proxy

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -68,6 +68,25 @@ git:
 See the [git provider documentation](../git/providers.mkd) for more information
 regarding Git providers.
 
+### forge
+
+The 'forge' setting is a hash that contains settings for downloading modules
+from the Puppet Forge.
+
+#### proxy
+
+The proxy option sets an optional HTTP proxy to use when downloading modules
+from the Forge.
+
+```yaml
+forge:
+  proxy: 'http://my-site.proxy:3128'
+```
+
+If no proxy is given, r10k will check the environment variables 'HTTPS_PROXY',
+'https_proxy', 'HTTP_PROXY', and 'http_proxy' in that order for a proxy URL.
+
+
 Deployment options
 ------------------
 

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -71,6 +71,14 @@ class Config
       R10K::Git::Cache.settings[:cache_root] = cachedir
     end
 
+    with_setting(:forge) do |forge_settings|
+      R10K::Util::SymbolizeKeys.symbolize_keys!(forge_settings)
+      proxy = forge_settings[:proxy]
+      if proxy
+        R10K::Forge::ModuleRelease.settings[:proxy] = proxy
+      end
+    end
+
     with_setting(:git) do |git_settings|
       R10K::Util::SymbolizeKeys.symbolize_keys!(git_settings)
       provider = git_settings[:provider]

--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -1,6 +1,7 @@
 require 'shared/puppet_forge/v3/module_release'
 require 'shared/puppet_forge/unpacker'
 require 'r10k/logging'
+require 'r10k/settings/mixin'
 require 'fileutils'
 require 'forwardable'
 require 'tmpdir'
@@ -9,6 +10,10 @@ module R10K
   module Forge
     # Download, unpack, and install modules from the Puppet Forge
     class ModuleRelease
+
+      include R10K::Settings::Mixin
+
+      def_setting_attr :proxy
 
       include R10K::Logging
 
@@ -125,6 +130,7 @@ module R10K
 
       def proxy
         [
+          settings[:proxy],
           ENV['HTTPS_PROXY'],
           ENV['https_proxy'],
           ENV['HTTP_PROXY'],

--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -38,7 +38,7 @@ module R10K
         @version   = version
 
         @forge_release = PuppetForge::V3::ModuleRelease.new(@full_name, @version)
-
+        @forge_release.conn.proxy(proxy)
 
         @download_path = Pathname.new(Dir.mktmpdir) + (slug + '.tar.gz')
         @unpack_path   = Pathname.new(Dir.mktmpdir) + slug
@@ -119,6 +119,17 @@ module R10K
         if download_path.exist?
           download_path.delete
         end
+      end
+
+      private
+
+      def proxy
+        [
+          ENV['HTTPS_PROXY'],
+          ENV['https_proxy'],
+          ENV['HTTP_PROXY'],
+          ENV['http_proxy']
+        ].find { |value| value }
       end
     end
   end

--- a/r10k.yaml.example
+++ b/r10k.yaml.example
@@ -84,3 +84,9 @@ git:
   #
   # The 'username' setting is only used by the 'rugged' Git provider.
   #username: 'git'
+
+# Configuration options for downloading modules from the Puppet Forge
+forge:
+  # The 'proxy' setting specifies an optional HTTP proxy to use when making
+  # requests to the Puppet Forge.
+  proxy: 'http://my.site.proxy:3128'

--- a/spec/unit/deployment/config_spec.rb
+++ b/spec/unit/deployment/config_spec.rb
@@ -26,6 +26,14 @@ describe R10K::Deployment::Config do
       end
     end
 
+    describe "for the forge" do
+      it "sets the proxy when given" do
+        expect(YAML).to receive(:load_file).with('foo/bar').and_return('forge' => {'proxy' => 'https://proxy.url'})
+        expect(R10K::Forge::ModuleRelease.settings).to receive(:[]=).with(:proxy, 'https://proxy.url')
+        described_class.new('foo/bar')
+      end
+    end
+
     describe "for git" do
       it "sets the git provider when given" do
         expect(YAML).to receive(:load_file).with('foo/bar').and_return('git' => {'provider' => 'rugged'})

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -25,6 +25,26 @@ describe R10K::Forge::ModuleRelease do
         end
       end
     end
+
+    describe 'using application settings' do
+      before { described_class.settings[:proxy] = 'http://proxy.setting' }
+      after { described_class.settings.reset! }
+
+      it 'has a setting for the forge proxy' do
+        subject = described_class.new('branan-eight_hundred', '8.0.0')
+        proxy_uri = subject.forge_release.conn.proxy.uri
+        expect(proxy_uri.to_s).to eq "http://proxy.setting"
+      end
+
+      it 'prefers the proxy setting over an environment variable' do
+        R10K::Util::ExecEnv.withenv('HTTPS_PROXY' => "http://proxy.from.env") do
+          subject = described_class.new('branan-eight_hundred', '8.0.0')
+          proxy_uri = subject.forge_release.conn.proxy.uri
+          expect(proxy_uri.to_s).to eq "http://proxy.setting"
+        end
+      end
+    end
+
   end
 
   describe '#download' do

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -34,7 +34,7 @@ describe R10K::Forge::ModuleRelease do
           and_return({:valid=>["extractedmodule/metadata.json"], :invalid=>[], :symlinks=>[]})
       subject.unpack(target_dir)
     end
-    
+
     it "raises an error if symlinks are present during the unpacking process after unpacking" do
       logger_dbl = double(Log4r::Logger)
       allow(subject).to receive(:logger).and_return(logger_dbl)
@@ -44,7 +44,7 @@ describe R10K::Forge::ModuleRelease do
       expect(logger_dbl).to receive(:debug2)
       expect {
         subject.unpack(target_dir)
-      }.to raise_error(R10K::Error, "Symlinks are unsupported and were not unpacked from the module tarball. " + 
+      }.to raise_error(R10K::Error, "Symlinks are unsupported and were not unpacked from the module tarball. " +
                                     "#{subject.forge_release.slug} contained these ignored symlinks: #{file_lists[:symlinks]}")
     end
   end

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'r10k/forge/module_release'
+require 'r10k/util/exec_env'
 
 describe R10K::Forge::ModuleRelease do
   subject { described_class.new('branan-eight_hundred', '8.0.0') }
@@ -12,6 +13,18 @@ describe R10K::Forge::ModuleRelease do
   before do
     subject.download_path = download_path
     subject.unpack_path = unpack_path
+  end
+
+  describe 'setting the proxy' do
+    %w[HTTPS_PROXY https_proxy HTTP_PROXY http_proxy].each do |env_var|
+      it "respects the #{env_var} environment variable" do
+        R10K::Util::ExecEnv.withenv(env_var => "http://proxy.value") do
+          subject = described_class.new('branan-eight_hundred', '8.0.0')
+          proxy_uri = subject.forge_release.conn.proxy.uri
+          expect(proxy_uri.to_s).to eq "http://proxy.value"
+        end
+      end
+    end
   end
 
   describe '#download' do


### PR DESCRIPTION
This pull request allows r10k to set an HTTP proxy for connecting to the Puppet Forge, either via a setting in r10k.yaml or via one of the commonly used http proxy environment variables.
