### PR TITLE
Feature support custom puppetfile name

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -1,5 +1,6 @@
 require 'pathname'
 require 'r10k/module'
+require 'r10k/settings'
 require 'r10k/util/purgeable'
 require 'r10k/errors'
 
@@ -8,6 +9,9 @@ class Puppetfile
   # Defines the data members of a Puppetfile
 
   include R10K::Logging
+  include R10K::Settings::Mixin
+
+  def_setting_attr :puppetfile, 'Puppetfile'
 
   # @!attribute [r] forge
   #   @return [String] The URL to use for the Puppet Forge
@@ -38,7 +42,7 @@ class Puppetfile
   def initialize(basedir, moduledir = nil, puppetfile = nil)
     @basedir         = basedir
     @moduledir       = moduledir  || File.join(basedir, 'modules')
-    @puppetfile_path = puppetfile || File.join(basedir, 'Puppetfile')
+    @puppetfile_path = puppetfile || File.join(basedir, settings[:puppetfile])
 
     @modules = []
     @managed_content = {}

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -122,6 +122,11 @@ module R10K
           :desc => "Where r10k should store cached Git repositories.",
         }),
 
+        Definition.new(:puppetfile, {
+          :desc => "The relative name of the Puppetfile to use (default 'Puppetfile').",
+          :default => 'Puppetfile',
+        }),
+
         Definition.new(:postrun, {
           :desc => "The command r10k should run after deploying environments.",
           :validate => lambda do |value|

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -15,6 +15,20 @@ describe R10K::Puppetfile do
     end
   end
 
+  describe "the default puppetfile" do
+    it "is the basedir joined with '/Puppetfile' path" do
+      expect(subject.puppetfile_path).to eq '/some/nonexistent/basedir/Puppetfile'
+    end
+  end
+
+  describe "a custom puppetfile Puppetfile.r10k" do
+    before { R10K::Puppetfile.settings[:puppetfile] = "Puppetfile.r10k" }
+    after { R10K::Puppetfile.settings.reset! }
+    it "is the basedir joined with '/Puppetfile.r10k' path" do
+      expect(subject.puppetfile_path).to eq '/some/nonexistent/basedir/Puppetfile.r10k'
+    end
+  end
+
   describe "setting moduledir" do
     it "changes to given moduledir if it is an absolute path" do
       subject.set_moduledir('/absolute/path/moduledir')


### PR DESCRIPTION
We need a way to specify a custom puppetfile name (e.g. Puppetfile.r10k) as Puppetfiles for r10k and librarian-puppet are not compatible and we use both tools for Module management. Therefore we need the possibility to use a different Puppetfile in our repos.
