### PR TITLE
Add r10k:syntax rake task to check the syntax of the Puppetfile

### DIFF
--- a/lib/r10k/tasks.rb
+++ b/lib/r10k/tasks.rb
@@ -1,0 +1,24 @@
+require 'rake'
+require 'rake/tasklib'
+
+module R10KTasks
+  class RakeTask < ::Rake::TaskLib
+    def initialize(*args)
+      namespace :r10k do
+        desc "Syntax check Puppetfile"
+        task :syntax do
+          require 'r10k/action/puppetfile/check'
+
+          puppetfile = R10K::Action::Puppetfile::Check.new({
+            :root => ".",
+            :moduledir => nil,
+            :puppetfile => nil
+          }, '')
+          puppetfile.call
+        end
+      end
+    end
+  end
+end
+
+R10KTasks::RakeTask.new


### PR DESCRIPTION
In order to use it, add the following in the Rakefile: require 'r10k/tasks'
and run '(bundle exec) rake r10k:syntax'
