### PR TITLE
(MAINT) Use gettext_setup 0.5

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'semantic_puppet', '~> 0.1.0'
   s.add_dependency 'minitar'
 
-  s.add_dependency 'gettext-setup', '>= 0.3'
+  s.add_dependency 'gettext-setup', '~> 0.5'
 
   s.add_development_dependency 'rspec', '~> 3.1'
 


### PR DESCRIPTION
Before v0.5, fast_gettext has no restrictions. This creates problems
when using ruby versions before 2.1.0.
