### PR TITLE
(CODEMGMT-194) Move Metadata to PuppetForge module

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -1,6 +1,6 @@
 require 'r10k/module'
 require 'r10k/errors'
-require 'shared/puppet/module_tool/metadata'
+require 'shared/puppet_forge/metadata'
 require 'r10k/module/metadata_file'
 
 require 'r10k/forge/module_release'
@@ -19,7 +19,7 @@ class R10K::Module::Forge < R10K::Module::Base
 
   # @!attribute [r] metadata
   #   @api private
-  #   @return [Puppet::ModuleTool::Metadata]
+  #   @return [PuppetForge::Metadata]
   attr_reader :metadata
 
   # @!attribute [r] v3_module

--- a/lib/r10k/module/metadata_file.rb
+++ b/lib/r10k/module/metadata_file.rb
@@ -1,6 +1,6 @@
 require 'r10k/module'
 require 'r10k/errors'
-require 'shared/puppet/module_tool/metadata'
+require 'shared/puppet_forge/metadata'
 
 class R10K::Module::MetadataFile
 
@@ -19,7 +19,7 @@ class R10K::Module::MetadataFile
     if self.exist?
       metadata_file_path.open do |f|
         begin
-          metadata = Puppet::ModuleTool::Metadata.new
+          metadata = PuppetForge::Metadata.new
           metadata.update(JSON.load(f), false)
         rescue JSON::ParserError => e
           exception = R10K::Error.wrap(e, "Could not read metadata.json")

--- a/lib/shared/puppet_forge/metadata.rb
+++ b/lib/shared/puppet_forge/metadata.rb
@@ -3,8 +3,7 @@ require 'json'
 require 'set'
 require 'semantic_puppet/version' 
 
-module Puppet
-module ModuleTool
+module PuppetForge
 
   # This class provides a data structure representing a module's metadata.
   # @api private
@@ -31,7 +30,7 @@ module ModuleTool
 
     # Returns a filesystem-friendly version of this module name.
     def dashed_name
-      @data['name'].tr('/', '-') if @data['name']
+      PuppetForge::V3.normalize_name(@data['name']) if @data['name']
     end
 
     # Returns a string that uniquely represents this version of this module.
@@ -194,4 +193,4 @@ module ModuleTool
     end
   end
 end
-end
+

--- a/spec/unit/module/metadata_file_spec.rb
+++ b/spec/unit/module/metadata_file_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'shared/puppet/module_tool/metadata'
+require 'shared/puppet_forge/metadata'
 
 describe R10K::Module::MetadataFile do
 

--- a/spec/unit/puppet_forge/metadata_spec.rb
+++ b/spec/unit/puppet_forge/metadata_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'shared/puppet/module_tool/metadata'
+require 'shared/puppet_forge/metadata'
 
-describe Puppet::ModuleTool::Metadata do
+describe PuppetForge::Metadata do
   let(:data) { {} }
-  let(:metadata) { Puppet::ModuleTool::Metadata.new }
+  let(:metadata) { PuppetForge::Metadata.new }
 
   describe 'property lookups' do
     subject { metadata }


### PR DESCRIPTION
Before the metadata was inside of Puppet::ModuleTool. This commit moves
it under the PuppetForge namespace instead.
