### PR TITLE
(RK-154) Move repository config from a hash to a list.

### DIFF
--- a/doc/git/providers.mkd
+++ b/doc/git/providers.mkd
@@ -40,14 +40,26 @@ greater to use this provider.
 
 ### SSH Configuration
 
-In order to use rugged with SSH based Git repositories, the 'private_key' option
-must be provided. An optional 'username' field can be provided when the Git
-remote URL does not provide a username.
+Since the rugged provider does not read ~/.ssh if using SSH based Git
+repositories, the 'private_key' option must be provided. An optional 'username'
+field can be provided when the Git remote URL does not provide a username.
 
 ```yaml
 git:
   private_key: '/root/.ssh/id_rsa'
   username: 'git'
+```
+
+If you have per repository private keys you can add them with the repositories list.
+
+```yaml
+git:
+  # default private key
+  private_key: '/root/.ssh/id_rsa'
+  repositories:
+    - remote: "git@github.com:my_org/private_repo"
+      # private key for this repo only
+      private_key: '/root/.ssh/private_repo_id'
 ```
 
 #### Supported transports with Rugged
@@ -72,7 +84,7 @@ irb(main):001:0> require('rugged')
 => true
 irb(main):002:0> Rugged.features
 => [:threads, :https, :ssh]
-irb(main):003:0> 
+irb(main):003:0>
 ```
 You will require the ':https' or ':ssh' features to use the respective protocols
 in your Puppetfile module references or in r10k.yaml. R10K 2.0.0 and later will

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -135,5 +135,9 @@ module R10K
     def_setting_attr :private_key
     def_setting_attr :username
     def_setting_attr :repositories, {}
+
+    def self.get_repo_settings(remote)
+      self.settings[:repositories].find {|r| r[:remote] == remote }
+    end
   end
 end

--- a/lib/r10k/git/rugged/credentials.rb
+++ b/lib/r10k/git/rugged/credentials.rb
@@ -27,15 +27,19 @@ class R10K::Git::Rugged::Credentials
   def get_ssh_key_credentials(url, username_from_url)
     user = get_git_username(url, username_from_url)
 
-    per_repo_private_key = R10K::Git.settings[:repositories].fetch(url, {})[:private_key]
+    per_repo_private_key = nil
+    if per_repo_settings = R10K::Git.get_repo_settings(url)
+      per_repo_private_key = per_repo_settings[:private_key]
+    end
+
     global_private_key = R10K::Git.settings[:private_key]
 
     if per_repo_private_key
       private_key = per_repo_private_key
-      logger.debug2 "Using per-repository private key #{per_repo_private_key} for URL #{url.inspect}"
+      logger.debug2 "Using per-repository private key #{private_key} for URL #{url.inspect}"
     elsif global_private_key
       private_key = global_private_key
-      logger.debug2 "URL #{url.inspect} has a per-repository private key #{per_repo_private_key}"
+      logger.debug2 "URL #{url.inspect} has no per-repository private key using '#{private_key}'."
     else
       raise R10K::Git::GitError.new("Git remote #{url.inspect} uses the SSH protocol but no private key was given", :git_dir => @repository.path.to_s)
     end

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -30,18 +30,19 @@ module R10K
         }),
 
         Definition.new(:repositories, {
-          :desc => "Repository specific configuration.",
-          :default => {},
-          :normalize => lambda do |repositories|
-            # The config file loading logic recursively converts hash keys that are strings to symbols,
-            # but in this case it makes sense to have string hash keys. This normalization undoes the
-            # hash key symbolization.
-            repositories.inject({}) do |retval, (key, value)|
-              retval[key.to_s] = value
+        :desc => "Repository specific configuration.",
+        :default => [],
+        :normalize => lambda do |repositories|
+        # The config file loading logic recursively converts hash keys that are strings to symbols,
+        # It doesn't understand hashes inside arrays though so we have to do this manually.
+          repositories.map do |repo|
+            repo.inject({}) do |retval, (key, value)|
+              retval[key.to_sym] = value
               retval
             end
           end
-        }),
+        end
+      }),
       ])
     end
 

--- a/lib/r10k/settings/collection.rb
+++ b/lib/r10k/settings/collection.rb
@@ -39,6 +39,7 @@ module R10K
       def assign(newvalues)
         return if newvalues.nil?
 
+        # TODO: this results in inconsistency for hashes inside arrays.
         R10K::Util::SymbolizeKeys.symbolize_keys!(newvalues)
         @settings.each_pair do |name, setting|
           if newvalues.key?(name)

--- a/spec/unit/git/rugged/credentials_spec.rb
+++ b/spec/unit/git/rugged/credentials_spec.rb
@@ -39,7 +39,8 @@ describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? 
 
     it "prefers a per-repository SSH private key" do
       allow(File).to receive(:readable?).with("/etc/puppetlabs/r10k/ssh/tessier-ashpool-id_rsa").and_return true
-      R10K::Git.settings[:repositories]["ssh://git@tessier-ashpool.freeside/repo.git"] = {private_key: "/etc/puppetlabs/r10k/ssh/tessier-ashpool-id_rsa"}
+      R10K::Git.settings[:repositories] = [{ remote: "ssh://git@tessier-ashpool.freeside/repo.git",
+        private_key: "/etc/puppetlabs/r10k/ssh/tessier-ashpool-id_rsa"}]
       creds = subject.get_ssh_key_credentials("ssh://git@tessier-ashpool.freeside/repo.git", nil)
       expect(creds).to be_a_kind_of(Rugged::Credentials::SshKey)
       expect(creds.instance_variable_get(:@privatekey)).to eq("/etc/puppetlabs/r10k/ssh/tessier-ashpool-id_rsa")

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -149,7 +149,14 @@ describe R10K::Settings do
     describe "git settings" do
       it "passes settings through to the git settings" do
         output = subject.evaluate("git" => {"provider" => "shellgit", "username" => "git"})
-        expect(output[:git]).to eq(:provider => :shellgit, :username => "git", :private_key => nil, :repositories => {})
+        expect(output[:git]).to eq(:provider => :shellgit, :username => "git", :private_key => nil, :repositories => [])
+      end
+
+      it "handles keywords in repository settings" do
+        output = subject.evaluate("git" => {"provider" => "shellgit",
+                                  "username" => "git",
+                                  "repositories" => [ {"remote" => "foo"} ]})
+        expect(output[:git]).to eq(:provider => :shellgit, :username => "git", :private_key => nil, :repositories => [{remote: "foo"}])
       end
     end
 


### PR DESCRIPTION
We may eventually want an ordering to the repository specific configs.
Also it's painful to work with complex YAML keys with some tools.
