### PR TITLE
workflow-guide typo?

### DIFF
--- a/doc/dynamic-environments/workflow-guide.mkd
+++ b/doc/dynamic-environments/workflow-guide.mkd
@@ -204,22 +204,22 @@ you are satisfied with the results.
 
 ### Merge changes
 
-In each of the changed module repos, checkout the main branch and merge.
+In each of the changed module repos, checkout the main production branch and merge.
 
 ```
 # Module repos
-git checkout master
+git checkout production
 git merge feature
-git push origin master
+git push origin production
 ```
 
-In the Control repo, check out master. Do NOT merge the feature branch as it
+In the Control repo, check out production. Do NOT merge the feature branch as it
 now references the incorrect branch for each git repo, and no other changes
 were made (unlike a new module, where a new repo is referenced).
 
 ```
 # Control repo
-git checkout master
+git checkout production
 ```
 
 ### Cleanup feature branches

--- a/doc/dynamic-environments/workflow-guide.mkd
+++ b/doc/dynamic-environments/workflow-guide.mkd
@@ -204,13 +204,13 @@ you are satisfied with the results.
 
 ### Merge changes
 
-In each of the changed module repos, checkout the main production branch and merge.
+In each of the changed module repos, checkout the main branch and merge.
 
 ```
 # Module repos
-git checkout production
+git checkout master
 git merge feature
-git push origin production
+git push origin master
 ```
 
 In the Control repo, check out production. Do NOT merge the feature branch as it
@@ -234,7 +234,7 @@ git branch -D repo
 git push origin :repo
 ```
 
-Redeploy with r10k on the master and ensure there are no errors. The *feature*
+Redeploy with r10k on the production and ensure there are no errors. The *feature*
 dynamic environment should no longer exist at `$environmentpath/feature`.
 
 ```r10k deploy environment -p```


### PR DESCRIPTION
In the workflow-guide you first declare, that puppet control repo should have main branch "production"
But later, in section "Editing existing Modules", at #Merge changes part, you propose

```
# Control repo
git checkout master
```

But we have main branch Production?
