### PR TITLE
Fix link in documentation

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -46,10 +46,9 @@ For example:
 cachedir: '/var/cache/r10k'
 ```
 
-[prerun_command](http://docs.puppetlabs.com/references/latest/configuration.html#preruncommand)
 
 The cachedir setting defaults to `~/.r10k`. If the HOME environment variable is
-unset r10k will assume that r10k is being run with the Puppet [`prerun_command`][prerun_command]
+unset r10k will assume that r10k is being run with the Puppet [`prerun_command`](http://docs.puppetlabs.com/references/latest/configuration.html#preruncommand)
 setting and will set the cachedir default to `/root/.r10k`.
 
 ### proxy


### PR DESCRIPTION
So I read the documentation and found a misplaced link.
