### PR TITLE
(RK-80) properly supply credentials to HTTPS connections

### DIFF
--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -62,7 +62,13 @@ class R10K::Git::Rugged::BaseRepository
   # @return [Proc]
   def credentials
     Proc.new do |url, username_from_url, allowed_types|
-      get_ssh_credentials(url, username_from_url)
+      if allowed_types.include?(:ssh_key)
+        get_ssh_key_credentials(url, username_from_url)
+      elsif allowed_types.include?(:plaintext)
+        get_plaintext_credentials(url, username_from_url)
+      else
+        get_default_credentials(url, username_from_url)
+      end
     end
   end
 
@@ -71,15 +77,30 @@ class R10K::Git::Rugged::BaseRepository
     nil
   end
 
-  def get_ssh_credentials(url, username_from_url)
+  def get_plaintext_credentials(url, username_from_url)
+    user = get_git_username(url, username_from_url)
+    password = URI.parse(url).password || ''
+
+    Rugged::Credentials::Plaintext.new(:username => user, :password => password)
+  end
+
+  def get_ssh_key_credentials(url, username_from_url)
     user = get_git_username(url, username_from_url)
     private_key = R10K::Git.settings[:private_key]
 
-    if private_key.nil?
+    if private_key
+      logger.debug2 "Using SSH private key #{private_key.inspect}"
+    else
       raise R10K::Git::GitError.new("Git remote #{url.inspect} uses the SSH protocol but no private key was given", :git_dir => @path.to_s)
     end
 
     Rugged::Credentials::SshKey.new(:username => user, :privatekey => private_key)
+  end
+
+  def get_plaintext_credentials(url, username_from_url)
+    user = get_git_username(url, username_from_url)
+    password = URI.parse(url).password || ''
+    Rugged::Credentials::UserPassword.new(username: user, password: password)
   end
 
   def get_git_username(url, username_from_url)
@@ -89,13 +110,13 @@ class R10K::Git::Rugged::BaseRepository
 
     if !username_from_url.nil?
       user = username_from_url
-      logger.debug1 "URL #{url.inspect} includes the username #{username_from_url}, using that user for authentication."
+      logger.debug2 "URL #{url.inspect} includes the username #{username_from_url}, using that user for authentication."
     elsif git_user
       user = git_user
-      logger.debug1 "URL #{url.inspect} did not specify a user, using #{user.inspect} from configuration"
+      logger.debug2 "URL #{url.inspect} did not specify a user, using #{user.inspect} from configuration"
     else
       user = Etc.getlogin
-      logger.debug1 "URL #{url.inspect} did not specify a user, using current user #{user.inspect}"
+      logger.debug2 "URL #{url.inspect} did not specify a user, using current user #{user.inspect}"
     end
 
     user

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -5,6 +5,10 @@ class R10K::Git::Rugged::BaseRepository
 
   include R10K::Logging
 
+  # @return [Pathname] The path to this repository.
+  # @note The `@path` instance variable must be set by inheriting classes on instantiation.
+  attr_reader :path
+
   def resolve(pattern)
     object = with_repo { |repo| repo.rev_parse(pattern) }
     case object

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -1,4 +1,5 @@
 require 'r10k/git/rugged'
+require 'r10k/git/rugged/credentials'
 require 'r10k/logging'
 
 class R10K::Git::Rugged::BaseRepository
@@ -65,64 +66,11 @@ class R10K::Git::Rugged::BaseRepository
   #
   # @return [Proc]
   def credentials
-    Proc.new do |url, username_from_url, allowed_types|
-      if allowed_types.include?(:ssh_key)
-        get_ssh_key_credentials(url, username_from_url)
-      elsif allowed_types.include?(:plaintext)
-        get_plaintext_credentials(url, username_from_url)
-      else
-        get_default_credentials(url, username_from_url)
-      end
-    end
+    R10K::Git::Rugged::Credentials.new(self)
   end
 
   def report_transfer(results, remote)
     logger.debug2 { "Transferred #{results[:total_objects]} objects (#{results[:received_bytes]} bytes) from '#{remote}' into #{git_dir}'" }
     nil
