### PR TITLE
(RK-121) Improve error handling for nonexistent forge module/module releases

### DIFF
--- a/lib/shared/puppet_forge/error.rb
+++ b/lib/shared/puppet_forge/error.rb
@@ -25,4 +25,10 @@ Could not install package
       MSG
     end
   end
+
+  class ModuleNotFound < PuppetForge::Error
+  end
+
+  class ModuleReleaseNotFound < PuppetForge::Error
+  end
 end

--- a/lib/shared/puppet_forge/v3/module.rb
+++ b/lib/shared/puppet_forge/v3/module.rb
@@ -1,6 +1,7 @@
 require 'shared/puppet_forge/v3'
 require 'shared/puppet_forge/v3/module_release'
 require 'shared/puppet_forge/connection'
+require 'shared/puppet_forge/error'
 
 module PuppetForge
   module V3
@@ -41,6 +42,8 @@ module PuppetForge
         end
 
         releases.reverse
+      rescue Faraday::ResourceNotFound => e
+        raise PuppetForge::ModuleNotFound, "The module #{@full_name} does not exist on #{conn.url_prefix}.", e.backtrace
       end
 
       # Get all released versions of this module

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -56,6 +56,7 @@ describe R10K::Forge::ModuleRelease do
 
   describe '#verify' do
     it "verifies the module checksum based on the Forge file checksum" do
+      allow(subject.forge_release).to receive(:data).and_return('file_md5' => 'something')
       expect(subject.forge_release).to receive(:verify).with(download_path)
       subject.verify
     end

--- a/spec/unit/puppet_forge/v3/module_spec.rb
+++ b/spec/unit/puppet_forge/v3/module_spec.rb
@@ -7,6 +7,7 @@ describe PuppetForge::V3::Module do
 
   let(:conn) do
     Faraday.new do |builder|
+      builder.response(:raise_error)
       builder.adapter :test, faraday_stubs
     end
   end
@@ -55,6 +56,13 @@ describe PuppetForge::V3::Module do
     it "ignores deleted releases" do
       faraday_stubs.get('/v3/modules/authorname-modulename') { [200, {}, releases_with_deletions] }
       expect(subject.versions).to eq ["0.3.0"]
+    end
+
+    it "raises an error when the module does not exist" do
+      faraday_stubs.get('/v3/modules/authorname-modulename') { [404, {}, ''] }
+      expect {
+        subject.versions
+      }.to raise_error(PuppetForge::ModuleNotFound, /The module authorname-modulename does not exist/)
     end
   end
 


### PR DESCRIPTION
This pull request improves the error messages emitted by the PuppetForge library when encountering nonexistent modules and module releases; instead of raising a general error indicating that a 404 occurred it raises errors indicating that the requested module/release doesn't exist.
