### PR TITLE
(refactor) Remove boilerplate and deduplicate code in actions

### DIFF
--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -1,0 +1,28 @@
+require 'r10k/util/setopts'
+require 'r10k/logging'
+
+module R10K
+  module Action
+    class Base
+
+      include R10K::Logging
+      include R10K::Util::Setopts
+
+      def initialize(opts, argv)
+        @opts = opts
+        @argv = argv
+
+        setopts(opts, allowed_initialize_opts)
+      end
+
+      private
+
+      def allowed_initialize_opts
+        {
+          :config => true,
+          :trace  => true,
+        }
+      end
+    end
+  end
+end

--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -1,30 +1,10 @@
-require 'r10k/util/setopts'
 require 'r10k/deployment'
-require 'r10k/logging'
+require 'r10k/action/base'
 
 module R10K
   module Action
     module Deploy
-      class Display
-
-        include R10K::Util::Setopts
-        include R10K::Logging
-
-        def initialize(opts, argv)
-          @opts = opts
-          @argv = argv
-          setopts(opts, {
-            :config     => :self,
-            :puppetfile => :self,
-            :detail     => :self,
-            :format     => :self,
-            :fetch      => :self,
-            :trace      => :self
-          })
-
-          @level  = 4
-          @indent = 0
-        end
+      class Display < R10K::Action::Base
 
         def call
           deployment = R10K::Deployment.load_config(@config)
@@ -91,6 +71,10 @@ module R10K
           else
             mod.title
           end
