### PR TITLE
(RK-174) Always sync alternates file when touching thin repos

### DIFF
--- a/lib/r10k/git/alternates.rb
+++ b/lib/r10k/git/alternates.rb
@@ -12,21 +12,34 @@ class R10K::Git::Alternates
   # @param git_dir [Pathname] The path to the git repository
   def initialize(git_dir)
     @file = git_dir + File.join('objects', 'info', 'alternates')
+    @entries = []
   end
 
-  def to_a
-    read()
-  end
-
-  def <<(path)
+  def add(path)
     write(to_a << path)
+  end
+  alias << add
+
+  # Conditionally add path to the alternates file
+  #
+  # @param path [String] The file path to add to the file if not already present
+  # @return [true, false] If the entry was added.
+  def add?(path)
+    paths = read()
+
+    add_entry = !paths.include?(path)
+
+    if add_entry
+      paths << path
+      write(paths)
+    end
+
+    add_entry
   end
 
   def include?(path)
     to_a.include?(path)
   end
-
-  private
 
   def write(entries)
     if ! @file.parent.directory?
@@ -46,4 +59,5 @@ class R10K::Git::Alternates
     end
     entries
   end
+  alias to_a read
 end

--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -46,7 +46,7 @@ class R10K::Git::Cache
 
   extend Forwardable
 
-  def_delegators :@repo, :git_dir, :branches, :tags, :exist?, :resolve, :ref_type
+  def_delegators :@repo, :git_dir, :objects_dir, :branches, :tags, :exist?, :resolve, :ref_type
 
   # @!attribute [r] path
   #   @deprecated

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -19,6 +19,11 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     @path
   end
 
+  # @return [Pathname] The path to the objects directory in this Git repository
+  def objects_dir
+    @path + "objects"
+  end
+
   # Clone the given remote.
   #
   # This should only be called if the repository does not exist.

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -60,4 +60,18 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
   def cache
     with_repo { |repo| repo.config['remote.cache.url'] }
   end
+
+  private
+
+  # Override the parent class repo setup so that we can make sure the alternates file is up to date
+  # before we create the Rugged::Repository object, which reads from the alternates file.
+  def setup_rugged_repo
+    if git_dir.exist?
+      entry_added = alternates.add?(@cache_repo.objects_dir.to_s)
+      if entry_added
+        logger.debug2 { "Updated repo #{@path} to include alternate object db path #{@cache_repo.objects_dir}" }
+      end
+    end
+    super
+  end
 end

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -24,7 +24,7 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
     set_cache(remote)
     @cache_repo.sync
 
-    objectpath = (@cache_repo.git_dir + 'objects').to_s
+    cache_objects_dir = @cache_repo.objects_dir.to_s
 
     # {Rugged::Repository.clone_at} doesn't support :alternates, which
     # completely breaks how thin repositories need to work. To circumvent
@@ -33,8 +33,8 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
     # fetch any objects because we don't need them, and we don't actually
     # use any refs in this repository so we skip all those steps.
     ::Rugged::Repository.init_at(@path.to_s, false)
-    @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [objectpath])
-    alternates << objectpath
+    @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [cache_objects_dir])
+    alternates << cache_objects_dir
 
     with_repo do |repo|
       config = repo.config

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -3,12 +3,10 @@ require 'r10k/git/rugged/working_repository'
 require 'r10k/git/rugged/cache'
 
 class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
-  def initialize(basedir, dirname)
-    super
+  def initialize(basedir, dirname, cache_repo)
+    @cache_repo = cache_repo
 
-    if exist? && origin
-      set_cache(origin)
-    end
+    super(basedir, dirname)
   end
 
   # Clone this git repository
@@ -21,7 +19,6 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
   # @return [void]
   def clone(remote, opts = {})
     logger.debug1 { "Cloning '#{remote}' into #{@path}" }
-    set_cache(remote)
     @cache_repo.sync
 
     cache_objects_dir = @cache_repo.objects_dir.to_s
@@ -62,11 +59,5 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
   # @return [String] The cache remote URL
   def cache
     with_repo { |repo| repo.config['remote.cache.url'] }
-  end
-
-  private
-
-  def set_cache(remote)
-    @cache_repo = R10K::Git::Rugged::Cache.generate(remote)
   end
 end

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -13,9 +13,7 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   # @param dirname [String] The directory name of the Git repository
   def initialize(basedir, dirname)
     @path = Pathname.new(File.join(basedir, dirname))
