### PR TITLE
(RK-90) [module/forge] Ensure module metadata is set

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -107,7 +107,7 @@ class R10K::Module::Forge < R10K::Module::Base
 
     # The module is present and has a metadata file, read the metadata to
     # determine the state of the module.
-    @metadata_file.read(@path + 'metadata.json')
+    @metadata = @metadata_file.read(@path + 'metadata.json')
 
     if not @title.tr('/','-') == @metadata.full_module_name.tr('/','-')
 

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -97,6 +97,7 @@ describe R10K::Module::Forge do
     it "is :mismatched if the metadata author doesn't match the expected author" do
       allow(subject).to receive(:exist?).and_return true
 
+      allow(subject.instance_variable_get(:@metadata_file)).to receive(:read).and_return subject.metadata
       allow(subject.metadata).to receive(:full_module_name).and_return 'blargh-blargh'
 
       expect(subject.status).to eq :mismatched
@@ -105,6 +106,7 @@ describe R10K::Module::Forge do
     it "is :outdated if the metadata version doesn't match the expected version" do
       allow(subject).to receive(:exist?).and_return true
 
+      allow(subject.instance_variable_get(:@metadata_file)).to receive(:read).and_return subject.metadata
       allow(subject.metadata).to receive(:version).and_return '7.0.0'
       expect(subject.status).to eq :outdated
     end


### PR DESCRIPTION
In certain cases, trying to determine the status of a Forge module would
try to access metadata that had not been set. This usually happened when
the Forge object was created before the module had been created, and #status
was called after the module was created. In this case the metadata would
not be properly set and checking the status of the module would raise an
exception.

This commit properly updates the metadata instance variable so that r10k
doesn't fail hard in the described scenario.
