### PR TITLE
(MAINT) Fixup test regex for unmanaged content removal logging.

### DIFF
--- a/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
@@ -21,7 +21,7 @@ site_pp = create_site_pp(master_certname, '  include helloworld')
 #Verification
 notify_message_prod_env_regex = /I am in the production environment/
 notify_message_test_env_regex = /I am in the test environment/
-removal_message_test_env_regex = /Removing unmanaged path.*test/
+removal_message_test_env_regex = /Removed unmanaged path.*test/
 error_message_regex = /Could not retrieve catalog from remote server/
 
 #Teardown


### PR DESCRIPTION
This was changed in RK-246 I think, the logging now happens after deletion instead of before and the message was updated to reflect that.
