### PR TITLE
(Doc) Add invalid_branches setting to source options list

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -188,6 +188,27 @@ sources:
 * if `false` (default) environment folder will not be prefixed
 * if `String` environment folder will be prefixed with the `prefix` value.
 
+### invalid_branches:
+
+This setting specifies how Git branch names that cannot be cleanly mapped to
+Puppet environments will be handled.
+
+Valid values:
+
+  * 'correct_and_warn': Non-word characters will be replaced with underscores
+    and a warning will be emitted. (Default)
+  * 'correct': Non-word characters will silently be replaced with underscores.
+  * 'error': Branches with non-word characters will be ignored and an error will
+    be emitted.
+
+```yaml
+---
+sources:
+  mysource:
+    basedir: '/etc/puppet/environments'
+    invalid_branches: 'error'
+```
+
 Examples
 --------
 

--- a/doc/dynamic-environments/git-environments.mkd
+++ b/doc/dynamic-environments/git-environments.mkd
@@ -58,18 +58,4 @@ keys][stash-access-keys].
 Configuration
 -------------
 
-The following configuration options can be specified for Git based environment
-sources.
-
-### invalid_branches:
-
-This setting specifies how Git branch names that cannot be cleanly mapped to
-Puppet environments will be handled.
-
-Valid values:
-
-  * 'correct_and_warn': Non-word characters will be replaced with underscores
-    and a warning will be emitted. (Default)
-  * 'correct': Non-word characters will silently be replaced with underscores.
-  * 'error': Branches with non-word characters will be ignored and an error will
-    be emitted.
+See the [configuration reference](configuration.mkd) for available parameters


### PR DESCRIPTION
Add the invalid_branches setting to the list of source options. Copy/paste from git-environments.md.
