### PR TITLE
More specific failure for argument error

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -51,7 +51,7 @@ class Puppetfile
   def load!
     dsl = R10K::Puppetfile::DSL.new(self)
     dsl.instance_eval(puppetfile_contents, @puppetfile_path)
-  rescue SyntaxError, LoadError => e
+  rescue SyntaxError, LoadError, ArgumentError => e
     raise R10K::Error.wrap(e, "Failed to evaluate #{@puppetfile_path}")
   end
 

--- a/spec/fixtures/unit/puppetfile/argument-error/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/argument-error/Puppetfile
@@ -1,0 +1,1 @@
+mod 'branan/eight_hundred', '1.0.0', :git => 'https://github.com/branan/eight_hundred', :ref => 'master'

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -55,6 +55,17 @@ describe R10K::Puppetfile do
         expect_wrapped_error(e, pf_path, LoadError)
       end
     end
+
+    it "wraps and re-raises argument errors" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'argument-error')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect {
+        subject.load!
+      }.to raise_error do |e|
+        expect_wrapped_error(e, pf_path, ArgumentError)
+      end
+    end
   end
 
   describe "accepting a visitor" do


### PR DESCRIPTION
If someone were to provide more than two arguments in a Puppetfile, not that I would ever do that :eyes:, then `r10k puppetfile check` wouldn't output a very helpful error message.

Make this error a little bit more informative by wrapping it.
