### PR TITLE
Added support to actually use forge directive in Puppetfiles

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -31,7 +31,7 @@ class R10K::Module::Forge < R10K::Module::Base
   # @!attribute [rw] forge
   #   @api private
   #   @return [String] The Puppet Forge where the module can be found
-  attr :forge
+  attr_accessor :forge
   
   include R10K::Logging
 

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -5,6 +5,7 @@ require 'r10k/module/metadata_file'
 
 require 'r10k/forge/module_release'
 require 'shared/puppet_forge/v3/module'
+require 'shared/puppet_forge/connection'
 
 require 'pathname'
 require 'fileutils'
@@ -27,6 +28,11 @@ class R10K::Module::Forge < R10K::Module::Base
   #   @return [PuppetForge::V3::Module] The Puppet Forge module metadata
   attr_reader :v3_module
 
+  # @!attribute [rw] forge
+  #   @api private
+  #   @return [String] The Puppet Forge where the module can be found
+  attr :forge
+  
   include R10K::Logging
 
   def initialize(title, dirname, expected_version)
@@ -36,6 +42,8 @@ class R10K::Module::Forge < R10K::Module::Base
 
     @expected_version = expected_version || current_version || :latest
     @v3_module = PuppetForge::V3::Module.new(@title)
+    
+    @forge = 'https://forgeapi.puppetlabs.com'
   end
 
   def sync(options = {})
@@ -126,6 +134,7 @@ class R10K::Module::Forge < R10K::Module::Base
       parent_path.mkpath
     end
     module_release = R10K::Forge::ModuleRelease.new(@title, expected_version)
+    module_release.conn = PuppetForge::Connection.make_connection(@forge)
     module_release.install(@path)
   end
 

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -73,7 +73,7 @@ class Puppetfile
   # @param [*Object] args
   def add_module(name, args)
     @modules << R10K::Module.new(name, @moduledir, args)
-    if @modules[-1].has_attribute? 'forge'
+    if @modules[-1].respond_to? :forge
       @modules[-1].forge = @forge
     end
   end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -73,6 +73,9 @@ class Puppetfile
   # @param [*Object] args
   def add_module(name, args)
     @modules << R10K::Module.new(name, @moduledir, args)
+    if @modules[-1].has_attribute? 'forge'
+      @modules[-1].forge = @forge
+    end
   end
 
   include R10K::Util::Purgeable


### PR DESCRIPTION
While the forge directive in a Puppet file was being read and stored, it was not being referenced when module was being downloaded. Instead the connection would default to _always_ download from https://forgeapi.puppetlabs.com/. 

Now when a module is being added to the internal data structures, it is check to see if it is an R10K::Module::Forge class and if so, the connection will be setup to use the specified forge. If the forge directive is not specified in the Puppetfile, it defaults as expected to http://forgeapi.puppetlabs.com/. 
