### PR TITLE
Fix typo: environment.path for environment_path

### DIFF
--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -37,7 +37,7 @@ module R10K
           if @opts[:environment] && (@opts[:environment] != environment.dirname)
             logger.debug1(_("Only updating modules in environment %{opt_env} skipping environment %{env_path}") % {opt_env: @opts[:environment], env_path: environment.path})
           else
-            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @argv.inspect, env_path: environment_path})
+            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @argv.inspect, env_path: environment.path})
             yield
           end
         end


### PR DESCRIPTION
Otherwise R10k::Action::Deploy::Module fails with "undefined local variable or method `environment_path' for #R10K::Action::Deploy::Module:0x00aabbcc".
