### PR TITLE
(RK-189) Implement R10K::API envmap generation functions.

### DIFF
--- a/lib/r10k/api/envmap_builder.rb
+++ b/lib/r10k/api/envmap_builder.rb
@@ -1,0 +1,54 @@
+require 'r10k/module/git'
+require 'r10k/module/svn'
+require 'r10k/module/forge'
+
+module R10K
+  module API
+    class EnvmapBuilder
+      def initialize
+        @modules = []
+      end
+
+      def build
+        @modules
+      end
+
+      # @param [String] forge
+      def set_forge(forge)
+        # No implementation for EnvMaps.
+      end
+
+      # @param [String] moduledir
+      def set_moduledir(moduledir)
+        # No implementation for EnvMaps.
+      end
+
+      # @param [String] name
+      # @param [Hash] args
+      def add_module(name, args)
+        name_parts = name.split(/[\-\/]/, 2)
+        mod_name = name_parts.size > 1 ? name_parts.last : name
+
+        if @modules.collect { |m| m[:name] }.include?(mod_name)
+          raise RuntimeError, "Puppetfile cannot declare the same module name twice: #{mod_name} was already declared"
+        end
+
+        case
+        when R10K::Module::Git.implement?(name, args)
+          git_opts = R10K::Module::Git.parse_options(args)
+          module_data = { :type => :git, :source => git_opts[:remote], :version => git_opts[:ref] }
+        when R10K::Module::SVN.implement?(name, args)
+          module_data = { :type => :svn, :source => args[:url], :version => (args[:rev] || args[:revision] || "unpinnned") }
+        when R10K::Module::Forge.implement?(name, args)
+          module_data = { :type => :forge, :source => name_parts.join('-'), :version => (args || "unpinned") }
+        when R10K::Module::Local.implement?(name, args)
+          raise NotImplementedError
+        else
+          raise RuntimeError, "Unregonized module type in Puppetfile: #{name} #{args}"
+        end
+
+        @modules << { :name => mod_name }.merge(module_data)
+      end
+    end
+  end
+end

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -88,4 +88,19 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
       end
     end
   end
+
+  def blob_at(treeish, path)
+    blob = nil
+
+    with_repo do |repo|
+      object = repo.rev_parse(treeish)
+
+      # Resolve tag annotations to the underlying commit.
+      sha = object.respond_to?(:target_oid) ? object.target_oid : object.oid
+
+      blob = repo.blob_at(sha, path)
+    end
+
+    blob.content.strip
+  end
 end

--- a/lib/r10k/git/shellgit/bare_repository.rb
+++ b/lib/r10k/git/shellgit/bare_repository.rb
@@ -31,4 +31,10 @@ class R10K::Git::ShellGit::BareRepository < R10K::Git::ShellGit::BaseRepository
   def exist?
     @path.exist?
   end
+
+  def blob_at(treeish, path)
+    result = git ['show', "#{treeish}:#{path}"], :git_dir => git_dir.to_s
+
+    result.success? ? result.stdout.strip : nil
+  end
 end

--- a/lib/r10k/git/shellgit/base_repository.rb
+++ b/lib/r10k/git/shellgit/base_repository.rb
@@ -1,5 +1,6 @@
 require 'r10k/git/shellgit'
 require 'r10k/logging'
+require 'r10k/util/subprocess'
 
 class R10K::Git::ShellGit::BaseRepository
 

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -13,6 +13,36 @@ class R10K::Module::Git < R10K::Module::Base
     false
   end
 
+  def self.parse_options(options)
+    parsed = {}
+
+    parsed[:remote] = options.delete(:git)
+
+    if options[:branch]
+      ref = options.delete(:branch)
+    end
+
+    if options[:tag]
+      ref = options.delete(:tag)
+    end
+
+    if options[:commit]
+      ref = options.delete(:commit)
+    end
+
+    if options[:ref]
+      ref = options.delete(:ref)
+    end
+
+    parsed[:ref] = ref || 'master'
+
+    unless options.empty?
+      raise ArgumentError, "Unhandled options #{options.keys.inspect} specified for #{self}"
+    end
+
+    return parsed
+  end
+
   # @!attribute [r] repo
   #   @api private
   #   @return [R10K::Git::StatefulRepository]
