### PR TITLE
(RK-70) add Forge baseurl setting

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -86,6 +86,15 @@ forge:
 If no proxy is given, r10k will check the environment variables 'HTTPS_PROXY',
 'https_proxy', 'HTTP_PROXY', and 'http_proxy' in that order for a proxy URL.
 
+#### baseurl
+
+The 'baseurl' setting indicates where Forge modules should be installed from.
+This defaults to 'https://forgeapi.puppetlabs.com'
+
+```yaml
+forge:
+  baseurl: 'https://private-forge.mysite'
+```
 
 Deployment options
 ------------------

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -77,6 +77,11 @@ class Config
       if proxy
         R10K::Forge::ModuleRelease.settings[:proxy] = proxy
       end
+
+      baseurl = forge_settings[:baseurl]
+      if baseurl
+        R10K::Forge::ModuleRelease.settings[:baseurl] = baseurl
+      end
     end
 
     with_setting(:git) do |git_settings|

--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -14,6 +14,7 @@ module R10K
       include R10K::Settings::Mixin
 
       def_setting_attr :proxy
+      def_setting_attr :baseurl
 
       include R10K::Logging
 
@@ -43,7 +44,7 @@ module R10K
         @version   = version
 
         @forge_release = PuppetForge::V3::ModuleRelease.new(@full_name, @version)
-        @forge_release.conn.proxy(proxy)
+        @forge_release.conn = conn
 
         @download_path = Pathname.new(Dir.mktmpdir) + (slug + '.tar.gz')
         @unpack_path   = Pathname.new(Dir.mktmpdir) + slug
@@ -127,6 +128,16 @@ module R10K
       end
 
       private
+
+      def conn
+        if settings[:baseurl]
+          conn = PuppetForge::Connection.make_connection(settings[:baseurl])
+        else
+          conn = PuppetForge::Connection.default_connection
+        end
+        conn.proxy(proxy)
+        conn
+      end
 
       def proxy
         [

--- a/lib/shared/puppet_forge/connection.rb
+++ b/lib/shared/puppet_forge/connection.rb
@@ -58,5 +58,6 @@ module PuppetForge
         builder.adapter(*adapter_args)
       end
     end
+    module_function :make_connection
   end
 end

--- a/lib/shared/puppet_forge/connection.rb
+++ b/lib/shared/puppet_forge/connection.rb
@@ -36,8 +36,13 @@ module PuppetForge
     # @return [Faraday::Connection] An existing Faraday connection if one was
     #   already set, otherwise a new Faraday connection.
     def conn
-      @conn ||= make_connection('https://forgeapi.puppetlabs.com')
+      @conn ||= default_connection
     end
+
+    def default_connection
+      make_connection('https://forgeapi.puppetlabs.com')
+    end
+    module_function :default_connection
 
     # Generate a new Faraday connection for the given URL.
     #

--- a/spec/unit/deployment/config_spec.rb
+++ b/spec/unit/deployment/config_spec.rb
@@ -32,6 +32,12 @@ describe R10K::Deployment::Config do
         expect(R10K::Forge::ModuleRelease.settings).to receive(:[]=).with(:proxy, 'https://proxy.url')
         described_class.new('foo/bar')
       end
+
+      it "sets the baseurl when given" do
+        expect(YAML).to receive(:load_file).with('foo/bar').and_return('forge' => {'baseurl' => 'https://local.puppet.forge'})
+        expect(R10K::Forge::ModuleRelease.settings).to receive(:[]=).with(:baseurl, 'https://local.puppet.forge')
+        described_class.new('foo/bar')
+      end
     end
 
     describe "for git" do

--- a/spec/unit/puppet_forge/connection_spec.rb
+++ b/spec/unit/puppet_forge/connection_spec.rb
@@ -36,4 +36,11 @@ describe PuppetForge::Connection do
       end
     end
   end
+
+  describe 'creating a default connection' do
+    it 'creates a connection with the default Forge URL' do
+      conn = described_class.default_connection
+      expect(conn.url_prefix.to_s).to eq 'https://forgeapi.puppetlabs.com/'
+    end
+  end
 end

--- a/spec/unit/puppet_forge/connection_spec.rb
+++ b/spec/unit/puppet_forge/connection_spec.rb
@@ -2,13 +2,11 @@ require 'shared/puppet_forge/connection'
 
 describe PuppetForge::Connection do
 
-  let(:extended) { Object.new.extend(described_class) }
-
   describe 'creating a new connection' do
 
     let(:faraday_stubs) { Faraday::Adapter::Test::Stubs.new }
 
-    subject { extended.make_connection('https://some.site/url', [:test, faraday_stubs]) }
+    subject { described_class.make_connection('https://some.site/url', [:test, faraday_stubs]) }
 
     it 'parses response bodies with a JSON content-type into a hash' do
       faraday_stubs.get('/json') { [200, {'Content-Type' => 'application/json'}, '{"hello": "world"}'] }


### PR DESCRIPTION
This allows users to specify a custom Forge URL for downloading and installing modules.
