### PR TITLE
(RK-154) Add per-repository config

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -68,6 +68,32 @@ git:
 See the [git provider documentation](../git/providers.mkd) for more information
 regarding Git providers.
 
+#### username
+
+The username option sets the username for SSH remotes when the SSH URL does not provide
+a username. When used with a Git hosting service this is most sensibly set to 'git'.
+
+The username defaults to the username of the currently logged in user.
+
+The username setting is only used by the Rugged git provider.
+
+```yaml
+git:
+  username: "git"
+```
+
+#### private_key
+
+The private_key option specifies the path to the default Git SSH private key for Git SSH remotes.
+The private_key setting must be set if SSH remotes are used.
+
+The private_key setting is only used by the Rugged git provider.
+
+```yaml
+git:
+  private_key: "/etc/puppetlabs/r10k/ssh/id_rsa"
+```
+
 ### forge
 
 The 'forge' setting is a hash that contains settings for downloading modules

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -70,12 +70,12 @@ regarding Git providers.
 
 #### username
 
+The username setting is only used by the Rugged git provider.
+
 The username option sets the username for SSH remotes when the SSH URL does not provide
 a username. When used with a Git hosting service this is most sensibly set to 'git'.
 
 The username defaults to the username of the currently logged in user.
-
-The username setting is only used by the Rugged git provider.
 
 ```yaml
 git:
@@ -84,14 +84,31 @@ git:
 
 #### private_key
 
+The private_key setting is only used by the Rugged git provider.
+
 The private_key option specifies the path to the default Git SSH private key for Git SSH remotes.
 The private_key setting must be set if SSH remotes are used.
-
-The private_key setting is only used by the Rugged git provider.
 
 ```yaml
 git:
   private_key: "/etc/puppetlabs/r10k/ssh/id_rsa"
+```
+
+#### repositories
+
+The repositories option allows configuration to be set on a per-remote basis. Each entry is a map of
+the repository URL and per-repository configuration for that repo.
+
+##### private_key
+
+A repository specific private key to use for SSH connections for the given repository URL. This
+overrides the global private_key setting.
+
+```yaml
+git:
+  repositories:
+    "ssh://tessier-ashpool.freeside/protected-repo.git":
+      private_key: "/etc/puppetlabs/r10k/ssh/id_rsa-protected-repo-deploy-key"
 ```
 
 ### forge

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -133,5 +133,6 @@ module R10K
 
     def_setting_attr :private_key
     def_setting_attr :username
+    def_setting_attr :repositories, {}
   end
 end

--- a/lib/r10k/git/rugged/credentials.rb
+++ b/lib/r10k/git/rugged/credentials.rb
@@ -26,9 +26,17 @@ class R10K::Git::Rugged::Credentials
 
   def get_ssh_key_credentials(url, username_from_url)
     user = get_git_username(url, username_from_url)
-    private_key = R10K::Git.settings[:private_key]
 
-    if private_key.nil?
+    per_repo_private_key = R10K::Git.settings[:repositories].fetch(url, {})[:private_key]
+    global_private_key = R10K::Git.settings[:private_key]
+
+    if per_repo_private_key
+      private_key = per_repo_private_key
+      logger.debug2 "Using per-repository private key #{per_repo_private_key} for URL #{url.inspect}"
+    elsif global_private_key
+      private_key = global_private_key
+      logger.debug2 "URL #{url.inspect} has a per-repository private key #{per_repo_private_key}"
+    else
       raise R10K::Git::GitError.new("Git remote #{url.inspect} uses the SSH protocol but no private key was given", :git_dir => @repository.path.to_s)
     end
 

--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -42,6 +42,7 @@ module R10K
         with_setting(:provider) { |value| R10K::Git.provider = value }
         with_setting(:username) { |value| R10K::Git.settings[:username] = value }
         with_setting(:private_key) { |value| R10K::Git.settings[:private_key] = value }
+        with_setting(:repositories) { |value| R10K::Git.settings[:repositories] = value }
       end
     end
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -27,7 +27,21 @@ module R10K
         Definition.new(:private_key, {
           :desc => "The path to the SSH private key for Git SSH remotes.
                     Only used by the 'rugged' Git provider.",
-        })
+        }),
+
+        Definition.new(:repositories, {
+          :desc => "Repository specific configuration.",
+          :default => {},
+          :normalize => lambda do |repositories|
+            # The config file loading logic recursively converts hash keys that are strings to symbols,
+            # but in this case it makes sense to have string hash keys. This normalization undoes the
+            # hash key symbolization.
+            repositories.inject({}) do |retval, (key, value)|
+              retval[key.to_s] = value
+              retval
+            end
+          end
+        }),
       ])
     end
 

--- a/lib/r10k/settings/container.rb
+++ b/lib/r10k/settings/container.rb
@@ -31,9 +31,9 @@ class R10K::Settings::Container
 
     if @settings[key]
       @settings[key]
-    elsif @parent and (pkey = @parent[key])
-      @settings[key] = pkey
-      pkey
+    elsif @parent && (pkey = @parent[key])
+      @settings[key] = pkey.dup
+      @settings[key]
     end
   end
 

--- a/spec/unit/settings/container_spec.rb
+++ b/spec/unit/settings/container_spec.rb
@@ -59,6 +59,13 @@ describe R10K::Settings::Container do
         expect(subject[:v]).to eq 'child'
       end
 
+      it 'duplicates and stores the parent object to avoid modifying the parent object' do
+        parent[:v] = {}
+        subject[:v][:hello] = "world"
+        expect(subject[:v]).to eq({hello: "world"})
+        expect(parent[:v]).to eq({})
+      end
+
       it 'falls back to the parent value if it does not have a value' do
         parent[:v] = 'parent'
         expect(subject[:v]).to eq 'parent'

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -137,7 +137,7 @@ describe R10K::Settings do
     describe "git settings" do
       it "passes settings through to the git settings" do
         output = subject.evaluate("git" => {"provider" => "shellgit", "username" => "git"})
-        expect(output[:git]).to eq(:provider => :shellgit, :username => "git", :private_key => nil)
+        expect(output[:git]).to eq(:provider => :shellgit, :username => "git", :private_key => nil, :repositories => {})
       end
     end
 


### PR DESCRIPTION
This allows users using the Rugged git provider to set a specific SSH private key on a per-remote basis.
