### PR TITLE
(CODEMGMT-660) (maint) bump puppet_forge dependency

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
 
-  s.add_dependency 'puppet_forge', '~> 2.1.1'
+  s.add_dependency 'puppet_forge', '~> 2.1.4'
   s.add_dependency 'semantic_puppet', '~> 0.1.0'
   s.add_dependency 'minitar'
 


### PR DESCRIPTION
This commit updates to puppet_forge 2.1.4.
