### PR TITLE
(maint) Correct error message when no config file present.

### DIFF
--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -43,7 +43,7 @@ class Config
       loader = R10K::Deployment::Config::Loader.new
       @configfile = loader.search
       if @configfile.nil?
-        raise ConfigError, "No configuration file given, no config file found in parent directory, and no global config present"
+        raise ConfigError, "No configuration file given, no config file found in current directory, and no global config present"
       end
     end
     begin


### PR DESCRIPTION
Before this, the error message for no config file present specified the parent directory. With this commit, that error message references the current directory.