@@ -20,7 +50,7 @@ class R10K::Module::Git < R10K::Module::Base
 
   def initialize(title, dirname, args)
     super
-    parse_options(@args)
+    @remote, @ref = self.class.parse_options(@args).values_at(:remote, :ref)
     @repo = R10K::Git::StatefulRepository.new(@ref, @remote, @dirname, @name)
   end
 
@@ -39,32 +69,4 @@ class R10K::Module::Git < R10K::Module::Base
   extend Forwardable
 
   def_delegators :@repo, :sync, :status
-
-  private
-
-  def parse_options(options)
-    @remote = options.delete(:git)
-
-    if options[:branch]
-      @ref = options.delete(:branch)
-    end
-
-    if options[:tag]
-      @ref = options.delete(:tag)
-    end
-
-    if options[:commit]
-      @ref = options.delete(:commit)
-    end
-
-    if options[:ref]
-      @ref = options.delete(:ref)
-    end
-
-    @ref ||= 'master'
-
-    unless options.empty?
-      raise ArgumentError, "Unhandled options #{options.keys.inspect} specified for #{self.class}"
-    end
-  end
 end

--- a/lib/r10k/settings/container.rb
+++ b/lib/r10k/settings/container.rb
@@ -3,91 +3,95 @@
 # This implements a hierarchical interface to application settings. Containers
 # can define an optional parent container that will be used for default options
 # if those options aren't set on the given container.
-class R10K::Settings::Container
+module R10K
+  module Settings
+    class Container
 
-  # @!attribute [r] valid_keys
-  #   @return [Set<Symbol>] All valid keys defined on the container or parent container.
-  attr_accessor :valid_keys
+      # @!attribute [r] valid_keys
+      #   @return [Set<Symbol>] All valid keys defined on the container or parent container.
+      attr_accessor :valid_keys
 
-  # @param parent [R10K::Settings::Container] An optional parent container
-  def initialize(parent = nil)
-    @parent = parent
+      # @param parent [R10K::Settings::Container] An optional parent container
+      def initialize(parent = nil)
+        @parent = parent
 
-    @valid_keys = Set.new
-    @settings = {}
-  end
+        @valid_keys = Set.new
+        @settings = {}
+      end
 
-  # Look up a value in the container. The lookup checks the current container,
-  # and then falls back to the parent container if it's given.
-  #
-  # @param key [Symbol] The lookup key
-  #
-  # @return [Object, nil] The retrieved value if present.
-  #
-  # @raise [R10K::Settings::Container::InvalidKey] If the looked up key isn't
-  #   a valid key.
-  def [](key)
-    validate_key! key
+      # Look up a value in the container. The lookup checks the current container,
+      # and then falls back to the parent container if it's given.
+      #
+      # @param key [Symbol] The lookup key
+      #
+      # @return [Object, nil] The retrieved value if present.
+      #
+      # @raise [R10K::Settings::Container::InvalidKey] If the looked up key isn't
+      #   a valid key.
+      def [](key)
+        validate_key! key
 
-    if @settings[key]
-      @settings[key]
-    elsif @parent && (pkey = @parent[key])
-      @settings[key] = pkey.dup
-      @settings[key]
+        if @settings[key]
+          @settings[key]
+        elsif @parent && (pkey = @parent[key])
+          @settings[key] = pkey.dup
+          @settings[key]
+        end
+      end
+
+      # Set a value on the container
+      #
+      # @param key [Symbol] The lookup key
+      # @param value [Object] The value to store in the container
+      #
+      # @raise [R10K::Settings::Container::InvalidKey] If the looked up key isn't
+      #   a valid key.
+      def []=(key, value)
+        validate_key! key
+
+        @settings[key] = value
+      end
+
+      # Define a valid container key
+      #
+      # @note This should only be used by {#R10K::Settings::ClassSettings}
+      #
+      # @param key [Symbol]
+      # @return [void]
+      def add_valid_key(key)
+        @valid_keys.add(key)
+      end
+
+      # Determine if a key is a valid setting.
+      #
+      # @param key [Symbol]
+      #
+      # @return [true, false]
+      def valid_key?(key)
+        if @valid_keys.include?(key)
+          true
+        elsif @parent and @parent.valid_key?(key)
+          @valid_keys.add(key)
+          true
+        end
+      end
+
+      # Clear all existing settings in this container. Valid settings are left alone.
+      # @return [void]
+      def reset!
+        @settings = {}
+      end
+
+      private
+
+      def validate_key!(key)
+        unless valid_key?(key)
+          raise InvalidKey, "Key #{key} is not a valid key"
+        end
+      end
+
+      # @api private
+      class InvalidKey < StandardError; end
     end
   end
