### PR TITLE
[git] (RK-42) Add logging for when Git provider changes

### DIFF
--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -68,6 +68,8 @@ module R10K
       name
     end
 
+    extend R10K::Logging
+
     # Manually set the Git provider by name.
     #
     # @param name [Symbol] The name of the Git provider to use.
@@ -87,7 +89,9 @@ module R10K
       if attrs[:on_set]
         attrs[:on_set].call
       end
+
       @provider = attrs[:module]
+      logger.debug1 { "Setting Git provider to #{@provider.name}" }
     end
 
     # @return [Module] The namespace of the first available Git implementation.
@@ -98,7 +102,9 @@ module R10K
         raise R10K::Error, "No Git provider set."
       when UNSET_PROVIDER
         self.provider = default_name
+        logger.debug1 { "Setting Git provider to default provider #{default_name}" }
       end
+
       @provider
     end
 


### PR DESCRIPTION
The Git provider in use changes a lot of how r10k may behave/misbehave,
but there was no logging to indicate which provider is in use. This
commit adds log messages for when the Git provider is changed.
