### PR TITLE
Use the pessimistic operator to check the 'colored' runtime dependency

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.license  = 'Apache-2.0'
 
-  s.add_dependency 'colored',   '1.2'
+  s.add_dependency 'colored',   '~> 1.2'
   s.add_dependency 'cri',       '~> 2.6.1'
 
   s.add_dependency 'log4r',     '1.1.10'


### PR DESCRIPTION
... in fact the [pessimistic](https://robots.thoughtbot.com/rubys-pessimistic-operator) operator is more optimistic than not using an operator at all :)
#### Backstory

I was using [`fpm`](https://github.com/jordansissel/fpm) to package R10K into RPMs like this:

```
docker run -it --rm -e GEM=r10k \
-v ${PWD}/newgems:/newgems centos:7 bash -c "
yum install -y ruby-devel gcc libffi-devel make rpm-build
gem install --no-document --verbose fpm
mkdir /tmp/gems
gem install --no-document --verbose --install-dir /tmp/gems \$GEM
cd /newgems
find /tmp/gems -name '*.gem' | \
xargs -rn1 fpm -d ruby -d rubygems --prefix /usr/share/gems -s gem -t rpm"
```

... it worked nicely producing all the RPMs that I need ...

```
$ ls newgems
rubygem-colored-1.2.0-1.noarch.rpm
rubygem-cri-2.6.1-1.noarch.rpm
rubygem-faraday-0.9.1-1.noarch.rpm
rubygem-faraday_middleware-0.9.1-1.noarch.rpm
rubygem-faraday_middleware-multi_json-0.0.6-1.noarch.rpm
rubygem-json_pure-1.8.2-1.noarch.rpm
rubygem-log4r-1.1.10-1.noarch.rpm
rubygem-multi_json-1.11.0-1.noarch.rpm
rubygem-multipart-post-2.0.0-1.noarch.rpm
rubygem-r10k-1.5.0-1.noarch.rpm
rubygem-semantic_puppet-0.1.1-1.noarch.rpm
```

... but when I try to install R10K I get this error:

```
Error: Package: rubygem-r10k-1.5.0-1.noarch (Misc)
           Requires: rubygem(colored) = 1.2
           Available: rubygem-colored-1.2.0-1.noarch (Misc)
               rubygem(colored) = 1.2.0
Error: Package: rubygem-r10k-1.5.0-1.noarch (Misc)
           Requires: rubygem(colored) = 1.2
           Installing: rubygem-colored-1.2.0-1.noarch (Misc)
               rubygem(colored) = 1.2.0
```

I think the problem is that `fpm` is adding an additional '0' as PATCH version:

```
$ rpm -qp --provides rubygem-colored-1.2.0-1.noarch.rpm
rubygem(colored) = 1.2.0
rubygem-colored = 1.2.0-1
```
#### Summary
1. `R10k` is too pessimistic checking the `colored` runtime dependency.
2. `colored` is not using the [Semantic Versioning 2.0.0](http://semver.org/).
3. `fpm` is adding the PATCH version when it shouldn't.
