### PR TITLE
(CODEMGMT-453) Preliminary JRuby support for r10k/shellgit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ rvm:
   - "2.1.0"
   - "2.0.0"
   - "1.9.3"
+  - "jruby-19mode"
+jdk:
+    - oraclejdk8

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :extra do
-  gem 'rugged', '~> 0.21.4'
+  gem 'rugged', '~> 0.21.4', :platforms => :ruby
 end
 
 group :development do

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -2,6 +2,7 @@ require 'r10k/features'
 require 'r10k/errors'
 require 'r10k/settings'
 require 'r10k/logging'
+require 'r10k/util/platform'
 
 module R10K
   module Git

--- a/lib/r10k/util/platform.rb
+++ b/lib/r10k/util/platform.rb
@@ -4,7 +4,10 @@ module R10K
   module Util
     module Platform
       def self.platform
-        if self.windows?
+        # Test JRuby first to handle JRuby on Windows as well.
+        if self.jruby?
+          :jruby
+        elsif self.windows?
           :windows
         else
           :posix
@@ -15,8 +18,12 @@ module R10K
         RbConfig::CONFIG['host_os'] =~ /mswin|win32|dos|mingw|cygwin/i
       end
 
+      def self.jruby?
+        RUBY_PLATFORM == "java"
+      end
+
       def self.posix?
-        !windows?
+        !windows? && !jruby?
       end
     end
   end

--- a/lib/r10k/util/subprocess.rb
+++ b/lib/r10k/util/subprocess.rb
@@ -18,6 +18,8 @@ module R10K
       def self.runner
         if R10K::Util::Platform.windows?
           R10K::Util::Subprocess::Runner::Windows
+        elsif R10K::Util::Platform.jruby?
+          R10K::Util::Subprocess::Runner::JRuby
         else
           R10K::Util::Subprocess::Runner::POSIX
         end

--- a/lib/r10k/util/subprocess/runner.rb
+++ b/lib/r10k/util/subprocess/runner.rb
@@ -5,6 +5,7 @@ class R10K::Util::Subprocess::Runner
 
   require 'r10k/util/subprocess/runner/windows'
   require 'r10k/util/subprocess/runner/posix'
+  require 'r10k/util/subprocess/runner/jruby'
 
   # @!attribute [rw] cwd
   #   @return [String] The directory to be used as the cwd when executing

--- a/lib/r10k/util/subprocess/runner/jruby.rb
+++ b/lib/r10k/util/subprocess/runner/jruby.rb
@@ -1,0 +1,23 @@
+require 'open3'
+require 'r10k/util/subprocess/runner'
+
+# Run processes under JRuby.
+#
+# This implementation relies on Open3.capture3 to run commands and capture
+# results. In contrast to the POSIX runner this cannot be used in an
+# asynchronous manner as-is; implementing that will probably mean launching a
+# thread and invoking #capture3 in that thread.
+class R10K::Util::Subprocess::Runner::JRuby < R10K::Util::Subprocess::Runner
+
+  def initialize(argv)
+    @argv = argv
+  end
+
+  def run
+    spawn_opts = @cwd ? {:chdir => @cwd} : {}
+    stdout, stderr, status = Open3.capture3(*@argv, spawn_opts)
+    @result = R10K::Util::Subprocess::Result.new(@argv, stdout, stderr, status.exitstatus)
+  rescue Errno::ENOENT, Errno::EACCES => e
+    @result = R10K::Util::Subprocess::Result.new(@argv, '', e.message, 255)
+  end
+end

--- a/spec/unit/git/rugged/cache_spec.rb
+++ b/spec/unit/git/rugged/cache_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
-require 'r10k/git/rugged/cache'
 
-describe R10K::Git::Rugged::Cache do
+describe R10K::Git::Rugged::Cache, :unless => R10K::Util::Platform.jruby? do
+  before(:all) do
+    require 'r10k/git/rugged/cache'
+  end
+
   subject(:cache) { described_class.new('git://some/git/remote') }
 
   it "wraps a Rugged::BareRepository instance" do

--- a/spec/unit/git/rugged/credentials_spec.rb
+++ b/spec/unit/git/rugged/credentials_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
-require 'r10k/git/rugged/credentials'
-require 'rugged/credentials'
 
