### PR TITLE
(CODEMGMT-199) rjgit provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 
 group :extra do
   gem 'rugged', '~> 0.21.4', :platforms => :ruby
+  gem 'rjgit', :git => 'https://github.com/andersonmills/rjgit.git', :branch => 'add_git_dir_to_repo', :platforms => :jruby
+#  gem 'rjgit', '~> 4.1.1.0', :platforms => :jruby
 end
 
 group :development do

--- a/lib/r10k/api/git.rb
+++ b/lib/r10k/api/git.rb
@@ -23,6 +23,10 @@ module R10K
       private
 
       def self.provider
+        if R10K::Features.available?(:rjgit)
+          R10K::Git.provider = :rjgit
+        end
+
         R10K::Git.provider
       end
       private_class_method :provider

--- a/lib/r10k/features.rb
+++ b/lib/r10k/features.rb
@@ -17,4 +17,6 @@ R10K::Features.add(:shellgit) { R10K::Util::Commands.which('git') }
 
 R10K::Features.add(:rugged, :libraries => 'rugged')
 
+R10K::Features.add(:rjgit, :libraries => 'rjgit')
+
 R10K::Features.add(:pe_license, :libraries => 'pe_license')

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -8,6 +8,7 @@ module R10K
   module Git
     require 'r10k/git/shellgit'
     require 'r10k/git/rugged'
+    require 'r10k/git/rjgit'
 
     extend R10K::Logging
 
@@ -32,6 +33,12 @@ module R10K
               end
             end
           end
+        }
+      ],
+      [ :rjgit,
+        {
+          :feature => :rjgit,
+          :module  => R10K::Git::RJGit,
         }
       ],
     ]

--- a/lib/r10k/git/rjgit.rb
+++ b/lib/r10k/git/rjgit.rb
@@ -1,0 +1,48 @@
+require 'r10k/logging'
+
+if R10K::Features.available?(:rjgit)
+  require 'rjgit'
+end
+
+module R10K
+  module Git
+    module RJGit
+      extend R10K::Logging
+
+      module_function
+
+      def reset(ver, opts = {})
+        reset_mode = opts[:hard] ? "HARD" : "MIXED"
+
+        repo = ::RJGit::Repo.new(opts[:work_tree], git_dir: opts[:git_dir])
+        opts[:repo] = repo
+        commit = resolve_version(ver, opts)
+        repo.git.reset(commit, reset_mode)
+      end
+
+      def clean(opts = {})
+        # TODO: implement excludes:
+        if opts[:excludes]
+          raise NotImplementedError, "rjgit clean does not implement excludes, yet."
+        end
+
+        repo = ::RJGit::Repo.new(opts[:work_tree], git_dir: opts[:git_dir])
+        repo.clean
+      end
+
+      def rev_parse(ver, opts = {})
+        ref = resolve_version(ver, opts)
+        ref.id
+      end
+
+      private
+
+      def self.resolve_version(ver, opts = {})
+        repo = opts[:repo] || ::RJGit::Repo.new(opts[:git_dir], is_bare: true)
+        ref = repo.commits(ver).first
+      end
+
+      private_class_method :resolve_version
+    end
+  end
+end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -17,14 +17,33 @@ describe R10K::Git do
         expect(R10K::Features).to receive(:available?).with(:rugged).and_return true
         expect(described_class.default_name).to eq :rugged
       end
+
+      it 'raises an error when the git executable and rugged library are absent' do
+        expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
+        expect(R10K::Features).to receive(:available?).with(:rugged).and_return false
+        expect(R10K::Features).to receive(:available?).with(:rjgit).and_return false
+        expect {
+          described_class.default_name
+        }.to raise_error(R10K::Error, 'No Git providers are functional.')
+      end
     end
 
-    it 'raises an error when the git executable and rugged library are absent' do
-      expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
-      expect(R10K::Features).to receive(:available?).with(:rugged).and_return false
-      expect {
-        described_class.default_name
-      }.to raise_error(R10K::Error, 'No Git providers are functional.')
+    context 'under jruby', :if => R10K::Util::Platform.jruby? do
+      it 'returns rjgit when the git executable is absent and the rjgit library is present' do
+        expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
+        expect(R10K::Features).to receive(:available?).with(:rugged).and_return false
+        expect(R10K::Features).to receive(:available?).with(:rjgit).and_return true
+        expect(described_class.default_name).to eq :rjgit
+      end
+
+      it 'raises an error when the git executable and rjgit library are absent' do
+        expect(R10K::Features).to receive(:available?).with(:shellgit).and_return false
+        expect(R10K::Features).to receive(:available?).with(:rugged).and_return false
+        expect(R10K::Features).to receive(:available?).with(:rjgit).and_return false
+        expect {
+          described_class.default_name
+        }.to raise_error(R10K::Error, 'No Git providers are functional.')
+      end
     end
 
     it "goes into an error state if an invalid provider was set" do


### PR DESCRIPTION
This commit adds an rjgit provider to r10k, but only for the r10k-api.

And, there are no tests, yet. That will be put together in RK-202.
