### PR TITLE
(RK-21) Treat missing deployed environments as an error

### DIFF
--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -98,8 +98,8 @@ module R10K
 
     def accept(visitor)
       visitor.visit(:deployment, self) do
-        sources.each do |env|
-          env.accept(visitor)
+        sources.each do |source|
+          source.accept(visitor)
         end
       end
     end

--- a/spec/r10k-mocks/mock_env.rb
+++ b/spec/r10k-mocks/mock_env.rb
@@ -4,4 +4,12 @@ class R10K::Environment::Mock < R10K::Environment::Base
   def sync
     "synced"
   end
+
+  def status
+    :insync
+  end
+
+  def signature
+    "mock"
+  end
 end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -20,4 +20,36 @@ describe R10K::Action::Deploy::Environment do
 
     it "normalizes environment names in the arg vector"
   end
+
+  describe "when called" do
+    describe "with an environment that doesn't exist" do
+      let(:config) do
+        R10K::Deployment::MockConfig.new(
+          :sources => {
+            :control => {
+              :type => :mock,
+              :basedir => '/some/nonexistent/path/control',
+              :environments => %w[first second third],
+            }
+          }
+        )
+      end
+
+      let(:deployment) do
+        R10K::Deployment.new(config)
+      end
+
+      before do
+        expect(R10K::Deployment).to receive(:load_config).and_return(deployment)
+      end
+
+      subject { described_class.new({purge: false}, %w[not_an_environment]) }
+
+      it "logs that the environments can't be deployed and returns false" do
+        expect(subject.logger).to receive(:error).with("Environment(s) 'not_an_environment' cannot be found in any source and will not be deployed.")
+        logger = subject.logger
+        expect(subject.call).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds checking to r10k to ensure that if environments are supplied to the `r10k deploy environment` command, r10k ensures they're present, logs an error if any are missing, and exits with a non-zero exit code when environments are missing.
