### PR TITLE
[runner] (RK-169) Print validation errors

### DIFF
--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -53,6 +53,9 @@ module R10K
         @settings = R10K::Settings.global_settings.evaluate(with_overrides)
 
         R10K::Initializers::GlobalInitializer.new(@settings).call
+      rescue R10K::Settings::Collection::ValidationError => e
+        logger.error e.format
+        exit(8)
       end
 
       def setup_authorization

--- a/lib/r10k/settings/collection.rb
+++ b/lib/r10k/settings/collection.rb
@@ -63,7 +63,7 @@ module R10K
         end
 
         if !errors.empty?
-          raise ValidationError.new("Validation failures for #{@name}", :errors => errors)
+          raise ValidationError.new("Validation failed for #{@name} settings group", :errors => errors)
         end
       end
 
@@ -84,6 +84,33 @@ module R10K
         def initialize(mesg, options = {})
           super
           @errors = options[:errors]
+        end
+
+        def format
+          struct = []
+          struct << "#{message}:"
+          @errors.each_pair do |name, nested|
+            struct << indent(structure_exception(name, nested))
+          end
+          struct.join("\n")
+        end
+
+        private
+
+        def structure_exception(name, exc)
+          struct = []
+          struct << "#{name}:"
+          if exc.is_a? ValidationError
+            struct << indent(exc.format)
+          else
+            struct << indent(exc.message)
+          end
+          struct.join("\n")
+        end
+
+        def indent(str, level = 4)
+          prefix = ' ' * level
+          str.gsub(/^/, prefix)
         end
       end
     end

--- a/spec/unit/settings/collection_spec.rb
+++ b/spec/unit/settings/collection_spec.rb
@@ -64,3 +64,59 @@ describe R10K::Settings::Collection do
     end
   end
 end
+
+describe R10K::Settings::Collection::ValidationError do
+
+
+  let(:flat_errors) do
+    described_class.new("Validation failures for some group", errors: {
+      some_defn: ArgumentError.new("some_defn is wrong, somehow."),
+      uri_setting: ArgumentError.new("uri_setting NOTAURI is not a URI.")
+    })
+  end
+
+  let(:flat_error_text) do
+    [
+      "Validation failures for some group:",
+      "    some_defn:",
+      "        some_defn is wrong, somehow.",
+      "    uri_setting:",
+      "        uri_setting NOTAURI is not a URI."]
+    .join("\n")
+  end
+
+  let(:nested_errors) do
+    described_class.new("Validation failures for some nesting group", errors: {
+      file_setting: ArgumentError.new("file_setting is a potato, not a file."),
+      nested: flat_errors
+    })
+  end
+
+  let(:nested_error_text) do
+    [
+      "Validation failures for some nesting group:",
+      "    file_setting:",
+      "        file_setting is a potato, not a file.",
+      "    nested:",
+      "        Validation failures for some group:",
+      "            some_defn:",
+      "                some_defn is wrong, somehow.",
+      "            uri_setting:",
+      "                uri_setting NOTAURI is not a URI."
+    ].join("\n")
+  end
+
+  describe "formatting a human readable error message" do
+    describe "no with no nested validation errors" do
+      it "generates a human readable set of validation errors." do
+        expect(flat_errors.format).to eq flat_error_text
+      end
+    end
+
+    describe "with nested validation errors" do
+      it "generates a human readable set of validation errors." do
+        expect(nested_errors.format).to eq nested_error_text
+      end
+    end
+  end
+end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -46,7 +46,7 @@ describe R10K::Settings do
         expect {
           subject.evaluate("proxy" => "that's no proxy!")
         }.to raise_error do |err|
-          expect(err.message).to match(/Validation failures for forge/)
+          expect(err.message).to match(/Validation failed for forge settings group/)
           expect(err.errors.size).to eq 1
           expect(err.errors[:proxy]).to be_a_kind_of(ArgumentError)
           expect(err.errors[:proxy].message).to match(/could not be parsed as a URL/)
@@ -64,7 +64,7 @@ describe R10K::Settings do
         expect {
           subject.evaluate("baseurl" => "that's no forge!")
         }.to raise_error do |err|
-          expect(err.message).to match(/Validation failures for forge/)
+          expect(err.message).to match(/Validation failed for forge settings group/)
           expect(err.errors.size).to eq 1
           expect(err.errors[:baseurl]).to be_a_kind_of(ArgumentError)
           expect(err.errors[:baseurl].message).to match(/could not be parsed as a URL/)
@@ -91,7 +91,7 @@ describe R10K::Settings do
         expect {
           subject.evaluate("write_lock" => %w[list of reasons why deploys are locked])
         }.to raise_error do |err|
-          expect(err.message).to match(/Validation failures for deploy/)
+          expect(err.message).to match(/Validation failed for deploy settings group/)
           expect(err.errors.size).to eq 1
           expect(err.errors[:write_lock]).to be_a_kind_of(ArgumentError)
           expect(err.errors[:write_lock].message).to match(/should be a string containing the reason/)
@@ -126,7 +126,7 @@ describe R10K::Settings do
         expect {
           subject.evaluate("postrun" => "curl -F 'deploy=done' https://reporting.tessier-ashpool.freeside/r10k")
         }.to raise_error do |err|
-          expect(err.message).to match(/Validation failures for global/)
+          expect(err.message).to match(/Validation failed for global settings group/)
           expect(err.errors.size).to eq 1
           expect(err.errors[:postrun]).to be_a_kind_of(ArgumentError)
           expect(err.errors[:postrun].message).to eq("The postrun setting should be an array of strings, not a String")


### PR DESCRIPTION
The settings framework that was added would collect all validation
failures and include them in the validation exception, but there was no
code handling that exception. Because of this, if validation failed the
error message would be "Validation failures for global" which is
entirely useless.

This commit adds a method to the validation error class that will format
the nested validation and support for catching validation errors and
printing out all validation errors.