-  end
-
-  def get_plaintext_credentials(url, username_from_url)
-    user = get_git_username(url, username_from_url)
-    password = URI.parse(url).password || ''
-
-    Rugged::Credentials::Plaintext.new(:username => user, :password => password)
-  end
-
-  def get_ssh_key_credentials(url, username_from_url)
-    user = get_git_username(url, username_from_url)
-    private_key = R10K::Git.settings[:private_key]
-
-    if private_key
-      logger.debug2 "Using SSH private key #{private_key.inspect}"
-    else
-      raise R10K::Git::GitError.new("Git remote #{url.inspect} uses the SSH protocol but no private key was given", :git_dir => @path.to_s)
-    end
-
-    Rugged::Credentials::SshKey.new(:username => user, :privatekey => private_key)
-  end
-
-  def get_plaintext_credentials(url, username_from_url)
-    user = get_git_username(url, username_from_url)
-    password = URI.parse(url).password || ''
-    Rugged::Credentials::UserPassword.new(username: user, password: password)
-  end
-
-  def get_git_username(url, username_from_url)
-    git_user = R10K::Git.settings[:username]
-
-    user = nil
-
-    if !username_from_url.nil?
-      user = username_from_url
-      logger.debug2 "URL #{url.inspect} includes the username #{username_from_url}, using that user for authentication."
-    elsif git_user
-      user = git_user
-      logger.debug2 "URL #{url.inspect} did not specify a user, using #{user.inspect} from configuration"
-    else
-      user = Etc.getlogin
-      logger.debug2 "URL #{url.inspect} did not specify a user, using current user #{user.inspect}"
-    end
-
-    user
   end
 end

--- a/lib/r10k/git/rugged/credentials.rb
+++ b/lib/r10k/git/rugged/credentials.rb
@@ -1,0 +1,66 @@
+require 'r10k/git/rugged'
+require 'r10k/git/errors'
+require 'r10k/logging'
+
+# Generate credentials for secured remote connections.
+#
+# @api private
+class R10K::Git::Rugged::Credentials
+
+  include R10K::Logging
+
+  # @param repository [R10K::Git::Rugged::BaseRepository]
+  def initialize(repository)
+    @repository = repository
+  end
+
+  def call(url, username_from_url, allowed_types)
+    if allowed_types.include?(:ssh_key)
+      get_ssh_key_credentials(url, username_from_url)
+    elsif allowed_types.include?(:plaintext)
+      get_plaintext_credentials(url, username_from_url)
+    else
+      get_default_credentials(url, username_from_url)
+    end
+  end
+
+  def get_ssh_key_credentials(url, username_from_url)
+    user = get_git_username(url, username_from_url)
+    private_key = R10K::Git.settings[:private_key]
+
+    if private_key.nil?
+      raise R10K::Git::GitError.new("Git remote #{url.inspect} uses the SSH protocol but no private key was given", :git_dir => @repository.path.to_s)
+    end
+
+    Rugged::Credentials::SshKey.new(:username => user, :privatekey => private_key)
+  end
+
+  def get_plaintext_credentials(url, username_from_url)
+    user = get_git_username(url, username_from_url)
+    password = URI.parse(url).password || ''
+    Rugged::Credentials::UserPassword.new(username: user, password: password)
+  end
+
+  def get_default_credentials(url, username_from_url)
+    Rugged::Credentials::Default.new
+  end
+
+  def get_git_username(url, username_from_url)
+    git_user = R10K::Git.settings[:username]
+
+    user = nil
+
+    if !username_from_url.nil?
+      user = username_from_url
+      logger.debug2 "URL #{url.inspect} includes the username #{username_from_url}, using that user for authentication."
+    elsif git_user
+      user = git_user
+      logger.debug2 "URL #{url.inspect} did not specify a user, using #{user.inspect} from configuration"
+    else
+      user = Etc.getlogin
+      logger.debug2 "URL #{url.inspect} did not specify a user, using current user #{user.inspect}"
+    end
+
+    user
+  end
+end

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -4,9 +4,6 @@ require 'r10k/git/errors'
 
 class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
 
