### PR TITLE
(RK-243) Refuse to generate rugged credentials more than 50 times.

### DIFF
--- a/spec/unit/git/rugged/credentials_spec.rb
+++ b/spec/unit/git/rugged/credentials_spec.rb
@@ -99,5 +99,11 @@ describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? 
     it "creates default credentials when no other types are allowed" do
       expect(subject.call("https://tessier-ashpool.freeside/repo.git", nil, [])).to be_a_kind_of(Rugged::Credentials::Default)
     end
+
+    it "refuses to generate credentials more than 50 times" do
+      (1..50).each { subject.call("https://tessier-ashpool.freeside/repo.git", nil, [:plaintext]) }
+
+      expect { subject.call("https://tessier-ashpool.freeside/repo.git", nil, [:plaintext]) }.to raise_error(R10K::Git::GitError, /authentication failed/i)
+    end
   end
 end


### PR DESCRIPTION
In libgit2/rugged 0.24.0 the callback for fixed credentials continues to be called until either it raises an error or the server gives up. Since neither was happening, invalid credentials were leading to an
infinite retry loop.
