### PR TITLE
Check version while parsing Puppetfile

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -17,7 +17,7 @@ class R10K::Module::Forge < R10K::Module::Base
   end
 
   def self.valid_version?(expected_version)
-    expected_version == :latest || expected_version.empty? || SemanticPuppet::Version.valid?(expected_version)
+    expected_version == :latest || expected_version.nil? || SemanticPuppet::Version.valid?(expected_version)
   end
 
   # @!attribute [r] metadata

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -13,7 +13,11 @@ class R10K::Module::Forge < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    !!(name.match %r[\w+[/-]\w+])
+    !!(name.match %r[\w+[/-]\w+]) && valid_version?(args)
+  end
+
+  def self.valid_version?(expected_version)
+    expected_version == :latest || expected_version.empty? || SemanticPuppet::Version.valid?(expected_version)
   end
 
   # @!attribute [r] metadata

--- a/spec/fixtures/unit/puppetfile/valid-forge-with-version/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/valid-forge-with-version/Puppetfile
@@ -1,0 +1,1 @@
+mod 'puppetlabs/apt', '2.1.1'

--- a/spec/fixtures/unit/puppetfile/valid-forge-without-version/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/valid-forge-without-version/Puppetfile
@@ -1,0 +1,1 @@
+mod 'puppetlabs/apt'

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -11,9 +11,9 @@ describe R10K::Module do
 
   describe 'delegating to R10K::Module::Forge' do
     [
-      ['bar/quux', []],
-      ['bar-quux', []],
-      ['bar/quux', ['8.0.0']],
+      ['bar/quux', nil],
+      ['bar-quux', nil],
+      ['bar/quux', '8.0.0'],
     ].each do |scenario|
       it "accepts a name matching #{scenario[0]} and args #{scenario[1].inspect}" do
         expect(R10K::Module.new(scenario[0], '/modulepath', scenario[1])).to be_a_kind_of(R10K::Module::Forge)

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -35,6 +35,18 @@ describe R10K::Puppetfile do
       expect(subject.modules.collect(&:name)).to include('test_module')
     end
 
+    it "should not accept Forge modules with a version comparison" do
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, '< 1.2.0').and_call_original
+
+      expect {
+        subject.add_module('puppet/test_module', '< 1.2.0')
+      }.to raise_error(
+        RuntimeError,
+        "Module puppet/test_module with args \"< 1.2.0\" doesn't have an implementation. (Are you using the right arguments?)"
+      )
+      expect(subject.modules.collect(&:name)).not_to include('test_module')
+    end
+
     it "should accept non-Forge modules with a hash arg" do
       module_opts = { git: 'git@example.com:puppet/test_module.git' }
 

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -144,6 +144,20 @@ describe R10K::Puppetfile do
         expect_wrapped_error(e, pf_path, ArgumentError)
       end
     end
+
+    it "accepts a forge module with a version" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect { subject.load! }.not_to raise_error
+    end
+
+    it "accepts a forge module without a version" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-without-version')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect { subject.load! }.not_to raise_error
+    end
   end
 
   describe "accepting a visitor" do


### PR DESCRIPTION
[Librarian Puppet supports constraints](https://github.com/voxpupuli/librarian-puppet/blob/master/features/install/forge.feature#L88) in the Puppetfile, but r10k doesn't and throws a rather obscure error:

```
ERROR    -> bad URI(is not URI?): /v3/files/puppetlabs-concat-< 2.0.0.tar.gz
```

This Pull Request seeks to fix that by ensuring the argument provided for a forge module is a valid Semantic Version number (using `semantic_puppet`) or `:latest` or it's absent.

Along the way I couldn't figure out what `args` would look like without a version, `module_spec` led me to believe it would be an empty array, but that is incorrect. So I've attempted to better define it with an example spec that has some Puppetfile fixtures for forge with and without args.
