### PR TITLE
(RK-117) Add minitar as runtime dependency

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -33,10 +33,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday_middleware-multi_json', '~> 0.0.6'
 
   s.add_dependency 'semantic_puppet', '~> 0.1.0'
+  s.add_dependency 'minitar'
 
   s.add_development_dependency 'rspec', '~> 3.1'
 
-  s.add_development_dependency 'minitar'
 
   s.add_development_dependency 'yard', '~> 0.8.7.3'
 


### PR DESCRIPTION
Minitar is required to install modules from the Puppet Forge, and is
required at application startup so it is a hard requirement. This commit
moves the dependency from a development dependency to a runtime
dependency.