-    if exist? && git_dir.exist?
-      @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => alternates.to_a)
-    end
+    setup_rugged_repo
   end
 
   # Clone this git repository
@@ -97,5 +95,13 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
 
   def origin
     with_repo { |repo| repo.config['remote.origin.url'] }
+  end
+
+  private
+
+  def setup_rugged_repo
+    if exist? && git_dir.exist?
+      @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => alternates.to_a)
+    end
   end
 end

--- a/lib/r10k/git/shellgit/bare_repository.rb
+++ b/lib/r10k/git/shellgit/bare_repository.rb
@@ -4,15 +4,20 @@ require 'r10k/git/shellgit/base_repository'
 # Create and manage Git bare repositories.
 class R10K::Git::ShellGit::BareRepository < R10K::Git::ShellGit::BaseRepository
 
+  # @param basedir [String] The base directory of the Git repository
+  # @param dirname [String] The directory name of the Git repository
+  def initialize(basedir, dirname)
+    @path = Pathname.new(File.join(basedir, dirname))
+  end
+
   # @return [Pathname] The path to this Git repository
   def git_dir
     @path
   end
 
-  # @param basedir [String] The base directory of the Git repository
-  # @param dirname [String] The directory name of the Git repository
-  def initialize(basedir, dirname)
-    @path = Pathname.new(File.join(basedir, dirname))
+  # @return [Pathname] The path to the objects directory in this Git repository
+  def objects_dir
+    @path + "objects"
   end
 
   def clone(remote)

--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -11,6 +11,12 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
   def initialize(basedir, dirname, cache_repo)
     @cache_repo = cache_repo
     super(basedir, dirname)
+    if git_dir.exist?
+      entry_added = alternates.add?(@cache_repo.objects_dir.to_s)
+      if entry_added
+        logger.debug2 { "Updated repo #{@path} to include alternate object db path #{@cache_repo.objects_dir}" }
+      end
+    end
   end
 
   # Clone this git repository

--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -8,12 +8,9 @@ require 'r10k/git/shellgit/working_repository'
 # making new clones very lightweight.
 class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingRepository
 
-  def initialize(basedir, dirname)
-    super
-
-    if exist? && origin
-      set_cache(origin)
-    end
+  def initialize(basedir, dirname, cache_repo)
+    @cache_repo = cache_repo
+    super(basedir, dirname)
   end
 
   # Clone this git repository
@@ -26,7 +23,6 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
   # @return [void]
   def clone(remote, opts = {})
     # todo check if opts[:reference] is set
-    set_cache(remote)
     @cache_repo.sync
 
     super(remote, opts.merge(:reference => @cache_repo.git_dir.to_s))
@@ -44,10 +40,6 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
   end
 
   private
-
-  def set_cache(remote)
-    @cache_repo = R10K::Git::ShellGit::Cache.generate(remote)
-  end
 
   def setup_cache_remote
     git ["remote", "add", "cache", @cache_repo.git_dir.to_s], :path => @path.to_s

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -25,8 +25,8 @@ class R10K::Git::StatefulRepository
     @ref = ref
     @remote = remote
 
-    @repo = R10K::Git.thin_repository.new(basedir, dirname)
     @cache = R10K::Git.cache.generate(remote)
+    @repo = R10K::Git.thin_repository.new(basedir, dirname, @cache)
   end
 
   def sync

