### PR TITLE
(RK-163) Add deploy write_lock setting

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -130,6 +130,28 @@ sources:
     # Source settings follow
 ```
 
+### deploy
+
+The `deploy` setting is a new top level setting for controlling how r10k deploys
+behave. At this point only new settings are included under this setting, but in
+the long term the current top level deploy settings will be moved under
+`deploy`.
+
+#### write_lock
+
+The `write_lock` setting allows administrators to temporarily disallow r10k code
+deploys without having to remove the r10k configuration entirely. This can be
+useful to prevent r10k deploys at certain times or prevent r10k from interfering
+with a common set of code that may be touched by multiple r10k configurations.
+
+```yaml
+---
+
+deploy:
+  write_lock: "Deploying code is disallowed until the next maintenance window (2038-01-19)"
+
+```
+
 Source options
 --------------
 

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -2,6 +2,7 @@ require 'r10k/util/setopts'
 require 'r10k/deployment'
 require 'r10k/logging'
 require 'r10k/action/visitor'
+require 'r10k/deployment/write_lock'
 require 'json'
 
 module R10K
@@ -11,6 +12,7 @@ module R10K
 
         include R10K::Util::Setopts
         include R10K::Logging
+        include R10K::Deployment::WriteLock
 
         def initialize(opts, argv)
           @opts = opts
@@ -28,7 +30,10 @@ module R10K
 
         def call
           @visit_ok = true
+
           deployment = R10K::Deployment.load_config(@config, :cachedir => @cachedir)
+          check_write_lock!(deployment.config.settings)
+
           deployment.accept(self)
           @visit_ok
         end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -2,6 +2,7 @@ require 'r10k/util/setopts'
 require 'r10k/deployment'
 require 'r10k/action/visitor'
 require 'r10k/logging'
+require 'r10k/deployment/write_lock'
 
 module R10K
   module Action
@@ -10,6 +11,7 @@ module R10K
 
         include R10K::Logging
         include R10K::Util::Setopts
+        include R10K::Deployment::WriteLock
 
         def initialize(opts, argv)
           @opts = opts
@@ -25,7 +27,10 @@ module R10K
 
         def call
           @visit_ok = true
+
           deployment = R10K::Deployment.load_config(@config)
+          check_write_lock!(deployment.config.settings)
+
           deployment.accept(self)
           @visit_ok
         end

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -25,6 +25,10 @@ class Config
     @config[key]
   end
 
+  def settings
+    @config
+  end
+
   # Load and store a config file, and set relevant options
   #
   # @param [String] configfile The path to the YAML config file

--- a/lib/r10k/deployment/write_lock.rb
+++ b/lib/r10k/deployment/write_lock.rb
@@ -1,0 +1,23 @@
+require 'r10k/logging'
+
+module R10K
+  class Deployment
+
+    # @api private
+    module WriteLock
+      include R10K::Logging
+
+      # @param config [Hash] The r10k config hash
+      #
+      # @raise [SystemExit] if the deploy write_lock setting has been set
+      def check_write_lock!(config)
+        write_lock = config[:deploy][:write_lock]
+        if write_lock
+          logger.fatal("Making changes to deployed environments has been administratively disabled.")
+          logger.fatal("Reason: #{write_lock}")
+          exit(16)
+        end
+      end
+    end
+  end
+end

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -43,6 +43,20 @@ module R10K
       ])
     end
 
+    def self.deploy_settings
+      R10K::Settings::Collection.new(:deploy, [
+        Definition.new(:write_lock, {
+          :desc => "Whether r10k deploy actions should be locked out in case r10k is being managed
+          by another application. The value should be a string containing the reason for the write lock.",
+          :validate => lambda do |value|
+            if value && !value.is_a?(String)
+              raise ArgumentError, "The write_lock setting should be a string containing the reason for the write lock, not a #{value.class}"
+            end
+          end
+        }),
+      ])
+    end
+
     def self.global_settings
       R10K::Settings::Collection.new(:global, [
         Definition.new(:sources, {
@@ -70,6 +84,8 @@ module R10K
         R10K::Settings.forge_settings,
 
         R10K::Settings.git_settings,
+
+        R10K::Settings.deploy_settings,
       ])
     end
   end

--- a/spec/r10k-mocks/mock_config.rb
+++ b/spec/r10k-mocks/mock_config.rb
@@ -3,8 +3,11 @@ require 'r10k/deployment/config'
 module R10K
   class Deployment
     class MockConfig
+
+      attr_accessor :hash
+
       def initialize(hash)
-        @hash = hash
+        @hash = hash.merge(deploy: {})
       end
 
       def configfile
@@ -13,19 +16,11 @@ module R10K
 
       # Perform a scan for key and check for both string and symbol keys
       def setting(key)
-        keys = [key]
-        case key
-        when String
-          keys << key.to_sym
-        when Symbol
-          keys << key.to_s
-        end
+        @hash[key]
+      end
 
-        # Scan all possible keys to see if the config has a matching value
-        keys.inject(nil) do |rv, k|
-          v = @hash[k]
-          break v unless v.nil?
-        end
+      def settings
+        @hash
       end
     end
   end

--- a/spec/shared-examples/deploy_write_lock.rb
+++ b/spec/shared-examples/deploy_write_lock.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+require 'r10k/deployment'
+
+shared_examples_for "a deploy action that can be write locked" do
+
+  let(:config) do
+    R10K::Deployment::MockConfig.new(
+      :sources => {
+        :control => {
+          :type => :mock,
+          :basedir => '/some/nonexistent/path/control',
+          :environments => %w[first second third],
+        },
+        :hiera => {
+          :type => :mock,
+          :basedir => '/some/nonexistent/path/hiera',
+          :environments => %w[fourth fifth sixth],
+        }
+      }
+    )
+  end
+
+  let(:deployment) { R10K::Deployment.new(config) }
+
+  before do
+    allow(R10K::Deployment).to receive(:load_config).and_return(deployment)
+  end
+
+  describe "when the write lock is" do
+
+    describe "unset" do
+      it "runs normally" do
+        expect(subject).to receive(:visit_deployment)
+        subject.call
+      end
+    end
+
+    describe "set" do
+      before do
+        config.hash[:deploy][:write_lock] = "Disabled, yo"
+      end
+
+      it "exits without running" do
+        expect(subject).to_not receive(:visit_deployment)
+        expect {
+          subject.call
+        }.to exit_with(16)
+      end
+    end
+  end
+end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+require 'r10k/deployment'
+require 'r10k/action/deploy/environment'
+
+describe R10K::Action::Deploy::Environment do
+
+  subject { described_class.new({}, []) }
+
+  it_behaves_like "a deploy action that can be write locked"
+end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+require 'r10k/action/deploy/module'
+
+describe R10K::Action::Deploy::Module do
+
+  subject { described_class.new({}, []) }
+
+  it_behaves_like "a deploy action that can be write locked"
+end

--- a/spec/unit/deployment/write_lock_spec.rb
+++ b/spec/unit/deployment/write_lock_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+require 'r10k/deployment/write_lock'
+
+describe R10K::Deployment::WriteLock do
+  subject { Object.new.extend(described_class) }
+
+  it "logs a warning and exits when the write lock is set" do
+    logger = subject.logger
+
+    expect(logger).to receive(:fatal).with("Making changes to deployed environments has been administratively disabled.")
+    expect(logger).to receive(:fatal).with("Reason: r10k is sleepy and wants to take a nap")
+
+    expect {
+      subject.check_write_lock!(deploy: {write_lock: "r10k is sleepy and wants to take a nap"})
+    }.to exit_with(16)
+  end
+end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -73,6 +73,33 @@ describe R10K::Settings do
     end
   end
 
+  describe "deploy settings" do
+    subject { described_class.deploy_settings }
+
+    describe "write_lock" do
+      it "accepts a string with a reason for the write lock" do
+        output = subject.evaluate("write_lock" => "No maintenance window active, code freeze till 2038-01-19")
+        expect(output[:write_lock]).to eq("No maintenance window active, code freeze till 2038-01-19")
+      end
+
+      it "accepts false and null values for the write lock" do
+        output = subject.evaluate("write_lock" => false)
+        expect(output[:write_lock]).to eq false
+      end
+
+      it "rejects non-string truthy values for the write lock" do
+        expect {
+          subject.evaluate("write_lock" => %w[list of reasons why deploys are locked])
+        }.to raise_error do |err|
+          expect(err.message).to match(/Validation failures for deploy/)
+          expect(err.errors.size).to eq 1
+          expect(err.errors[:write_lock]).to be_a_kind_of(ArgumentError)
+          expect(err.errors[:write_lock].message).to match(/should be a string containing the reason/)
+        end
+      end
+    end
+  end
+
   describe "global settings" do
     subject { described_class.global_settings }
     describe "sources" do


### PR DESCRIPTION
This pull request adds a `write_lock` setting for deployments; this allows administrators to disable r10k either to avoid interference with another r10k config or application or to disable r10k from making changes at unexpected times.