-  #  @return [Pathname] The path to this directory
-  attr_reader :path
-
   # @return [Pathname] The path to the Git repository inside of this directory
   def git_dir
     @path + '.git'

--- a/spec/unit/git/rugged/credentials_spec.rb
+++ b/spec/unit/git/rugged/credentials_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'r10k/git/rugged/credentials'
+require 'rugged/credentials'
+
+describe R10K::Git::Rugged::Credentials do
+
+  let(:repo) { R10K::Git::Rugged::BareRepository.new("/some/nonexistent/path", "repo.git") }
+
+  subject { described_class.new(repo) }
+
+  after(:all) { R10K::Git.settings.reset! }
+
+  describe "determining the username" do
+    before { R10K::Git.settings[:username] = "moderns" }
+    after { R10K::Git.settings.reset! }
+
+    it "prefers a username from the URL" do
+      user = subject.get_git_username("https://tessier-ashpool.freeside/repo.git", "ashpool")
+      expect(user).to eq "ashpool"
+    end
+
+    it "uses the username from the Git config when specified" do
+      user = subject.get_git_username("https://tessier-ashpool.freeside/repo.git", nil)
+      expect(user).to eq "moderns"
+    end
+
+    it "falls back to the current user" do
+      R10K::Git.settings.reset!
+      expect(Etc).to receive(:getlogin).and_return("finn")
+      user = subject.get_git_username("https://tessier-ashpool.freeside/repo.git", nil)
+      expect(user).to eq "finn"
+    end
+  end
+
+  describe "generating ssh key credentials" do
+    after { R10K::Git.settings.reset! }
+
+    it "raises an error if no key has been set" do
+      R10K::Git.settings[:private_key] = nil
+      expect {
+        subject.get_ssh_key_credentials("https://tessier-ashpool.freeside/repo.git", nil)
+      }.to raise_error(R10K::Git::GitError, /no private key was given/)
+    end
+
+    it "generates the rugged sshkey credential type" do
+      R10K::Git.settings[:private_key] = "/some/nonexistent/.ssh/key"
+      creds = subject.get_ssh_key_credentials("https://tessier-ashpool.freeside/repo.git", nil)
+      expect(creds).to be_a_kind_of(Rugged::Credentials::SshKey)
+      expect(creds.instance_variable_get(:@privatekey)).to eq("/some/nonexistent/.ssh/key")
+    end
+  end
+
+  describe "generating default credentials" do
+    it "generates the rugged default credential type" do
+      creds = subject.get_default_credentials("https://azurediamond:hunter2@tessier-ashpool.freeside/repo.git", "azurediamond")
+      expect(creds).to be_a_kind_of(Rugged::Credentials::Default)
+    end
+  end
+
+  describe "generating credentials" do
+    it "creates ssh key credentials for the sshkey allowed type" do
+      R10K::Git.settings[:private_key] = "/some/nonexistent/.ssh/key"
+      expect(subject.call("https://tessier-ashpool.freeside/repo.git", nil, [:ssh_key])).to be_a_kind_of(Rugged::Credentials::SshKey)
+    end
+
+    it "creates user/password credentials for the default allowed type" do
+      expect(subject.call("https://tessier-ashpool.freeside/repo.git", nil, [:plaintext])).to be_a_kind_of(Rugged::Credentials::UserPassword)
+    end
+
+    it "creates default credentials when no other types are allowed" do
+      expect(subject.call("https://tessier-ashpool.freeside/repo.git", nil, [])).to be_a_kind_of(Rugged::Credentials::Default)
+    end
+  end
+end


### PR DESCRIPTION
Previously, r10k would always supply SSH key based authentication credentials when authentication was requested, which would fail poorly when a HTTPS based URL required authentication. This refactors and extracts the logic for supplying credentials to Rugged and adds support for user/password based authentication.
