### PR TITLE
(CODEMGMT-440) Defer rugged repo alternates setup

### DIFF
--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -66,11 +66,9 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
   # Override the parent class repo setup so that we can make sure the alternates file is up to date
   # before we create the Rugged::Repository object, which reads from the alternates file.
   def setup_rugged_repo
-    if git_dir.exist?
-      entry_added = alternates.add?(@cache_repo.objects_dir.to_s)
-      if entry_added
-        logger.debug2 { "Updated repo #{@path} to include alternate object db path #{@cache_repo.objects_dir}" }
-      end
+    entry_added = alternates.add?(@cache_repo.objects_dir.to_s)
+    if entry_added
+      logger.debug2 { "Updated repo #{@path} to include alternate object db path #{@cache_repo.objects_dir}" }
     end
     super
   end

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -13,7 +13,6 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   # @param dirname [String] The directory name of the Git repository
   def initialize(basedir, dirname)
     @path = Pathname.new(File.join(basedir, dirname))
-    setup_rugged_repo
   end
 
   # Clone this git repository
@@ -99,9 +98,14 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
 
   private
 
-  def setup_rugged_repo
-    if exist? && git_dir.exist?
-      @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => alternates.to_a)
+  def with_repo
+    if @_rugged_repo.nil? && git_dir.exist?
+      setup_rugged_repo
     end
+    super
+  end
+
+  def setup_rugged_repo
+    @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => alternates.to_a)
   end
 end


### PR DESCRIPTION
Attempting to reset the git alternates file when creating Git
repositories means that actions with side effects can occur during
object initialization, which is pretty terrible and can result in some
very odd bugs. This commit defers the rugged repo setup/alternates setup
till the first time the rugged repo is accessed, which should remove
this problem.
