### PR TITLE
[R10K #583] - TPOC fix for local environment changes not being updated

### DIFF
--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -39,6 +39,12 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
     git(['config', '--get', 'remote.cache.url'], :path => @path.to_s, :raise_on_fail => false).stdout
   end
 
+  # Determine whether the workdir differs from origin.  Ignore untracked files because of .r10k-deploy.json
+  def changes
+    changes = git(['status', '--porcelain', '--untracked-files=no'], :path => @path.to_s, :raise_on_fail => false).stdout.split("\n")
+    changes.count
+  end
+
   private
 
   def setup_cache_remote

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -67,6 +67,9 @@ class R10K::Git::StatefulRepository
       :outdated
     elsif @cache.ref_type(@ref) == :branch && !@cache.synced?
       :outdated
+    elsif @repo.changes > 0
+      logger.debug { "Found #{@repo.changes} changes unstaged in workdir" }
+      :mismatched
     else
       :insync
     end


### PR DESCRIPTION
# What's the problem?

This is a a pull request to demonstrate a hacky fix for [R10K Issue #583](https://github.com/puppetlabs/r10k/issues/583).

In R10K 1.5.0 and later, if I make changes to a local environment directory (e.g. changing a file, deleting a file), then run `r10k deploy environment <blah>`, the changed or removed file is not restored because git doesn't think anything's changed as it's just comparing references.  

In R10K version 1.3.4, the file would be restored.
# What's this PR?

My idea was that `r10k deploy environment` could run `git status --porcelain --untracked-files=no` before determining the status of the working directory.  If there were unstaged changes, someone's been messing around in the working directory and the whole thing should be considered mismatched.

I don't expect this to be up to standard, and it's incomplete, but this is enough to demonstrate the behaviour I'd expect from R10K in this scenario.  Maybe it could be used as a basis for further work?

Only implements `shellgit` changes, for demonstration purposes.  

There is more than likely a better way to implement this idea.
# Demonstration?

Shell output below on Ruby 2.3.0:

```
# remove environment completely
root@vagrant:/# rm -rf /etc/puppet/environments/master/

# deploy environment, fresh.
root@vagrant:/# r10k deploy environment master --verbose debug
[2016-06-01 01:36:50 - WARN] The r10k configuration file at /etc/r10k.yaml is deprecated.
[2016-06-01 01:36:50 - WARN] Please move your r10k configuration to /etc/puppetlabs/r10k/r10k.yaml.
[2016-06-01 01:36:50 - DEBUG] Fetching 'git@github.com:hybby/puppet.git' to determine current branches.
[2016-06-01 01:36:56 - INFO] Deploying environment /etc/puppet/environments/master
[2016-06-01 01:36:56 - DEBUG] Cloning /etc/puppet/environments/master and checking out master
[2016-06-01 01:37:05 - INFO] Environment master is now at fb00587ea2ca36ed0ed6858738460f176fc23e7f
[2016-06-01 01:37:05 - DEBUG] Environment master is new, updating all modules

# check what modules we have
root@vagrant:/# ls /etc/puppet/environments/master/modules/
dns  dotfiles  firewall  motd  rootuser  selinux  sshd

# remove a module
root@vagrant:/# rm -rf /etc/puppet/environments/master/modules/firewall/

# check it's gone
root@vagrant:/# ls /etc/puppet/environments/master/modules/
dns  dotfiles  motd  rootuser  selinux  sshd

# redeploy environment
root@vagrant:/# r10k deploy environment master --verbose debug
[2016-06-01 01:37:19 - WARN] The r10k configuration file at /etc/r10k.yaml is deprecated.
[2016-06-01 01:37:19 - WARN] Please move your r10k configuration to /etc/puppetlabs/r10k/r10k.yaml.
[2016-06-01 01:37:19 - DEBUG] Fetching 'git@github.com:hybby/puppet.git' to determine current branches.
[2016-06-01 01:37:26 - DEBUG] Found 7 changes unstaged in workdir
[2016-06-01 01:37:26 - INFO] Deploying environment /etc/puppet/environments/master
[2016-06-01 01:37:26 - DEBUG] Found 7 changes unstaged in workdir
[2016-06-01 01:37:26 - DEBUG] Replacing /etc/puppet/environments/master and checking out master
[2016-06-01 01:37:32 - INFO] Environment master is now at fb00587ea2ca36ed0ed6858738460f176fc23e7f

# check that removed file has been restored
root@vagrant:/# ls /etc/puppet/environments/master/modules/
dns  dotfiles  firewall  motd  rootuser  selinux  sshd
```