-describe R10K::Git::Rugged::Credentials do
+describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? do
+  before(:all) do
+    require 'r10k/git/rugged/credentials'
+    require 'rugged/credentials'
+  end
 
   let(:repo) { R10K::Git::Rugged::BareRepository.new("/some/nonexistent/path", "repo.git") }
 

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -11,10 +11,12 @@ describe R10K::Git do
       expect(described_class.default_name).to eq :shellgit
     end
 
-    it 'returns rugged when the git executable is absent and the rugged library is present' do
-      expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
-      expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
-      expect(described_class.default_name).to eq :rugged
+    context 'under c-based rubies', :unless => R10K::Util::Platform.jruby? do
+      it 'returns rugged when the git executable is absent and the rugged library is present' do
+        expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
+        expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
+        expect(described_class.default_name).to eq :rugged
+      end
     end
 
     it 'raises an error when the git executable and rugged library are absent' do
@@ -51,24 +53,50 @@ describe R10K::Git do
       }.to raise_error(R10K::Error, "Git provider 'shellgit' is not functional.")
     end
 
-    it "sets the current provider if the provider exists and is functional" do
-      expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
-      described_class.provider = :rugged
-      expect(described_class.provider).to eq(R10K::Git::Rugged)
+    context 'under c-based rubies', :unless => R10K::Util::Platform.jruby? do
+      it "sets the current provider if the provider exists and is functional" do
+        expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
+        described_class.provider = :rugged
+        expect(described_class.provider).to eq(R10K::Git::Rugged)
+      end
+    end
+
+    context 'under jruby', :if => R10K::Util::Platform.jruby? do
+      it "sets the current provider if the provider exists and is functional" do
+        expect(R10K::Features).to receive(:available?).with(:shellgit).and_return true
+        described_class.provider = :shellgit
+        expect(described_class.provider).to eq(R10K::Git::ShellGit)
+      end
     end
   end
 
   describe "retrieving the current provider" do
-    it "uses the default if a provider has not been set" do
-      expect(described_class).to receive(:default_name).and_return :rugged
-      expect(described_class.provider).to eq(R10K::Git::Rugged)
+    context 'under c-based rubies', :unless => R10K::Util::Platform.jruby? do
+      it "uses the default if a provider has not been set" do
+        expect(described_class).to receive(:default_name).and_return :rugged
+        expect(described_class.provider).to eq(R10K::Git::Rugged)
+      end
+
+      it "uses an explicitly set provider" do
+        expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
+        described_class.provider = :rugged
+        expect(described_class).to_not receive(:default)
+        expect(described_class.provider).to eq R10K::Git::Rugged
+      end
     end
 
-    it "uses an explicitly set provider" do
-      expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
-      described_class.provider = :rugged
-      expect(described_class).to_not receive(:default)
-      expect(described_class.provider).to eq R10K::Git::Rugged
+    context 'under jruby', :if => R10K::Util::Platform.jruby? do
+      it "uses the default if a provider has not been set" do
+        expect(described_class).to receive(:default_name).and_return :shellgit
+        expect(described_class.provider).to eq(R10K::Git::ShellGit)
+      end
+
+      it "uses an explicitly set provider" do
+        expect(R10K::Features).to receive(:available?).with(:shellgit).and_return true
+        described_class.provider = :shellgit
+        expect(described_class).to_not receive(:default)
+        expect(described_class.provider).to eq R10K::Git::ShellGit
+      end
     end
   end
 end

--- a/spec/unit/util/subprocess/runner/windows_spec.rb
+++ b/spec/unit/util/subprocess/runner/windows_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'r10k/util/subprocess/runner'
 
-describe R10K::Util::Subprocess::Runner::Windows do
+describe R10K::Util::Subprocess::Runner::Windows, :if => R10K::Util::Platform.windows? do
   fixture_root = File.expand_path('spec/fixtures/unit/util/subprocess/runner', PROJECT_ROOT)
   it_behaves_like 'a subprocess runner', fixture_root
 end


### PR DESCRIPTION
This seems to be the minimal set of changes required to get the spec tests running under JRuby 1.7 and JDK8. Everything apart from public Forge interactions _should_ work under JDK7, public Forge doesn't work due to JDK7 not supporting DH keys longer than 1024 bytes.
