### PR TITLE
(RK-220) Fail early when git private key is unreadable

### DIFF
--- a/lib/r10k/git/rugged/credentials.rb
+++ b/lib/r10k/git/rugged/credentials.rb
@@ -40,6 +40,10 @@ class R10K::Git::Rugged::Credentials
       raise R10K::Git::GitError.new("Git remote #{url.inspect} uses the SSH protocol but no private key was given", :git_dir => @repository.path.to_s)
     end
 
+    if !File.readable?(private_key)
+      raise R10K::Git::GitError.new("Unable to use SSH key auth for #{url.inspect}: private key #{private_key.inspect} is missing or unreadable", :git_dir => @repository.path.to_s)
+    end
+
     Rugged::Credentials::SshKey.new(:username => user, :privatekey => private_key)
   end
 


### PR DESCRIPTION
When r10k was using rugged and Git SSH remotes with pubkey
authentication, r10k didn't check if the specified SSH key was readable
and let rugged do that checking. However rugged's error messaging around
this was less than clear when the private key was missing or unreadable
which users found confusing. This commit remedies the error messaging by
doing the check inside of r10k and failing early with a more readable
message.