-
-  # Set a value on the container
-  #
-  # @param key [Symbol] The lookup key
-  # @param value [Object] The value to store in the container
-  #
-  # @raise [R10K::Settings::Container::InvalidKey] If the looked up key isn't
-  #   a valid key.
-  def []=(key, value)
-    validate_key! key
-
-    @settings[key] = value
-  end
-
-  # Define a valid container key
-  #
-  # @note This should only be used by {#R10K::Settings::ClassSettings}
-  #
-  # @param key [Symbol]
-  # @return [void]
-  def add_valid_key(key)
-    @valid_keys.add(key)
-  end
-
-  # Determine if a key is a valid setting.
-  #
-  # @param key [Symbol]
-  #
-  # @return [true, false]
-  def valid_key?(key)
-    if @valid_keys.include?(key)
-      true
-    elsif @parent and @parent.valid_key?(key)
-      @valid_keys.add(key)
-      true
-    end
-  end
-
-  # Clear all existing settings in this container. Valid settings are left alone.
-  # @return [void]
-  def reset!
-    @settings = {}
-  end
-
-  private
-
-  def validate_key!(key)
-    unless valid_key?(key)
-      raise InvalidKey, "Key #{key} is not a valid key"
-    end
-  end
-
-  # @api private
-  class InvalidKey < StandardError; end
 end

--- a/lib/r10k/settings/mixin.rb
+++ b/lib/r10k/settings/mixin.rb
@@ -1,53 +1,57 @@
-module R10K::Settings::Mixin
+require 'r10k/settings/container'
 
-  def self.included(klass)
-    klass.send(:include, InstanceMethods)
-    klass.send(:extend, ClassMethods)
-  end
+module R10K
+  module Settings
+    module Mixin
 
-  module InstanceMethods
+      def self.included(klass)
+        klass.send(:include, InstanceMethods)
+        klass.send(:extend, ClassMethods)
+      end
 
-    # @return [R10K::Settings::Container] A settings container for the given instance.
-    def settings
-      @settings ||= R10K::Settings::Container.new(self.class.settings)
-    end
-  end
+      module InstanceMethods
+        # @return [R10K::Settings::Container] A settings container for the given instance.
+        def settings
+          @settings ||= R10K::Settings::Container.new(self.class.settings)
+        end
+      end
 
-  module ClassMethods
+      module ClassMethods
+        # Define a setting and optional default on the extending class.
+        #
+        # @param key [Symbol]
+        # @param default [Object]
+        #
+        # @return [void]
+        def def_setting_attr(key, default = nil)
+          defaults.add_valid_key(key)
+          defaults[key] = default if default
+        end
 
-    # Define a setting and optional default on the extending class.
-    #
-    # @param key [Symbol]
-    # @param default [Object]
-    #
-    # @return [void]
-    def def_setting_attr(key, default = nil)
-      defaults.add_valid_key(key)
-      defaults[key] = default if default
-    end
+        # A singleton settings container for storing immutable default configuration
+        # on the extending class.
+        #
+        # @return [R10K::Settings::Container]
+        def defaults
+          @defaults ||= R10K::Settings::Container.new
+        end
 
-    # A singleton settings container for storing immutable default configuration
-    # on the extending class.
-    #
-    # @return [R10K::Settings::Container]
-    def defaults
-      @defaults ||= R10K::Settings::Container.new
-    end
+        # A singleton settings container for storing manual setting configurations
+        # on the extending class.
+        #
+        # @return [R10K::Settings::Container]
+        def settings
+          @settings ||= R10K::Settings::Container.new(defaults)
+        end
 
