### PR TITLE
(maint) Fix documentation of per repo private keys.

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -107,7 +107,7 @@ overrides the global private_key setting.
 ```yaml
 git:
   repositories:
-    "ssh://tessier-ashpool.freeside/protected-repo.git":
+    - remote: "ssh://tessier-ashpool.freeside/protected-repo.git"
       private_key: "/etc/puppetlabs/r10k/ssh/id_rsa-protected-repo-deploy-key"
 ```
 


### PR DESCRIPTION
This commit updates the documentation for per repo private keys on the dynamic environments docs.
