### PR TITLE
(RK-175) [rugged] Don't check out unresolvable refs

### DIFF
--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -59,8 +59,13 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   # @param ref [String] The git reference to check out
   # @return [void]
   def checkout(ref)
-    logger.debug1 { "Checking out ref '#{ref}' at #{@path}" }
     sha = resolve(ref)
+
+    if sha
+      logger.debug2 { "Checking out ref '#{ref}' (resolved to SHA '#{sha}') in repository #{@path}" }
+    else
+      raise R10K::Git::GitError.new("Unable to check out unresolvable ref '#{ref}'", git_dir: git_dir)
+    end
 
     with_repo do |repo|
       repo.checkout(sha)

--- a/spec/integration/git/rugged/working_repository_spec.rb
+++ b/spec/integration/git/rugged/working_repository_spec.rb
@@ -10,4 +10,13 @@ describe R10K::Git::Rugged::WorkingRepository, :if => R10K::Features.available?(
 
   it_behaves_like 'a git repository'
   it_behaves_like 'a git working repository'
+
+  describe "checking out an unresolvable ref" do
+    it "raises an error indicating that the ref was unresolvable" do
+      expect(subject).to receive(:resolve).with("unresolvable")
+      expect {
+        subject.checkout("unresolvable")
+      }.to raise_error(R10K::Git::GitError, /Unable to check out unresolvable ref 'unresolvable'/)
+    end
+  end
 end


### PR DESCRIPTION
The rugged working repository always tried to resolve a Git ref to a SHA
when checking out a ref, but while the shellgit implementation could
rely on the underlying git binary to report meaningful errors the rugged
implementation had no such fallback check. This could lead to r10k
trying to check out 'nil' when an unresolvable ref was given, which
would raise an ArgumentError. This commit adds an explicit check for
unresolvable refs and raises a meaningful error instead of an
ArgumentError.