-    # A singleton settings container for storing manual setting configurations
-    # on the extending class.
-    #
-    # @return [R10K::Settings::Container]
-    def settings
-      @settings ||= R10K::Settings::Container.new(defaults)
-    end
-
-    # Allow subclasses to use the settings of the parent class as default values
-    #
-    # @return [void]
-    def inherited(subclass)
-      subclass.instance_eval do
-        @settings = R10K::Settings::Container.new(superclass.settings)
+        # Allow subclasses to use the settings of the parent class as default values
+        #
+        # @return [void]
+        def inherited(subclass)
+          subclass.instance_eval do
+            @settings = R10K::Settings::Container.new(superclass.settings)
+          end
+        end
       end
     end
   end

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -17,6 +17,11 @@ class R10K::Source::Git < R10K::Source::Base
   # Register git as the default source
   R10K::Source.register(nil, self)
 
+
+  # @!attribute [r] type
+  #   @return [:git] The type of this control repo source
+  attr_reader :type
+
   # @!attribute [r] remote
   #   @return [String] The URL to the remote git repository
   attr_reader :remote
@@ -53,6 +58,7 @@ class R10K::Source::Git < R10K::Source::Base
 
     @environments = []
 
+    @type             = :git
     @remote           = options[:remote]
     @invalid_branches = (options[:invalid_branches] || 'correct_and_warn')
 

--- a/lib/r10k/source/svn.rb
+++ b/lib/r10k/source/svn.rb
@@ -18,6 +18,10 @@ class R10K::Source::SVN < R10K::Source::Base
 
   R10K::Source.register(:svn, self)
 
+  # @!attribute [r] type
+  #   @return [:svn] The type of this control repo source
+  attr_reader :type
+
   # @!attribute [r] remote
   #   @return [String] The URL to the base directory of the SVN repository
   attr_reader :remote
@@ -53,6 +57,7 @@ class R10K::Source::SVN < R10K::Source::Base
   def initialize(name, basedir, options = {})
     super
 
+    @type = :svn
     setopts(options, {:remote => :self, :username => :self, :password => :self})
     @environments = []
     @svn_remote = R10K::SVN::Remote.new(@remote, :username => @username, :password => @password)

--- a/lib/r10k/svn/remote.rb
+++ b/lib/r10k/svn/remote.rb
@@ -1,68 +1,82 @@
 require 'r10k/util/subprocess'
 require 'r10k/util/setopts'
 
-# Inspect and interact with SVN remote repositories
-#
-# @api private
-# @since 1.3.0
-class R10K::SVN::Remote
+module R10K
+  module SVN
+    # Inspect and interact with SVN remote repositories
+    #
+    # @api private
+    # @since 1.3.0
+    class Remote
 
-  include R10K::Util::Setopts
+      include R10K::Util::Setopts
 
-  def initialize(baseurl, opts = {})
-    @baseurl = baseurl
-    setopts(opts, {:username => :self, :password => :self})
-  end
+      def initialize(baseurl, opts = {})
+        @baseurl = baseurl
+        setopts(opts, {:username => :self, :password => :self})
+      end
 
-  # @todo validate that the path to trunk exists in the remote
-  def trunk
-    "#{@baseurl}/trunk"
-  end
+      # @todo validate that the path to trunk exists in the remote
+      def trunk
+        "#{@baseurl}/trunk"
+      end
 
