### PR TITLE
(RK-118) readd /etc/r10k.yaml to config search path

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -21,12 +21,13 @@ locations for a configuration file.
 
   * `{current working directory}/r10k.yaml`
   * `/etc/puppetlabs/r10k/r10k.yaml` (1.5.0 and later)
-  * `/etc/r10k.yaml` (removed in 2.0.0, deprecated in 1.5.0)
+  * `/etc/r10k.yaml` (deprecated in 1.5.0)
 
-As of 2.0.0, r10k will no longer search for a configuration file at
-`/etc/r10k.yaml`. In 1.5.0 r10k added `/etc/puppetlabs/r10k/r10k.yaml` to the
-configuration search path. The old location, `/etc/r10k.yaml` was deprecated
-at that time.
+In 1.5.0 r10k added `/etc/puppetlabs/r10k/r10k.yaml` to the configuration search
+path. The old location, `/etc/r10k.yaml` has been deprecated in favor of the new
+location. If both `/etc/puppetlabs/r10k/r10k.yaml` and `/etc/r10k.yaml` exist
+and explicit configuration file has not been given, r10k will log a warning and
+use `/etc/puppetlabs/r10k/r10.yaml`.
 
 General options
 ---------------

--- a/lib/r10k/deployment/config/loader.rb
+++ b/lib/r10k/deployment/config/loader.rb
@@ -11,6 +11,7 @@ module R10K
 
         CONFIG_FILE = 'r10k.yaml'
         DEFAULT_LOCATION = File.join('/etc/puppetlabs/r10k', CONFIG_FILE)
+        OLD_DEFAULT_LOCATION = File.join('/etc', CONFIG_FILE)
 
         # Search for a deployment configuration file (r10k.yaml) in several locations
         def initialize
@@ -20,6 +21,13 @@ module R10K
 
         # @return [String] The path to the first valid configfile
         def search
+
+          # If both default files are present, issue a warning.
+          if (File.file? DEFAULT_LOCATION) && (File.file? OLD_DEFAULT_LOCATION)
+            logger.warn "Both #{DEFAULT_LOCATION} and #{OLD_DEFAULT_LOCATION} configuration files exist."
+            logger.warn "#{DEFAULT_LOCATION} will be used."
+          end
+
           first = @loadpath.find {|filename| File.file? filename}
         end
 
@@ -32,6 +40,9 @@ module R10K
 
           # Add the AIO location for of r10k.yaml
           @loadpath << DEFAULT_LOCATION
+
+          # Add the old default location last.
+          @loadpath << OLD_DEFAULT_LOCATION
 
           @loadpath
         end

--- a/lib/r10k/deployment/config/loader.rb
+++ b/lib/r10k/deployment/config/loader.rb
@@ -28,7 +28,14 @@ module R10K
             logger.warn "#{DEFAULT_LOCATION} will be used."
           end
 
-          first = @loadpath.find {|filename| File.file? filename}
+          path = @loadpath.find {|filename| File.file? filename}
+
+          if path == OLD_DEFAULT_LOCATION
+            logger.warn "The r10k configuration file at #{OLD_DEFAULT_LOCATION} is deprecated."
+            logger.warn "Please move your r10k configuration to #{DEFAULT_LOCATION}."
+          end
+
+          path
         end
 
         private

--- a/spec/unit/deployment/config/loader_spec.rb
+++ b/spec/unit/deployment/config/loader_spec.rb
@@ -8,14 +8,13 @@ describe R10K::Deployment::Config::Loader do
       expect(subject.loadpath).to include('/etc/puppetlabs/r10k/r10k.yaml')
     end
 
+    it 'includes /etc/r10k.yaml in the loadpath' do
+      expect(subject.loadpath).to include('/etc/r10k.yaml')
+    end
+
     it 'does include the current working directory in the loadpath' do
       allow(Dir).to receive(:getwd).and_return '/some/random/path/westvletren'
       expect(subject.loadpath).to include('/some/random/path/westvletren/r10k.yaml')
-    end
-
-    # This was the old default location that is no longer supported as of 2.0.0.
-    it 'does not include /etc/r10k.yaml in the loadpath' do
-      expect(subject.loadpath).not_to include('/etc/r10k.yaml')
     end
 
     it 'does not include /some/random/path/atomium/r10k.yaml in the loadpath' do
@@ -28,7 +27,22 @@ describe R10K::Deployment::Config::Loader do
     it 'returns the correct default location' do
       allow(File).to receive(:file?).and_return false
       allow(File).to receive(:file?).with('/etc/puppetlabs/r10k/r10k.yaml').and_return true
+      allow(File).to receive(:file?).with('/etc/r10k.yaml').and_return true
       expect(subject.search).to eq '/etc/puppetlabs/r10k/r10k.yaml'
+    end
+
+    it 'issues a warning if both default locations are present' do
+      allow(File).to receive(:file?).and_return false
+      allow(File).to receive(:file?).with('/etc/puppetlabs/r10k/r10k.yaml').and_return true
+      allow(File).to receive(:file?).with('/etc/r10k.yaml').and_return true
+
+      logger_dbl = double('Logging')
+      allow(subject).to receive(:logger).and_return logger_dbl
+
+      expect(logger_dbl).to receive(:warn).with('Both /etc/puppetlabs/r10k/r10k.yaml and /etc/r10k.yaml configuration files exist.')
+      expect(logger_dbl).to receive(:warn).with('/etc/puppetlabs/r10k/r10k.yaml will be used.')
+
+      subject.search
     end
   end
 end

--- a/spec/unit/deployment/config/loader_spec.rb
+++ b/spec/unit/deployment/config/loader_spec.rb
@@ -44,5 +44,19 @@ describe R10K::Deployment::Config::Loader do
 
       subject.search
     end
+
+    it 'issues a warning if the old location is used' do
+      allow(File).to receive(:file?).and_return false
+      allow(File).to receive(:file?).with('/etc/puppetlabs/r10k/r10k.yaml').and_return false
+      allow(File).to receive(:file?).with('/etc/r10k.yaml').and_return true
+
+      logger_dbl = double('Logging')
+      allow(subject).to receive(:logger).and_return logger_dbl
+
+      expect(logger_dbl).to receive(:warn).with("The r10k configuration file at /etc/r10k.yaml is deprecated.")
+      expect(logger_dbl).to receive(:warn).with('Please move your r10k configuration to /etc/puppetlabs/r10k/r10k.yaml.')
+
+      subject.search
+    end
   end
 end


### PR DESCRIPTION
Perhaps removing the config path for r10k that has been standard for two years without a visible deprecation was far, far too hasty. This rolls back that change.