+        end
+
+        def allowed_initialize_opts
+          super.merge(puppetfile: :self, detail: :self, format: :self, fetch: :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -2,29 +2,20 @@ require 'r10k/util/setopts'
 require 'r10k/deployment'
 require 'r10k/logging'
 require 'r10k/action/visitor'
+require 'r10k/action/base'
 require 'r10k/deployment/write_lock'
 require 'json'
 
 module R10K
   module Action
     module Deploy
-      class Environment
+      class Environment < R10K::Action::Base
 
-        include R10K::Util::Setopts
-        include R10K::Logging
         include R10K::Deployment::WriteLock
 
         def initialize(opts, argv)
-          @opts = opts
-          @argv = argv.map { |arg| arg.gsub(/\W/,'_') }
-          setopts(opts, {
-            :config     => :self,
-            :cachedir   => :self,
-            :puppetfile => :self,
-            :purge      => :self,
-            :trace      => :self
-          })
-
+          super
+          @argv = @argv.map { |arg| arg.gsub(/\W/,'_') }
           @purge = true
         end
 
@@ -111,6 +102,10 @@ module R10K
 
             f.puts(JSON.pretty_generate(deploy_info))
           end
+        end
+
+        def allowed_initialize_opts
+          super.merge(puppetfile: :self, cachedir: :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -1,29 +1,14 @@
-require 'r10k/util/setopts'
 require 'r10k/deployment'
 require 'r10k/action/visitor'
-require 'r10k/logging'
+require 'r10k/action/base'
 require 'r10k/deployment/write_lock'
 
 module R10K
   module Action
     module Deploy
-      class Module
+      class Module < R10K::Action::Base
 
-        include R10K::Logging
-        include R10K::Util::Setopts
         include R10K::Deployment::WriteLock
-
-        def initialize(opts, argv)
-          @opts = opts
-          @argv = argv
-          setopts(opts, {
-            :config      => :self,
-            :environment => nil,
-            :trace       => :self
-          })
-
-          @purge = true
-        end
 
         def call
           @visit_ok = true
@@ -68,6 +53,10 @@ module R10K
           else
             logger.debug1("Only updating modules #{@argv.inspect}, skipping module #{mod.name}")
           end
+        end
+
+        def allowed_initialize_opts
+          super.merge(environment: true)
         end
       end
     end

--- a/lib/r10k/action/puppetfile/check.rb
+++ b/lib/r10k/action/puppetfile/check.rb
@@ -1,30 +1,14 @@
 require 'r10k/puppetfile'
-require 'r10k/util/setopts'
+require 'r10k/action/base'
 require 'r10k/errors/formatting'
-require 'r10k/logging'
 
 module R10K
   module Action
     module Puppetfile
-      class Check
-        include R10K::Logging
-        include R10K::Util::Setopts
-
-        def initialize(opts, argv)
-          @opts = opts
-          @argv = argv
-
-          setopts(opts, {
-            :root       => :self,
-            :moduledir  => :self,
-            :puppetfile => :path,
-            :trace      => :self,
-          })
-        end
+      class Check < R10K::Action::Base
 
         def call
           pf = R10K::Puppetfile.new(@root, @moduledir, @path)
-
           begin
             pf.load!
             $stderr.puts "Syntax OK"
@@ -33,6 +17,12 @@ module R10K
             $stderr.puts R10K::Errors::Formatting.format_exception(e, @trace)
             false
           end
+        end
+
+        private
+
+        def allowed_initialize_opts
+          super.merge(root: :self, puppetfile: :self, moduledir: :self)
         end
       end
     end

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -1,29 +1,12 @@
 require 'r10k/puppetfile'
-require 'r10k/util/setopts'
 require 'r10k/errors/formatting'
-require 'r10k/logging'
 require 'r10k/action/visitor'
+require 'r10k/action/base'
 
 module R10K
   module Action
     module Puppetfile
-      class Install
-        include R10K::Logging
-        include R10K::Util::Setopts
-
-        def initialize(opts, argv)
-          @opts = opts
-          @argv = argv
-
-          @ok = true
-
-          setopts(opts, {
-            :root       => :self,
-            :moduledir  => :self,
-            :puppetfile => :path,
-            :trace      => :self,
-          })
-        end
+      class Install < R10K::Action::Base
 
         def call
           @visit_ok = true
@@ -45,6 +28,10 @@ module R10K
         def visit_module(mod)
           logger.info "Updating module #{mod.path}"
           mod.sync
+        end
+
+        def allowed_initialize_opts
+          super.merge(root: :self, puppetfile: :self, moduledir: :self)
         end
       end
     end

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -2,6 +2,7 @@ require 'r10k/puppetfile'
 require 'r10k/util/setopts'
 require 'r10k/errors/formatting'
 require 'r10k/logging'
+require 'r10k/action/visitor'
 
 module R10K
   module Action
@@ -25,17 +26,15 @@ module R10K
         end
 
         def call
+          @visit_ok = true
           pf = R10K::Puppetfile.new(@root, @moduledir, @path)
           pf.accept(self)
-          @ok
+          @visit_ok
         end
 
-        def visit(type, other, &block)
-          send("visit_#{type}", other, &block)
-        rescue => e
-          logger.error R10K::Errors::Formatting.format_exception(e, @trace)
-          @ok = false
-        end
+        private
+
+        include R10K::Action::Visitor
 
         def visit_puppetfile(pf)
           pf.load!

--- a/lib/r10k/action/puppetfile/purge.rb
+++ b/lib/r10k/action/puppetfile/purge.rb
@@ -1,26 +1,11 @@
 require 'r10k/puppetfile'
-require 'r10k/util/setopts'
+require 'r10k/action/base'
 require 'r10k/errors/formatting'
-require 'r10k/logging'
 
 module R10K
   module Action
     module Puppetfile
-      class Purge
-        include R10K::Logging
-        include R10K::Util::Setopts
-
-        def initialize(opts, argv)
-          @opts = opts
-          @argv = argv
-
-          setopts(opts, {
-            :root       => :self,
-            :moduledir  => :self,
-            :puppetfile => :path,
-            :trace      => :self,
-          })
-        end
+      class Purge < R10K::Action::Base
 
         def call
           pf = R10K::Puppetfile.new(@root, @moduledir, @path)
@@ -30,6 +15,12 @@ module R10K
         rescue => e
           logger.error R10K::Errors::Formatting.format_exception(e, @trace)
           false
+        end
+
+        private
+
+        def allowed_initialize_opts
+          super.merge(root: :self, puppetfile: :self, moduledir: :self)
         end
       end
     end

--- a/lib/r10k/cli.rb
+++ b/lib/r10k/cli.rb
@@ -35,9 +35,7 @@ module R10K::CLI
 
       flag nil, :color, 'Enable colored log messages'
 
-      required :c, :config, 'Specify a global configuration file (deprecated, use `r10k deploy -c`)' do |value, cmd|
-        logger.warn "Calling `r10k --config <action>` as a global option is deprecated; use r10k <action> --config"
-      end
+      required :c, :config, 'Specify a global configuration file (deprecated, use `r10k deploy -c`)'
 
       run do |opts, args, cmd|
         puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -21,8 +21,6 @@ module R10K::CLI
 (https://puppetlabs.com/blog/git-workflow-and-puppet-environments/).
         DESCRIPTION
 
-        required :c, :config, 'Specify a configuration file'
-
         required nil, :cachedir, 'Specify a cachedir, overriding the value in config'
 
         run do |opts, args, cmd|

--- a/spec/shared-examples/puppetfile-action.rb
+++ b/spec/shared-examples/puppetfile-action.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+shared_examples_for "a puppetfile action" do
+  describe "initializing" do
+    it "accepts the :root option" do
+      described_class.new({root: "/some/nonexistent/path"}, [])
+    end
+
+    it "accepts the :puppetfile option" do
+      described_class.new({puppetfile: "/some/nonexistent/path/Puppetfile"}, [])
+    end
+
+    it "accepts the :moduledir option" do
+      described_class.new({moduledir: "/some/nonexistent/path/modules"}, [])
+    end
+  end
+end

--- a/spec/unit/action/deploy/display_spec.rb
+++ b/spec/unit/action/deploy/display_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+require 'r10k/action/deploy/display'
+
+describe R10K::Action::Deploy::Display do
+  describe "initializing" do
+    it "accepts a puppetfile option" do
+      described_class.new({puppetfile: true}, [])
+    end
+
+    it "accepts a detail option" do
+      described_class.new({detail: true}, [])
+    end
+
+    it "accepts a format option" do
+      described_class.new({format: "json"}, [])
+    end
+
+    it "accepts a fetch option" do
+      described_class.new({fetch: true}, [])
+    end
+  end
+end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -8,4 +8,16 @@ describe R10K::Action::Deploy::Environment do
   subject { described_class.new({}, []) }
 
   it_behaves_like "a deploy action that can be write locked"
+
+  describe "initializing" do
+    it "can accept a cachedir option" do
+      described_class.new({cachedir: "/some/nonexistent/cachedir"}, [])
+    end
+
+    it "can accept a puppetfile option" do
+      described_class.new({puppetfile: true}, [])
+    end
+
+    it "normalizes environment names in the arg vector"
+  end
 end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -7,4 +7,10 @@ describe R10K::Action::Deploy::Module do
   subject { described_class.new({}, []) }
 
   it_behaves_like "a deploy action that can be write locked"
+
+  describe "initializing" do
+    it "accepts an environment option" do
+      described_class.new({environment: "production"}, [])
+    end
+  end
 end

--- a/spec/unit/action/puppetfile/check_spec.rb
+++ b/spec/unit/action/puppetfile/check_spec.rb
@@ -9,6 +9,8 @@ describe R10K::Action::Puppetfile::Check do
 
   before { allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile) }
 
+  it_behaves_like "a puppetfile action"
+
   it "prints 'Syntax OK' when the Puppetfile syntax could be validated" do
     expect(puppetfile).to receive(:load!)
     expect($stderr).to receive(:puts).with("Syntax OK")

--- a/spec/unit/action/puppetfile/check_spec.rb
+++ b/spec/unit/action/puppetfile/check_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'r10k/action/puppetfile/check'
+
+describe R10K::Action::Puppetfile::Check do
+
+  subject { described_class.new({root: "/some/nonexistent/path"}, []) }
+
+  let(:puppetfile) { instance_double('R10K::Puppetfile') }
+
+  before { allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile) }
+
+  it "prints 'Syntax OK' when the Puppetfile syntax could be validated" do
+    expect(puppetfile).to receive(:load!)
+    expect($stderr).to receive(:puts).with("Syntax OK")
+    subject.call
+  end
+
+  it "prints an error message when validating the Puppetfile syntax raised an error" do
+    expect(puppetfile).to receive(:load!).and_raise(R10K::Error.new("Boom!"))
+    expect(R10K::Errors::Formatting).to receive(:format_exception).with(instance_of(R10K::Error), anything).and_return("Formatted error message")
+    expect($stderr).to receive(:puts).with("Formatted error message")
+    subject.call
+  end
+end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -12,6 +12,8 @@ describe R10K::Action::Puppetfile::Install do
     allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
   end
 
+  it_behaves_like "a puppetfile action"
+
   describe "installing modules" do
     let(:modules) do
       Array.new(4, R10K::Module::Base.new('author/modname', "/some/nonexistent/path/modname", nil))

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'r10k/action/puppetfile/install'
+
+describe R10K::Action::Puppetfile::Install do
+
+  subject { described_class.new({root: "/some/nonexistent/path"}, []) }
+
+  let(:puppetfile) { R10K::Puppetfile.new('/some/nonexistent/path', nil, nil) }
+
+
+  before do
+    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
+  end
+
+  describe "installing modules" do
+    let(:modules) do
+      Array.new(4, R10K::Module::Base.new('author/modname', "/some/nonexistent/path/modname", nil))
+    end
+
+    before do
+      allow(puppetfile).to receive(:purge!)
+      allow(puppetfile).to receive(:modules).and_return(modules)
+    end
+
+    it "syncs each module in the Puppetfile" do
+      expect(puppetfile).to receive(:load!)
+      modules.each { |m| expect(m).to receive(:sync) }
+      expect(subject.call).to eq true
+    end
+
+    it "returns false if a module failed to install" do
+      expect(puppetfile).to receive(:load!)
+
+      modules[0..2].each { |m| expect(m).to receive(:sync) }
+      expect(modules[3]).to receive(:sync).and_raise
+      expect(subject.call).to eq false
+    end
+  end
+
+  describe "purging" do
+    before do
+      allow(puppetfile).to receive(:load!)
+      allow(puppetfile).to receive(:modules).and_return([])
+    end
+
+    it "purges the moduledir after installation" do
+      expect(puppetfile).to receive(:purge!)
+      subject.call
+    end
+  end
+end

--- a/spec/unit/action/puppetfile/purge_spec.rb
+++ b/spec/unit/action/puppetfile/purge_spec.rb
@@ -9,6 +9,8 @@ describe R10K::Action::Puppetfile::Purge do
 
   before { allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile) }
 
+  it_behaves_like "a puppetfile action"
+
   it "purges unmanaged entries in the Puppetfile moduledir" do
     allow(puppetfile).to receive(:load!)
     expect(puppetfile).to receive(:purge!)

--- a/spec/unit/action/puppetfile/purge_spec.rb
+++ b/spec/unit/action/puppetfile/purge_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'r10k/action/puppetfile/purge'
+
+describe R10K::Action::Puppetfile::Purge do
+
+  subject { described_class.new({root: "/some/nonexistent/path"}, []) }
+
+  let(:puppetfile) { instance_double('R10K::Puppetfile') }
+
+  before { allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile) }
+
+  it "purges unmanaged entries in the Puppetfile moduledir" do
+    allow(puppetfile).to receive(:load!)
+    expect(puppetfile).to receive(:purge!)
+    subject.call
+  end
+end


### PR DESCRIPTION
There's a lot of boilerplate that's crept into the action classes over time; this commit adds a base class that handles a number of shared concerns. This pull request also adds in tests in areas that were lacking to validate that the refactoring had no adverse affects.
