### PR TITLE
(RK-181) Set baseurl/proxy with shared PuppetForge URL

### DIFF
--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -47,8 +47,8 @@ module R10K
 
     class ForgeInitializer < BaseInitializer
       def call
-        with_setting(:proxy) { |value| R10K::Forge::ModuleRelease.settings[:proxy] = value }
-        with_setting(:baseurl) { |value| R10K::Forge::ModuleRelease.settings[:baseurl] = value }
+        with_setting(:baseurl) { |value| PuppetForge.host = value }
+        with_setting(:proxy) { |value| PuppetForge::V3::Base.conn.proxy(value) }
       end
     end
   end

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -60,7 +60,7 @@ class R10K::Module::Forge < R10K::Module::Base
   def expected_version
     if @expected_version == :latest
       begin
-      @expected_version = @v3_module.current_release.version
+        @expected_version = @v3_module.current_release.version
       rescue Faraday::ResourceNotFound => e
         raise PuppetForge::ReleaseNotFound, "The module #{@title} does not exist on #{PuppetForge::V3::Release.conn.url_prefix}.", e.backtrace
       end

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -35,6 +35,14 @@ module R10K
       R10K::Settings::Collection.new(:forge, [
         URIDefinition.new(:proxy, {
           :desc => "An optional proxy server to use when downloading modules from the forge.",
+          :default => lambda do
+            [
+              ENV['HTTPS_PROXY'],
+              ENV['https_proxy'],
+              ENV['HTTP_PROXY'],
+              ENV['http_proxy']
+            ].find { |value| value }
+          end
         }),
 
         URIDefinition.new(:baseurl, {

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -18,38 +18,6 @@ describe R10K::Forge::ModuleRelease do
     subject.unpack_path = unpack_path
   end
 
-  describe 'setting the proxy' do
-    %w[HTTPS_PROXY https_proxy HTTP_PROXY http_proxy].each do |env_var|
-      it "respects the #{env_var} environment variable" do
-        R10K::Util::ExecEnv.withenv(env_var => "http://proxy.value") do
-          subject = described_class.new('branan-eight_hundred', '8.0.0')
-          proxy_uri = forge_release_class.conn.proxy.uri
-          expect(proxy_uri.to_s).to eq "http://proxy.value"
-        end
-      end
-    end
-
-    describe 'using application settings' do
-      before { described_class.settings[:proxy] = 'http://proxy.setting' }
-      after { described_class.settings.reset! }
-
-      it 'has a setting for the forge proxy' do
-        subject = described_class.new('branan-eight_hundred', '8.0.0')
-        proxy_uri = forge_release_class.conn.proxy.uri
-        expect(proxy_uri.to_s).to eq "http://proxy.setting"
-      end
-
-      it 'prefers the proxy setting over an environment variable' do
-        R10K::Util::ExecEnv.withenv('HTTPS_PROXY' => "http://proxy.from.env") do
-          subject = described_class.new('branan-eight_hundred', '8.0.0')
-          proxy_uri = forge_release_class.conn.proxy.uri
-          expect(proxy_uri.to_s).to eq "http://proxy.setting"
-        end
-      end
-    end
-
-  end
-
   describe '#download' do
     it "downloads the module from the forge into `download_path`" do
       expect(subject.forge_release).to receive(:download).with(download_path)

--- a/spec/unit/initializers_spec.rb
+++ b/spec/unit/initializers_spec.rb
@@ -22,15 +22,15 @@ describe R10K::Initializers::GitInitializer do
 end
 
 describe R10K::Initializers::ForgeInitializer do
-  it "configures the Forge proxy" do
-    subject = described_class.new({:proxy => 'http://my.site.proxy:3128'})
-    expect(R10K::Forge::ModuleRelease.settings).to receive(:[]=).with(:proxy, 'http://my.site.proxy:3128')
+  it "sets the PuppetForge host" do
+    subject = described_class.new({:baseurl => 'https://my.site.forge'})
+    expect(PuppetForge).to receive(:host=).with('https://my.site.forge')
     subject.call
   end
 
-  it "configures the Forge baseurl" do
-    subject = described_class.new({:baseurl => 'https://my.site.forge'})
-    expect(R10K::Forge::ModuleRelease.settings).to receive(:[]=).with(:baseurl, 'https://my.site.forge')
+  it "configures PuppetForge connection proxy" do
+    subject = described_class.new({:proxy => 'http://my.site.proxy:3128'})
+    expect(PuppetForge::V3::Base.conn).to receive(:proxy).with('http://my.site.proxy:3128')
     subject.call
   end
 end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'r10k/settings'
+require 'r10k/util/exec_env'
 
 describe R10K::Settings do
   describe "git settings" do
@@ -50,6 +51,17 @@ describe R10K::Settings do
           expect(err.errors.size).to eq 1
           expect(err.errors[:proxy]).to be_a_kind_of(ArgumentError)
           expect(err.errors[:proxy].message).to match(/could not be parsed as a URL/)
+        end
+      end
+
+      describe "setting a default value" do
+        %w[HTTPS_PROXY https_proxy HTTP_PROXY http_proxy].each do |env_var|
+          it "respects the #{env_var} environment variable" do
+            R10K::Util::ExecEnv.withenv(env_var => "http://proxy.value/#{env_var}") do
+              output = subject.evaluate({})
+              expect(output[:proxy]).to eq("http://proxy.value/#{env_var}")
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
The PuppetForge 2.0 release changed how Faraday connections were passed
around, and r10k wasn't passing the Forge baseurl information to all of
the necessary Faraday clients. This pull request fixes the error by
explicitly configuring the PuppetForge host and connection proxy
information for the shared PuppetForge connection.
