### PR TITLE
Fix "git environment guide" internal link

### DIFF
--- a/doc/dynamic-environments/quickstart.mkd
+++ b/doc/dynamic-environments/quickstart.mkd
@@ -167,7 +167,7 @@ class profile::base {
 
 Ensure that the user r10k runs as (typically root) can access the git
 repository. See the [git environment guide]
-(doc/dynamic-environments/git-environments.mkd) for more detail.  You can test
+(git-environments.mkd) for more detail.  You can test
 the access by using su/sudo to perform `git clone yourrepoURL` as the correct
 user.
 


### PR DESCRIPTION
Bad URL (now): https://github.com/puppetlabs/r10k/blob/master/doc/dynamic-environments/doc/dynamic-environments/git-environments.mkd
Good URL (proposed): https://github.com/puppetlabs/r10k/blob/master/doc/dynamic-environments/git-environments.mkd
(these are full URLs, fix proposed using internal links)
