### PR TITLE
#455 fix issue on windows where path include spaces

### DIFF
--- a/lib/r10k/util/subprocess/runner/windows.rb
+++ b/lib/r10k/util/subprocess/runner/windows.rb
@@ -15,6 +15,13 @@ class R10K::Util::Subprocess::Runner::Windows < R10K::Util::Subprocess::Runner
 
   def run
     cmd = @argv.join(' ')
+    cmd = @argv.map do |elem|
+        if elem.match(/\s/)
+          %Q["#{elem}"]
+        else
+          elem
+        end
+    end.join(' ')
 
     stdout, stderr, status = Open3.capture3(cmd)
 


### PR DESCRIPTION
When using _ssh_ connections to windows servers (**openssh**) the default **HOME** path targets _C:/Program Files/OpenSSH/home_ (with spaces) breaking almost all _git_ commands. 

After the fix the **debug** information shows exit code 0 for git commands.

```
Exit code: 0
[2015-06-19 10:35:37 - DEBUG2] Starting process: ["git", "--git-dir", "C:/puppet/modules/chocolatey/.git", "--work-tree", "C:/puppet/modules/chocolatey", "remote", "add", "cache", "C:/Program Files/OpenSSH/home/_puppet/.r10k/git/https---github.com-chocolatey-puppet-chocolatey.git"]
[2015-06-19 10:35:37 - DEBUG2] Finished process:
Command: git --git-dir C:/puppet/modules/chocolatey/.git --work-tree C:/puppet/modules/chocolatey remote add cache C:/Program Files/OpenSSH/home/_puppet/.r10k/git/https---github.com-chocolatey-puppet-chocolatey.git
Exit code: 0
```
