### PR TITLE
(RK-190) Implement basic env_map resolution functions

### DIFF
--- a/lib/r10k/api/git.rb
+++ b/lib/r10k/api/git.rb
@@ -6,6 +6,8 @@ module R10K
     module Git
       extend R10K::Logging
 
+      class CommandFailedError < StandardError; end
+
       module_function
 
       def reset(ref, opts={})
@@ -17,7 +19,13 @@ module R10K
       end
 
       def rev_parse(rev, opts={})
-        provider.rev_parse(rev, opts)
+        result = provider.rev_parse(rev, opts)
+
+        if result.success?
+          return result.stdout.strip
+        else
+          raise CommandFailedError.new(result.stderr)
+        end
       end
 
       private

--- a/lib/r10k/git/shellgit.rb
+++ b/lib/r10k/git/shellgit.rb
@@ -40,7 +40,7 @@ module R10K
       def rev_parse(rev, opts = {})
         cmd = ["rev-parse", rev]
 
-        git(cmd, opts).stdout
+        git(cmd, opts)
       end
 
       # Wrap git commands


### PR DESCRIPTION
This adds the ability to resolve environment maps containing git and Forge sourced module declarations.

Still needs unit testing and there are some bits that will need to be adjusted to work with the jgit provider, but the basic resolution logic is all in place.
