### PR TITLE
[deploy/display] (maint) reuse parsed settings

### DIFF
--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -7,7 +7,7 @@ module R10K
       class Display < R10K::Action::Base
 
         def call
-          deployment = R10K::Deployment.load_config(@config)
+          deployment = R10K::Deployment.new(@settings)
 
           if @fetch
             deployment.preload!


### PR DESCRIPTION
The Deploy::Display action didn't get updated to use the already
evaluated settings and was re-reading the config file; this commit
fixes that to avoid re-reading the config file and reuse the evaluated
values.
