### PR TITLE
Add --fetch option to "deploy display".

### DIFF
--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -88,6 +88,7 @@ try to deploy the given module names in all environments.
 
           flag :p, :puppetfile, 'Display Puppetfile modules'
           flag nil, :detail, 'Display detailed information'
+          flag nil, :fetch, 'Update available environment lists from all remote sources'
           required nil, :format, 'Display output in a specific format. Valid values: json, yaml. Default: yaml'
 
           runner R10K::Action::CriRunner.wrap(R10K::Action::Deploy::Display)


### PR DESCRIPTION
Passing --fetch to "r10k deploy display" will cause r10k to update
its internal cache of the available environments for each source
before producing output. This commit also adds a "status" key to
the description of each environment when --detail or --puppetfile is
passed.
