### PR TITLE
[puppetlabs/r10k] (GH-647) identify r10k on error

### DIFF
--- a/bin/r10k
+++ b/bin/r10k
@@ -6,12 +6,12 @@ require 'colored'
 begin
   R10K::CLI.command.run(ARGV)
 rescue Interrupt
-  $stderr.puts "Aborted!".red
+  $stderr.puts "#{File.basename($PROGRAM_NAME)} Aborted!".red
   exit(1)
 rescue SystemExit => e
   exit(e.status)
 rescue Exception => e
-  $stderr.puts "\nError while running: #{e.inspect}".red
+  $stderr.puts "\nError running #{File.basename($PROGRAM_NAME)}: #{e.inspect}".red
   $stderr.puts e.backtrace.join("\n").red if ARGV.include? '--trace'
   exit(1)
 end


### PR DESCRIPTION
Incorporate the program name into the message when exiting on exception
eg "error while running r10k: ..." not just "error while running: ..."
