### PR TITLE
(RK-109) Add context to connection failure errors

### DIFF
--- a/lib/shared/puppet_forge/connection.rb
+++ b/lib/shared/puppet_forge/connection.rb
@@ -1,4 +1,5 @@
 require 'shared/puppet_forge/version'
+require 'shared/puppet_forge/connection/connection_failure'
 
 require 'faraday'
 require 'faraday_middleware'
@@ -54,6 +55,7 @@ module PuppetForge
       Faraday.new(url, options) do |builder|
         builder.response(:json, :content_type => /\bjson$/)
         builder.response(:raise_error)
+        builder.use(:connection_failure)
 
         builder.adapter(*adapter_args)
       end

--- a/lib/shared/puppet_forge/connection/connection_failure.rb
+++ b/lib/shared/puppet_forge/connection/connection_failure.rb
@@ -1,0 +1,26 @@
+require 'faraday'
+
+module PuppetForge
+  module Connection
+    # Wrap Faraday connection failures to include the host and optional proxy
+    # in use for the failed connection.
+    class ConnectionFailure < Faraday::Middleware
+      def call(env)
+        @app.call(env)
+      rescue Faraday::ConnectionFailed => e
+        baseurl = env[:url].dup
+        baseurl.path = ''
+        errmsg = "Unable to connect to #{baseurl.to_s}"
+        if proxy = env[:request][:proxy]
+          errmsg << " (using proxy #{proxy.uri.to_s})"
+        end
+        errmsg << ": #{e.message}"
+        m = Faraday::ConnectionFailed.new(errmsg)
+        m.set_backtrace(e.backtrace)
+        raise m
+      end
+    end
+  end
+end
+
+Faraday::Middleware.register_middleware(:connection_failure => lambda { PuppetForge::Connection::ConnectionFailure })

--- a/spec/unit/puppet_forge/connection/connection_failure_spec.rb
+++ b/spec/unit/puppet_forge/connection/connection_failure_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'shared/puppet_forge/connection/connection_failure'
+
+describe PuppetForge::Connection::ConnectionFailure do
+
+  subject do
+    Faraday.new('https://my-site.url/some-path') do |builder|
+      builder.use(:connection_failure)
+
+      builder.adapter :test do |stub|
+        stub.get('/connectfail') { raise Faraday::ConnectionFailed.new(SocketError.new("getaddrinfo: Name or service not known"), :hi) }
+      end
+    end
+  end
+
+  it "includes the base URL in the error message" do
+    expect {
+      subject.get('/connectfail')
+    }.to raise_error(Faraday::ConnectionFailed, "Unable to connect to https://my-site.url: getaddrinfo: Name or service not known")
+  end
+
+  it "includes the proxy host in the error message when set" do
+    subject.proxy('https://some-unreachable.proxy:3128')
+    expect {
+      subject.get('/connectfail')
+    }.to raise_error(Faraday::ConnectionFailed, "Unable to connect to https://my-site.url (using proxy https://some-unreachable.proxy:3128): getaddrinfo: Name or service not known")
+  end
+end


### PR DESCRIPTION
When Faraday encounters an issue establishing a connection to a host or
to a proxy, it raises an error indicating that the connection failed
but does not include the name of the host. This commit adds a middleware
class that rescues ConnectionFailed exceptions and raises a new error
that includes the host, and optional proxy host.
