### PR TITLE
(maint) Add postrun to the configurable settings

### DIFF
--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -58,6 +58,10 @@ module R10K
           :desc => "Where r10k should store cached Git repositories.",
         }),
 
+        Definition.new(:postrun, {
+          :desc => "The command r10k should run after deploying environments.",
+        }),
+
         R10K::Settings.forge_settings,
 
         R10K::Settings.git_settings,


### PR DESCRIPTION
Before this commit, the postrun key in r10k.yaml was ignored. With this
commit, the postrun command works again.

There should probably be some spec tests added to make sure this regression doesn't happen again.