-  # @todo gracefully handle cases where no branches exist
-  def branches
-    argv = ['ls', "#{@baseurl}/branches"]
-    argv.concat(auth)
-    text = svn(argv)
-    text.lines.map do |line|
-      line.chomp!
-      line.gsub!(%r[/$], '')
-      line
+      # @todo gracefully handle cases where no branches exist
+      def branches
+        argv = ['ls', "#{@baseurl}/branches"]
+        argv.concat(auth)
+        text = svn(argv)
+        text.lines.map do |line|
+          line.chomp!
+          line.gsub!(%r[/$], '')
+          line
+        end
+      end
+
+      def cat(path, revision=nil)
+        argv = ['cat']
+        argv << "-r #{revision}" if revision
+        argv << "#{@baseurl}/#{path}"
+
+        argv.concat(auth)
+
+        svn(argv)
+      end
+
+      private
+
+      # Format authentication information for SVN command args, if applicable
+      def auth
+        auth = []
+        if @username
+          auth << "--username" << @username
+          auth << "--password" << @password
+        end
+        auth
+      end
+
+      include R10K::Logging
+
+      # Wrap SVN commands
+      #
+      # @param argv [Array<String>]
+      # @param opts [Hash]
+      #
+      # @option opts [Pathname] :cwd The directory to run the command in
+      #
+      # @return [String] The stdout from the given command
+      def svn(argv, opts = {})
+        argv.unshift('svn', '--non-interactive')
+
+        subproc = R10K::Util::Subprocess.new(argv)
+        subproc.raise_on_fail = true
+        subproc.logger = self.logger
+
+        subproc.cwd = opts[:cwd]
+        result = subproc.execute
+
+        result.stdout
+      end
     end
-  end
-
-  private
-
-  # Format authentication information for SVN command args, if applicable
-  def auth
-    auth = []
-    if @username
-      auth << "--username" << @username
-      auth << "--password" << @password
-    end
-    auth
-  end
-
-  include R10K::Logging
-
-  # Wrap SVN commands
-  #
-  # @param argv [Array<String>]
-  # @param opts [Hash]
-  #
-  # @option opts [Pathname] :cwd The directory to run the command in
-  #
-  # @return [String] The stdout from the given command
-  def svn(argv, opts = {})
-    argv.unshift('svn', '--non-interactive')
-
-    subproc = R10K::Util::Subprocess.new(argv)
-    subproc.raise_on_fail = true
-    subproc.logger = self.logger
-
-    subproc.cwd = opts[:cwd]
-    result = subproc.execute
-
-    result.stdout
   end
 end

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
 
   s.add_development_dependency 'yard', '~> 0.8.7.3'
-  s.add_development_dependency 'redcarpet'
+  s.add_development_dependency 'redcarpet' unless RUBY_PLATFORM == 'java'
 
   s.files        = %x[git ls-files].split($/)
   s.require_path = 'lib'

--- a/spec/fixtures/unit/puppetfile/valid-forge/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/valid-forge/Puppetfile
@@ -1,0 +1,14 @@
+# Fixture Puppetfile with only valid Forge module declarations
+
+# unpinned, slash seperator
+mod 'puppetlabs/apache'
+
+# unpinned, hyphen seperator
+mod 'puppetlabs-mysql'
+
+# version pinned
+mod 'puppetlabs/stdlib', '4.10.0'
+
+# track latest
+mod 'puppetlabs/vcsrepo', :latest
+

--- a/spec/fixtures/unit/puppetfile/valid-git/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/valid-git/Puppetfile
@@ -1,0 +1,26 @@
+# Fixture Puppetfile with only valid git module declarations.
+
+# implicit ref => 'master'
+mod 'apache',
+  :git => 'https://github.com/puppetlabs/puppetlabs-apache'
+
+# Track branch via 'ref' option
+mod 'stdlib',
+  :git => 'https://github.com/puppetlabs/puppetlabs-stdlib',
+  :ref => '4.10.x'
+
+# Track branch via 'branch' option
+mod 'vcsrepo',
+  :git    => 'https://github.com/puppetlabs/puppetlabs-vcsrepo',
+  :branch => '1.3.x'
+
+# Pin to tag
+mod 'apt',
+  :git => 'https://github.com/puppetlabs/puppetlabs-apt',
+  :tag => '2.2.1'
+
+# Pin to commit
+mod 'concat',
+  :git    => 'https://github.com/puppetlabs/puppetlabs-concat',
+  :commit => 'ca98a145ca4374383dc33db7119fb0b5364e736f'
+

