### PR TITLE
Fix modulepath examples in environment.conf

### DIFF
--- a/doc/faq.mkd
+++ b/doc/faq.mkd
@@ -99,7 +99,7 @@ environment to indicate which directories contain modules:
 
 ```
 # environment.conf
-modulepath: modules:external-modules
+modulepath = modules:external-modules
 ```
 
 #### Move your local modules
@@ -111,7 +111,7 @@ directories contain modules.
 
 ```
 # environment.conf
-modulepath: internal-modules::modules
+modulepath = internal-modules:modules
 ```
 
 #### What does the name mean?


### PR DESCRIPTION
If I try to use the modulepath settings as they are documented now I get:

```
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/settings/config_file.rb:37:in `block (2 levels) in parse_file': Could not match line modulepath: modules:external-modules (Puppet::Settings::ParseError)
 at /etc/puppetlabs/code/environments/master/environment.conf:2
```

Also fix the double colon in the second example
