### PR TITLE
(RK-198) Parse environment dir

### DIFF
--- a/lib/r10k/api.rb
+++ b/lib/r10k/api.rb
@@ -95,8 +95,19 @@ module R10K
     # of every environment found.
     #
     # @param path [String] Path on disk to search for Puppet environments.
+    # @param moduledir [String] The path, relative to the environment path, where the modules are deployed.
     # @return [Array<Hash>] An array of hashmaps, each representing the actual state of a single environment found in environmentdir.
-    def parse_environmentdir(path)
+    def parse_environmentdir(path, moduledir="modules")
+      deployed_env_states = []
+
+      if path
+        deployed_envs = Dir.glob(File.join(path, '*')).select {|f| File.directory? f}
+        deployed_envs.each do |env_dir|
+          deployed_env_states << parse_deployed_env(env_dir, moduledir)
+        end
+      end
+
+      return deployed_env_states
     end
 
     # Return a single module_source hashmap for the given module_name from the given env_map.

--- a/spec/unit/api_spec.rb
+++ b/spec/unit/api_spec.rb
@@ -114,7 +114,32 @@ RSpec.describe R10K::API do
     end
   end
 
-  describe ".parse_deployed_git_evn" do
+  describe ".parse_environmentdir" do
+
+    it "calls parse_deployed_env on each dir in the path" do
+      env_path = '/tmp/environments'
+      parse_env_a = '/dir_a'
+      parse_env_b = '/dir_b'
+      deployed_envs = [parse_env_a, parse_env_b]
+      mock_envmap_a = { :mock => :a_envmap }
+      mock_envmap_b = { :mock => :b_envmap }
+      mock_envmaps = [mock_envmap_a, mock_envmap_b]
+      moduledir = "mods"
+      allow(Dir).to receive(:glob).with(/#{env_path}/).and_return(deployed_envs)
+      allow(File).to receive(:directory?).with(Regexp.union(deployed_envs)).and_return(true)
+      expect(R10K::API).to receive(:parse_deployed_env).with(parse_env_a, moduledir).and_return(mock_envmap_a)
+      expect(R10K::API).to receive(:parse_deployed_env).with(parse_env_b, moduledir).and_return(mock_envmap_b)
+      expect(subject.parse_environmentdir(env_path, moduledir)).to eq(mock_envmaps)
+    end
+
+    it "returns an empty array if the environment dir is empty" do
+      empty_env_path = '/tmp/no_environments'
+      allow(Dir).to receive(:glob).with(/#{empty_env_path}/).and_return([])
+      expect(subject.parse_environmentdir(empty_env_path)).to eq([])
+    end
+  end
+
+  describe ".parse_deployed_git_env" do
     pending
   end
 


### PR DESCRIPTION
With this commit, the method is added to parse an entire environment
directory. Tests are included to make sure the proper calls are made.