--- a/spec/fixtures/unit/puppetfile/valid-svn/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/valid-svn/Puppetfile
@@ -1,0 +1,25 @@
+# Fixture Puppetfile containing only valid SVN module declarations
+
+# Track trunk (master)
+mod 'apache',
+  :svn => 'https://github.com/puppetlabs/puppetlabs-apache/trunk'
+
+# Pin trunk at revision using "rev"
+mod 'stdlib',
+  :svn => 'https://github.com/puppetlabs/puppetlabs-stdlib/trunk',
+  :rev => '2365'
+
+# Pin trunk at revision using "revision"
+mod 'mysql',
+  :svn      => 'https://github.com/puppetlabs/puppetlabs-mysql/trunk',
+  :revision => '1344'
+
+# Track trunk with credentials, (note these credentials are not valid)
+mod 'vcsrepo',
+  :svn      => 'https://github.com/puppetlabs/puppetlabs-vcsrepo/trunk',
+  :username => 'fixtureuser',
+  :password => 'invalid'
+
+# Track svn branch
+mod 'concat',
+  :svn      => 'https://github.com/puppetlabs/puppetlabs-concat/branches/2.0.x'

--- a/spec/shared-examples/git/bare_repository.rb
+++ b/spec/shared-examples/git/bare_repository.rb
@@ -67,4 +67,30 @@ RSpec.shared_examples "a git bare repository" do
       expect(subject.ref_type('1.2.3')).to eq :unknown
     end
   end
+
+  describe "extracting file contents at revision" do
+    before do
+      subject.clone(remote)
+    end
+
+    it "can extract at a branch ref" do
+      content = subject.blob_at('0.9.x', 'Modulefile')
+      expect(content.size).to eq 439
+    end
+
+    it "can extract at a full SHA ref" do
+      content = subject.blob_at('baa30e4d34b83187624335236cc91ecb18d9ceff', 'README.markdown')
+      expect(content.size).to eq 2360
+    end
+
+    it "can extract at a short SHA ref" do
+      content = subject.blob_at('baa30e4', 'README.markdown')
+      expect(content.size).to eq 2360
+    end
+
+    it "can extract at a tag ref" do
+      content = subject.blob_at('0.9.0-rc1', 'Modulefile')
+      expect(content.size).to eq 443
+    end
+  end
 end

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+require 'r10k/api'
+
+RSpec.describe R10K::API do
+  describe ".get_puppetfile" do
+    before(:each) do
+      @git_repo = instance_double(R10K::Git.bare_repository)
+      allow(R10K::Git.bare_repository).to receive(:new).and_return(@git_repo)
+
+      @svn_repo = instance_double(R10K::SVN::Remote)
+      allow(R10K::SVN::Remote).to receive(:new).and_return(@svn_repo)
+    end
+
+    it "handles a base_path with a leading slash" do
+      expect(@git_repo).to receive(:blob_at).with('branch', 'puppet/Puppetfile')
+
+      subject.get_puppetfile(:git, '/tmp/repo.git', 'branch', '/puppet')
+    end
+
+    it "handles a base_path with lots of leading slashes" do
+      expect(@git_repo).to receive(:blob_at).with('branch', 'puppet/Puppetfile')
+
+      subject.get_puppetfile(:git, '/tmp/repo.git', 'branch', '//////puppet')
+    end
+
+    context "with a Git source" do
+      it "calls #blob_at with expected values" do
+        expect(@git_repo).to receive(:blob_at).with('branch', 'Puppetfile')
+
+        subject.get_puppetfile(:git, '/tmp/repo.git', 'branch')
+      end
+    end
+
+    context "with an SVN source" do
+      it "calls #cat with expected values for production env" do
+        expect(@svn_repo).to receive(:cat).with('trunk/Puppetfile')
+
+        subject.get_puppetfile(:svn, 'https://example.com/svn/puppet', 'production')
+      end
+
+      it "calls #cat with expected values for non-production env" do
+        expect(@svn_repo).to receive(:cat).with('branches/branch/Puppetfile')
+
+        subject.get_puppetfile(:svn, 'https://example.com/svn/puppet', 'branch')
+      end
+    end
+  end
+
+  describe ".parse_puppetfile" do
+    before(:each) do
+      @modules = [ { name: "mod1" }, { name: "mod2" } ]
+
+      @builder = instance_double(R10K::API::EnvmapBuilder, :build => @modules)
+      allow(R10K::API::EnvmapBuilder).to receive(:new).and_return(@builder)
+
+      @parser = instance_double(R10K::Puppetfile::DSL)
+      allow(R10K::Puppetfile::DSL).to receive(:new).and_return(@parser)
+    end
+
+    it "reads directly from stream when passed an IO" do
+      @io = double(:io)
+      @puppetfile_content = "Puppetfile from IO!"
+
+      expect(@io).to receive(:read).and_return(@puppetfile_content)
+      expect(@parser).to receive(:instance_eval).with(@puppetfile_content)
+
+      expect(subject.parse_puppetfile(@io)).to eq({ :modules => @modules })
+    end
+
+    it "reads from a File when passed a non-IO" do
+      @path = "/tmp/Puppetfile"
+      @fh = double(:fh)
+      @puppetfile_content = "Puppetfile from file!"
+
+      expect(File).to receive(:open).with(@path, 'r').and_yield(@fh)
+      expect(@fh).to receive(:read).and_return(@puppetfile_content)
+      expect(@parser).to receive(:instance_eval).with(@puppetfile_content)
+
+      expect(subject.parse_puppetfile(@path)).to eq({ :modules => @modules })
+    end
+  end
+
+  describe ".parse_deployed_env" do
+    let(:env_data) do
+      { mock: "envmap" }
+    end
+
+    context "for a deployed Git env" do
+      before(:each) do
+        allow(File).to receive(:directory?).with(/\.git$/).and_return(true)
+        allow(File).to receive(:directory?).with(/\.svn$/).and_return(false)
+      end
+
+      it "delegates to parse_deployed_git_env" do
+        @path = "/tmp/environments/production"
+        @moduledir = "mods"
+
+        expect(R10K::API).to receive(:parse_deployed_git_env).with(@path, @moduledir).and_return(env_data)
+
+        expect(subject.parse_deployed_env(@path, @moduledir)).to eq({ environment: "production", mock: "envmap" })
+      end
+    end
+
+    context "for a deployed SVN env" do
+      before(:each) do
+        allow(File).to receive(:directory?).with(/\.svn$/).and_return(true)
+        allow(File).to receive(:directory?).with(/\.git$/).and_return(false)
+      end
+
+      it "delegates to parse_deployed_svn_env" do
+        @path = "/tmp/environments/production"
+        @moduledir = "mods"
+
+        expect(R10K::API).to receive(:parse_deployed_svn_env).with(@path, @moduledir).and_return(env_data)
+
+        expect(subject.parse_deployed_env(@path, @moduledir)).to eq({ environment: "production", mock: "envmap" })
+      end
+    end
+  end
+
+  describe ".parse_deployed_git_evn" do
+    pending
+  end
+
+  describe ".parse_deployed_svn_env" do
+    pending
+  end
+
+  describe ".parse_deployed_module" do
+    pending
+  end
+end

