### PR TITLE
(RK-146) Use settings class for normalization

### DIFF
--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -21,19 +21,7 @@ class Config
 
   # Perform a scan for key and check for both string and symbol keys
   def setting(key)
-    keys = [key]
-    case key
-    when String
-      keys << key.to_sym
-    when Symbol
-      keys << key.to_s
-    end
-
-    # Scan all possible keys to see if the config has a matching value
-    keys.inject(nil) do |rv, k|
-      v = @config[k]
-      break v unless v.nil?
-    end
+    @config[key]
   end
 
   # Load and store a config file, and set relevant options
@@ -41,7 +29,8 @@ class Config
   # @param [String] configfile The path to the YAML config file
   def load_config
     loader = R10K::Settings::Loader.new
-    @config = loader.read(@configfile)
+    hash = loader.read(@configfile)
+    @config = R10K::Settings.global_settings.evaluate(hash)
     initializer = R10K::Initializers::GlobalInitializer.new(@config)
     initializer.call
   end

--- a/spec/unit/deployment/config_spec.rb
+++ b/spec/unit/deployment/config_spec.rb
@@ -1,22 +1,6 @@
 require 'spec_helper'
 
 describe R10K::Deployment::Config do
-
-  describe "reading settings" do
-    # Try all permutations of string/symbol values as arguments to #setting and
-    # values in the config file
-    x = [:key, "key"]
-    matrix = x.product(x)
-
-    matrix.each do |(searchvalue, configvalue)|
-      it "treats #{searchvalue.inspect}:#{searchvalue.class} and #{configvalue.inspect}:#{configvalue.class} as equivalent" do
-        expect(YAML).to receive(:load_file).with('foo/bar').and_return(configvalue => 'some/cache')
-        subject = described_class.new('foo/bar')
-        expect(subject.setting(searchvalue)).to eq 'some/cache'
-      end
-    end
-  end
-
   describe "applying global settings" do
     let(:loader) { instance_double('R10K::Settings::Loader') }
     let(:initializer) { instance_double('R10K::Initializers::GlobalInitializer') }
@@ -28,7 +12,7 @@ describe R10K::Deployment::Config do
 
     it 'runs application initialization' do
       config = instance_double('Hash')
-      allow(loader).to receive(:read)
+      allow(loader).to receive(:read).and_return({})
       expect(initializer).to receive(:call)
       described_class.new('some/path')
     end


### PR DESCRIPTION
The settings classes added in RK-59 weren't being used which meant that
we weren't getting input normalization; this commit resolves this by
using the settings layer when loading a config in
R10K::Deployment::Config. This commit also tears out some internal
string/symbol normalization that is handled by the config loading
process and thus is no longer needed.
