### PR TITLE
(RK-206) add ssh transport to rjgit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :extra do
   gem 'rugged', '~> 0.21.4', :platforms => :ruby
-  gem 'rjgit', :git => 'https://github.com/andersonmills/rjgit.git', :branch => 'add_fetch_to_git', :platforms => :jruby
+  gem 'rjgit', :git => 'https://github.com/andersonmills/rjgit.git', :branch => 'master', :platforms => :jruby
 #  gem 'rjgit', :path => '/Users/anderson/puppet/src/rjgit', :platforms => :jruby
 #  gem 'rjgit', '~> 4.1.1.0', :platforms => :jruby
 end

--- a/lib/r10k/api/git.rb
+++ b/lib/r10k/api/git.rb
@@ -56,7 +56,7 @@ module R10K
       # @return [true] Repo was successfully cloned to local path.
       # @raise [R10K::Git::GitError] An error was encountered, see exception message.
       def clone(local, remote, opts={})
-        git_opts = filter_opts(opts, :private_key, :user, :bare)
+        git_opts = filter_opts(opts, :private_key, :username, :bare)
 
         # TODO: swap arguments in provider to match
         provider.clone(remote, local, git_opts)

--- a/lib/r10k/git/rjgit.rb
+++ b/lib/r10k/git/rjgit.rb
@@ -66,14 +66,12 @@ module R10K
           raise R10K::Git::GitError.new("CloneCommand requires that local parent directory (#{local_parent}) already exist.")
         end
 
-        if opts[:private_key] || opts[:username]
-          raise NotImplementedError, "RJGit does not support SSH transport."
-        end
-
         clone_opts = {
           branch: :all,
           is_bare: opts[:bare],
         }
+        clone_opts = clone_opts.merge(private_key_file: opts[:private_key]) if opts[:private_key]
+        clone_opts = clone_opts.merge(username: opts[:username]) if opts[:username]
 
         begin
           ::RJGit::RubyGit.clone(remote, local, clone_opts)
@@ -87,15 +85,13 @@ module R10K
       end
 
       def fetch(git_dir, remote, opts={})
-        if opts[:private_key] || opts[:username]
-          raise NotImplementedError, "RJGit does not support SSH transport."
-        end
-
         repo = ::RJGit::Repo.new(git_dir, is_bare: true)
 
         fetch_opts = {
           refspecs: "+refs/*:refs/*",
         }
+        fetch_opts = fetch_opts.merge(private_key_file: opts[:private_key]) if opts[:private_key]
+        fetch_opts = fetch_opts.merge(username: opts[:username]) if opts[:username]
 
         begin
           repo.git.fetch(remote, fetch_opts)

--- a/lib/r10k/git/rjgit.rb
+++ b/lib/r10k/git/rjgit.rb
@@ -70,8 +70,8 @@ module R10K
           branch: :all,
           is_bare: opts[:bare],
         }
-        clone_opts = clone_opts.merge(private_key_file: opts[:private_key]) if opts[:private_key]
-        clone_opts = clone_opts.merge(username: opts[:username]) if opts[:username]
+        clone_opts[:private_key_file] = opts[:private_key] if opts[:private_key]
+        clone_opts[:username] = opts[:username] if opts[:username]
 
         begin
           ::RJGit::RubyGit.clone(remote, local, clone_opts)
@@ -90,8 +90,8 @@ module R10K
         fetch_opts = {
           refspecs: "+refs/*:refs/*",
         }
-        fetch_opts = fetch_opts.merge(private_key_file: opts[:private_key]) if opts[:private_key]
-        fetch_opts = fetch_opts.merge(username: opts[:username]) if opts[:username]
+        fetch_opts[:private_key_file] = opts[:private_key] if opts[:private_key]
+        fetch_opts[:username] = opts[:username] if opts[:username]
 
         begin
           repo.git.fetch(remote, fetch_opts)


### PR DESCRIPTION
This commit uses the new ssh transport functionality of rjgit to allow
users to use ssh to connect to remote git repositories.
