### PR TITLE
(RK-120) Allow all commands/actions to use --config

### DIFF
--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -8,6 +8,8 @@ module R10K
       include R10K::Logging
       include R10K::Util::Setopts
 
+      attr_accessor :settings
+
       def initialize(opts, argv, settings = {})
         @opts = opts
         @argv = argv

--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -8,9 +8,10 @@ module R10K
       include R10K::Logging
       include R10K::Util::Setopts
 
-      def initialize(opts, argv)
+      def initialize(opts, argv, settings = {})
         @opts = opts
         @argv = argv
+        @settings = settings
 
         setopts(opts, allowed_initialize_opts)
       end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -13,7 +13,7 @@ module R10K
 
         include R10K::Deployment::WriteLock
 
-        def initialize(opts, argv)
+        def initialize(opts, argv, settings = {})
           @purge = true
           super
           @argv = @argv.map { |arg| arg.gsub(/\W/,'_') }

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -22,7 +22,7 @@ module R10K
         def call
           @visit_ok = true
 
-          deployment = R10K::Deployment.load_config(@config, :cachedir => @cachedir)
+          deployment = R10K::Deployment.new(@settings)
           check_write_lock!(@settings)
 
           deployment.accept(self)

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -23,7 +23,7 @@ module R10K
           @visit_ok = true
 
           deployment = R10K::Deployment.load_config(@config, :cachedir => @cachedir)
-          check_write_lock!(deployment.config.settings)
+          check_write_lock!(@settings)
 
           deployment.accept(self)
           @visit_ok
@@ -52,7 +52,7 @@ module R10K
           deployment.purge! if @purge
 
         ensure
-          if (postcmd = deployment.config.setting(:postrun))
+          if (postcmd = @settings[:postrun])
             subproc = R10K::Util::Subprocess.new(postcmd)
             subproc.logger = logger
             subproc.execute

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -14,7 +14,7 @@ module R10K
           @visit_ok = true
 
           deployment = R10K::Deployment.load_config(@config)
-          check_write_lock!(deployment.config.settings)
+          check_write_lock!(@settings)
 
           deployment.accept(self)
           @visit_ok

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -13,7 +13,7 @@ module R10K
         def call
           @visit_ok = true
 
-          deployment = R10K::Deployment.load_config(@config)
+          deployment = R10K::Deployment.new(@settings)
           check_write_lock!(@settings)
 
           deployment.accept(self)

--- a/lib/r10k/cli.rb
+++ b/lib/r10k/cli.rb
@@ -35,7 +35,7 @@ module R10K::CLI
 
       flag nil, :color, 'Enable colored log messages'
 
-      required :c, :config, 'Specify a global configuration file (deprecated, use `r10k deploy -c`)'
+      required :c, :config, 'Specify a global configuration file'
 
       run do |opts, args, cmd|
         puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -107,9 +107,9 @@ module R10K
     private
 
     def load_sources
-      sources = @config.setting(:sources)
+      sources = @config[:sources]
       if sources.nil? || sources.empty?
-        raise R10K::Error, "'sources' key in #{@config.configfile} missing or empty."
+        raise R10K::Error, "Unable to load sources; the supplied configuration does not define the 'sources' key"
       end
       @_sources = sources.map do |(name, hash)|
         R10K::Source.from_hash(name, hash)

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -15,6 +15,8 @@ module R10K
 
     # Generate a deployment object based on a config
     #
+    # @deprecated
+    #
     # @param path [String] The path to the deployment config
     # @return [R10K::Deployment] The deployment loaded with the given config
     def self.load_config(path, overrides={})

--- a/lib/r10k/deployment/config.rb
+++ b/lib/r10k/deployment/config.rb
@@ -25,6 +25,8 @@ class Config
     @config[key]
   end
 
+  alias [] setting
+
   def settings
     @config
   end

--- a/lib/r10k/deployment/write_lock.rb
+++ b/lib/r10k/deployment/write_lock.rb
@@ -11,7 +11,7 @@ module R10K
       #
       # @raise [SystemExit] if the deploy write_lock setting has been set
       def check_write_lock!(config)