--- a/spec/integration/git/rugged/thin_repository_spec.rb
+++ b/spec/integration/git/rugged/thin_repository_spec.rb
@@ -6,9 +6,9 @@ describe R10K::Git::Rugged::ThinRepository, :if => R10K::Features.available?(:ru
 
   let(:dirname) { 'working-repo' }
 
-  subject { described_class.new(basedir, dirname) }
-
   let(:cacherepo) { R10K::Git::Rugged::Cache.generate(remote) }
+
+  subject { described_class.new(basedir, dirname, cacherepo) }
 
   it_behaves_like "a git thin repository"
 end

--- a/spec/integration/git/shellgit/thin_repository_spec.rb
+++ b/spec/integration/git/shellgit/thin_repository_spec.rb
@@ -6,9 +6,9 @@ describe R10K::Git::ShellGit::ThinRepository do
 
   let(:dirname) { 'working-repo' }
 
-  subject { described_class.new(basedir, dirname) }
-
   let(:cacherepo) { R10K::Git::ShellGit::Cache.generate(remote) }
+
+  subject { described_class.new(basedir, dirname, cacherepo) }
 
   it_behaves_like "a git thin repository"
 end

--- a/spec/integration/git/stateful_repository_spec.rb
+++ b/spec/integration/git/stateful_repository_spec.rb
@@ -7,8 +7,8 @@ describe R10K::Git::StatefulRepository do
 
   let(:dirname) { 'working-repo' }
 
-  let(:thinrepo) { R10K::Git.thin_repository.new(basedir, dirname) }
   let(:cacherepo) { R10K::Git.cache.generate(remote) }
+  let(:thinrepo) { R10K::Git.thin_repository.new(basedir, dirname, cacherepo) }
 
   subject { described_class.new('0.9.x', remote, basedir, dirname) }
 

--- a/spec/unit/git/alternates_spec.rb
+++ b/spec/unit/git/alternates_spec.rb
@@ -17,7 +17,7 @@ describe R10K::Git::Alternates do
         "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git\n",
       ])
 
-      expect(subject.to_a).to eq([
+      expect(subject.read).to eq([
         "/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
         "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
       ])
@@ -47,11 +47,12 @@ describe R10K::Git::Alternates do
     end
   end
 
-  describe "appending a new alternate object entry" do
+
+  describe "writing alternate entries" do
     describe "and the git objects/info directory does not exist" do
       it "raises an error when the parent directory does not exist" do
         expect {
-          subject << "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"
+          subject.write(["/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
         }.to raise_error(R10K::Git::GitError,"Cannot write /some/nonexistent/path/.git/objects/info/alternates; parent directory does not exist")
       end
     end
@@ -64,20 +65,15 @@ describe R10K::Git::Alternates do
         expect(subject.file).to receive_message_chain(:parent, :directory?).and_return true
       end
 
-
       it "creates the alternates file with the new entry when not present" do
-        expect(subject).to receive(:to_a).and_return([])
-        subject << "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"
-
+        subject.write(["/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
         expect(io.string).to eq("/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git\n")
       end
 
       it "rewrites the file with all alternate entries" do
-        expect(subject).to receive(:to_a).and_return([
-          "/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-          "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-        ])
-        subject << "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"
+        subject.write(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+                       "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+                       "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
 
         expect(io.string).to eq(<<-EOD)
 /var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git
@@ -85,6 +81,36 @@ describe R10K::Git::Alternates do
 /tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git
         EOD
       end
+    end
+
+    describe "appending a new alternate object entry" do
+      it "re-writes the file with the new entry concatenated to the file" do
+        expect(subject).to receive(:to_a).and_return(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+                                                       "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
+
+        expect(subject).to receive(:write).with(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+                                                 "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+                                                 "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
+
+        subject.add("/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")
+      end
+    end
+  end
+
+  describe "conditionally appending a new alternate object entry" do
+    before do
+      expect(subject).to receive(:read).and_return(%w[/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git])
+    end
+
+    it "adds the entry and returns true when the entry doesn't exist" do
+      expect(subject).to receive(:write).with(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+                                               "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
+      expect(subject.add?("/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")).to eq true
+    end
+
+    it "doesn't modify the file and returns false when the entry exists" do
+      expect(subject).to_not receive(:write)
+      expect(subject.add?("/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")).to eq false
     end
   end
 end

--- a/spec/unit/git/cache_spec.rb
+++ b/spec/unit/git/cache_spec.rb
@@ -31,6 +31,10 @@ describe R10K::Git::Cache do
       expect_delegation(:git_dir)
     end
 
+    it "delegates #objects_dir" do
+      expect_delegation(:objects_dir)
+    end
+
     it "delegates #branches" do
       expect_delegation(:branches)
     end


### PR DESCRIPTION
When r10k switches the Git cachedir, it will try to associate existing thin repositories with a new cached repo, but doesn't properly update the alternates file, which means that it will ignore the new cache directory. This can lead to situations where the repos in the new cache directory are updated but existing thin repositories are referencing Git repositories that were not updated, and are missing objects that only exist in the new cached repo.

This commit changes thin repository creation to check and update the alternates file when needed so that cachedir updates are automatically reflected in referenced object dbs.
