### PR TITLE
[puppetlabs/r10k] (GH-645) Fix undefined method if r10.yaml empty

### DIFF
--- a/lib/r10k/settings/loader.rb
+++ b/lib/r10k/settings/loader.rb
@@ -69,8 +69,8 @@ module R10K
           raise ConfigError, _("Couldn't load config file: %{error_msg}") % {error_msg: e.message}
         end
 
-        if ! contents
-          raise ConfigError, _("File exists at #{path} but doesn't contain any YAML") % {path:path}
+        if !contents
+          raise ConfigError, _("File exists at #{path} but doesn't contain any YAML") % {path: path}
         end
         R10K::Util::SymbolizeKeys.symbolize_keys!(contents, true)
         contents

--- a/lib/r10k/settings/loader.rb
+++ b/lib/r10k/settings/loader.rb
@@ -69,6 +69,9 @@ module R10K
           raise ConfigError, _("Couldn't load config file: %{error_msg}") % {error_msg: e.message}
         end
 
+        if ! contents
+          raise ConfigError, _("File exists at #{path} but doesn't contain any YAML") % {path:path}
+        end
         R10K::Util::SymbolizeKeys.symbolize_keys!(contents, true)
         contents
       end


### PR DESCRIPTION
Protect the call to `symbolize_keys!` by raising ConfigError with helpful message if no YAML was loaded