-        write_lock = config[:deploy][:write_lock]
+        write_lock = config.fetch(:deploy, {})[:write_lock]
         if write_lock
           logger.fatal("Making changes to deployed environments has been administratively disabled.")
           logger.fatal("Reason: #{write_lock}")

--- a/spec/r10k-mocks/mock_config.rb
+++ b/spec/r10k-mocks/mock_config.rb
@@ -19,6 +19,8 @@ module R10K
         @hash[key]
       end
 
+      alias [] setting
+
       def settings
         @hash
       end

--- a/spec/shared-examples/deploy_write_lock.rb
+++ b/spec/shared-examples/deploy_write_lock.rb
@@ -38,7 +38,7 @@ shared_examples_for "a deploy action that can be write locked" do
 
     describe "set" do
       before do
-        config.hash[:deploy][:write_lock] = "Disabled, yo"
+        subject.settings = {deploy: {write_lock: "Disabled, yo"}}
       end
 
       it "exits without running" do

--- a/spec/shared-examples/deploy_write_lock.rb
+++ b/spec/shared-examples/deploy_write_lock.rb
@@ -24,7 +24,7 @@ shared_examples_for "a deploy action that can be write locked" do
   let(:deployment) { R10K::Deployment.new(config) }
 
   before do
-    allow(R10K::Deployment).to receive(:load_config).and_return(deployment)
+    allow(R10K::Deployment).to receive(:new).and_return(deployment)
   end
 
   describe "when the write lock is" do

--- a/spec/unit/action/cri_runner_spec.rb
+++ b/spec/unit/action/cri_runner_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'r10k/action/base'
 require 'r10k/action/cri_runner'
 
 describe R10K::Action::CriRunner do
@@ -8,9 +9,10 @@ describe R10K::Action::CriRunner do
       attr_reader :opts
       attr_reader :argv
 
-      def initialize(opts, argv)
+      def initialize(opts, argv, settings = {})
         @opts = opts
         @argv = argv
+        @settings = {}
       end
 
       def call

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -40,7 +40,7 @@ describe R10K::Action::Deploy::Environment do
       end
 
       before do
-        expect(R10K::Deployment).to receive(:load_config).and_return(deployment)
+        expect(R10K::Deployment).to receive(:new).and_return(deployment)
       end
 
       subject { described_class.new({purge: false}, %w[not_an_environment]) }

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
-require 'r10k/action/runner'
+require 'r10k/action/base'
 require 'puppet_forge/connection'
 
+require 'r10k/action/runner'
 
 describe R10K::Action::Runner do
 
@@ -10,9 +11,10 @@ describe R10K::Action::Runner do
       attr_reader :opts
       attr_reader :argv
 
-      def initialize(opts, argv)
+      def initialize(opts, argv, settings = {})
         @opts = opts
         @argv = argv
+        @settings = {}
       end
 
       def call
@@ -50,6 +52,11 @@ describe R10K::Action::Runner do
       runner.call
     end
 
+    it "configures forge authorization" do
+      expect(runner).to receive(:setup_authorization)
+      runner.call
+    end
+
     it "returns the result of the wrapped class #call method" do
       expect(runner.call).to eq %w[ARGS YES]
     end
@@ -65,13 +72,6 @@ describe R10K::Action::Runner do
     it "does not modify the loglevel if :loglevel is not provided" do
       expect(R10K::Logging).to_not receive(:level=)
       runner.call
-    end
-  end
-
-  describe "configuring settings" do
-    it "configures authorization" do
-      expect(runner).to receive(:setup_authorization)
-      runner.setup_settings
     end
   end
 

--- a/spec/unit/deployment_spec.rb
+++ b/spec/unit/deployment_spec.rb
@@ -155,7 +155,7 @@ describe R10K::Deployment, "checking the 'sources' key" do
       it "raises an error when enumerating sources" do
         expect {
           deployment.sources
-        }.to raise_error(R10K::Error, "'sources' key in /some/nonexistent/config_file missing or empty.")
+        }.to raise_error(R10K::Error, "Unable to load sources; the supplied configuration does not define the 'sources' key")
       end
     end
   end


### PR DESCRIPTION
This pull request moves config loading/reading to the application startup so that all r10k subcommands can specify a config.