--- a/spec/unit/svn/remote_spec.rb
+++ b/spec/unit/svn/remote_spec.rb
@@ -18,4 +18,16 @@ describe R10K::SVN::Remote do
       expect(subject.branches).to eq(%w[apache dns robobutler staging])
     end
   end
+
+  describe "extracting file contents" do
+    it "returns contents at given path as string" do
+      allow(subject).to receive(:svn).with(['cat', 'https://svn-server.site/repo/trunk/Puppetfile']).and_return("Puppetfile Contents")
+      expect(subject.cat('trunk/Puppetfile')).to eq("Puppetfile Contents")
+    end
+
+    it "extracts file at specific revision when given" do
+      allow(subject).to receive(:svn).with(['cat', '-r 20', 'https://svn-server.site/repo/trunk/Puppetfile']).and_return("Puppetfile Contents at r20")
+      expect(subject.cat('trunk/Puppetfile', 20)).to eq("Puppetfile Contents at r20")
+    end
+  end
 end


### PR DESCRIPTION
Initial implementations for the basic Puppetfile extraction and parsing functions, as well as inspecting an already deployed environment.

There are a few changes mixed in here to just make it possible to require various bits of R10K in piecemeal since since Ruby's global namespace context makes it easy to forget to require/define various things where they are used.

The testing is not as robust as it should be yet, but there is some basic unit test coverage.
