### PR TITLE
(RK-156) Check for pe-license lib via `require`, improve module release logging

### DIFF
--- a/lib/r10k/features.rb
+++ b/lib/r10k/features.rb
@@ -16,3 +16,5 @@ end
 R10K::Features.add(:shellgit) { R10K::Util::Commands.which('git') }
 
 R10K::Features.add(:rugged, :libraries => 'rugged')
+
+R10K::Features.add(:pe_license, :libraries => 'pe_license')

--- a/lib/r10k/util/license.rb
+++ b/lib/r10k/util/license.rb
@@ -1,19 +1,23 @@
 require 'r10k/errors'
-require 'rubygems'
+require 'r10k/features'
 
 module R10K
   module Util
     module License
+      extend R10K::Logging
+
       def self.load
-        if Gem::Specification::find_all_by_name('pe-license').any?
+        if R10K::Features.available?(:pe_license)
+          logger.debug2 "pe_license feature is available, loading PE license key"
           begin
             return PELicense.load_license_key
           rescue PELicense::InvalidLicenseError => e
             raise R10K::Error.wrap(e, "Invalid PE license detected: #{e.message}")
           end
+        else
+          logger.debug2 "pe_license feature is not available, PE only Puppet modules will not be downloadable."
+          nil
         end
-
-        nil
       end
     end
   end

--- a/lib/shared/puppet_forge/error.rb
+++ b/lib/shared/puppet_forge/error.rb
@@ -31,4 +31,11 @@ Could not install package
 
   class ModuleReleaseNotFound < PuppetForge::Error
   end
+
+  class ModuleReleaseForbidden < PuppetForge::Error
+    def self.from_response(response)
+      body = JSON.parse(response[:body])
+      new(body["message"])
+    end
+  end
 end

--- a/lib/shared/puppet_forge/v3/module_release.rb
+++ b/lib/shared/puppet_forge/v3/module_release.rb
@@ -1,6 +1,7 @@
 require 'shared/puppet_forge/v3'
 require 'shared/puppet_forge/connection'
 require 'shared/puppet_forge/error'
+require 'json'
 
 module PuppetForge
   module V3
@@ -46,6 +47,12 @@ module PuppetForge
         path.open('wb') { |fh| fh.write(resp.body) }
       rescue Faraday::ResourceNotFound => e
         raise PuppetForge::ModuleReleaseNotFound, "The module release #{slug} does not exist on #{conn.url_prefix}.", e.backtrace
+      rescue Faraday::ClientError => e
+        if e.response[:status] == 403
+          raise PuppetForge::ModuleReleaseForbidden.from_response(e.response)
+        else
+          raise e
+        end
       end
 
       # Verify that a downloaded module matches the checksum in the metadata for this release.


### PR DESCRIPTION
If the pe_license module is installed into the ruby library path via something like rpm or deb and is not installed into the rubygems library path, it will not be locatable via `Gem::Specification.find_all_by_name`.  This commit switches the library detection to use the r10k feature system, which handles detection by actually requiring the library. While requiring the library as part of detection is a fairly blunt approach and has side effects, it's a more reliable detection method (and if we're checking to see if the library is present, we're going to want to require it anyways).

This also adds improved logging when PE only modules can't be downloaded.
