### PR TITLE
Feature support custom puppetfile name per source

### DIFF
--- a/lib/r10k/action/puppetfile/check.rb
+++ b/lib/r10k/action/puppetfile/check.rb
@@ -8,7 +8,7 @@ module R10K
       class Check < R10K::Action::Base
 
         def call
-          pf = R10K::Puppetfile.new(@root, @moduledir, @path)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
           begin
             pf.load!
             $stderr.puts _("Syntax OK")

--- a/lib/r10k/action/puppetfile/purge.rb
+++ b/lib/r10k/action/puppetfile/purge.rb
@@ -8,7 +8,7 @@ module R10K
       class Purge < R10K::Action::Base
 
         def call
-          pf = R10K::Puppetfile.new(@root, @moduledir, @path)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
           pf.load!
           pf.purge!
           true

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -45,6 +45,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           name  'check'
           usage 'check'
           summary 'Try and load the Puppetfile to verify the syntax is correct.'
+
+          required nil, :puppetfile, 'Path to puppetfile'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Check)
         end
       end
@@ -57,6 +59,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'purge'
           summary 'Purge unmanaged modules from a Puppetfile managed directory'
 
+          required nil, :moduledir, 'Path to install modules to'
+          required nil, :puppetfile, 'Path to puppetfile'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Purge)
         end
       end

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -36,11 +36,12 @@ class R10K::Environment::Base
     @basedir = basedir
     @dirname = dirname
     @options = options
+    @puppetfile_name = options[:puppetfile_name]
 
     @full_path = File.join(@basedir, @dirname)
     @path = Pathname.new(File.join(@basedir, @dirname))
 
-    @puppetfile  = R10K::Puppetfile.new(@full_path)
+    @puppetfile  = R10K::Puppetfile.new(@full_path, nil, nil, puppetfile_name = @puppetfile_name)
     @puppetfile.environment = self
   end
 

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -24,6 +24,11 @@ class R10K::Environment::Base
   #   @return [R10K::Puppetfile] The puppetfile instance associated with this environment
   attr_reader :puppetfile
 
+  # @!attribute [r] puppetfile_name
+  #   @api public
+  #   @return [String] The puppetfile name (relative)
+  attr_reader :puppetfile_name
+
   # Initialize the given environment.
   #
   # @param name [String] The unique name describing this environment.

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -46,7 +46,7 @@ class R10K::Environment::Base
     @full_path = File.join(@basedir, @dirname)
     @path = Pathname.new(File.join(@basedir, @dirname))
 
-    @puppetfile  = R10K::Puppetfile.new(@full_path, nil, nil, puppetfile_name = @puppetfile_name)
+    @puppetfile  = R10K::Puppetfile.new(@full_path, nil, nil, @puppetfile_name)
     @puppetfile.environment = self
   end
 

--- a/lib/r10k/environment/svn.rb
+++ b/lib/r10k/environment/svn.rb
@@ -43,7 +43,7 @@ class R10K::Environment::SVN < R10K::Environment::Base
   def initialize(name, basedir, dirname, options = {})
     super
 
-    setopts(options, {:remote => :self, :username => :self, :password => :self})
+    setopts(options, {:remote => :self, :username => :self, :password => :self, :puppetfile_name => :self })
 
     @working_dir = R10K::SVN::WorkingDir.new(Pathname.new(@full_path), :username => @username, :password => @password)
   end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -36,10 +36,14 @@ class Puppetfile
   # @param [String] basedir
   # @param [String] moduledir The directory to install the modules, default to #{basedir}/modules
   # @param [String] puppetfile_path The path to the Puppetfile, default to #{basedir}/Puppetfile
-  def initialize(basedir, moduledir = nil, puppetfile_path = nil)
+  # @param [String] puppetfile_name The name of the Puppetfile, default to 'Puppetfile'
+  def initialize(basedir, moduledir = nil, puppetfile_path = nil, puppetfile_name = nil )
     @basedir         = basedir
     @moduledir       = moduledir  || File.join(basedir, 'modules')
-    @puppetfile_path = puppetfile_path || File.join(basedir, 'Puppetfile')
+    @puppetfile_name = puppetfile_name || 'Puppetfile'
+    @puppetfile_path = puppetfile_path || File.join(basedir, @puppetfile_name)
+
+    logger.info _("Using Puppetfile '%{puppetfile}'") % {puppetfile: @puppetfile_path}
 
     @modules = []
     @managed_content = {}

--- a/lib/r10k/source/base.rb
+++ b/lib/r10k/source/base.rb
@@ -16,6 +16,11 @@ class R10K::Source::Base
   #     Defaults to nil.
   attr_reader :prefix
 
+  # @!attribute [r] puppetfile_name
+  #   @return [String, nil] The Name of the puppetfile
+  #     Defaults to nil.
+  attr_reader :puppetfile_name
+
   # Initialize the given source.
   #
   # @param name [String] The identifier for this source.
@@ -30,6 +35,7 @@ class R10K::Source::Base
     @name    = name
     @basedir = Pathname.new(basedir).cleanpath.to_s
     @prefix  = options.delete(:prefix)
+    @puppetfile_name = options.delete(:puppetfile_name)
     @options = options
   end
 

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -89,11 +89,11 @@ class R10K::Source::Git < R10K::Source::Base
     branch_names.each do |bn|
       if bn.valid?
         envs << R10K::Environment::Git.new(bn.name, @basedir, bn.dirname,
-                                       {:remote => remote, :ref => bn.name})
+                                       {:remote => remote, :ref => bn.name, :puppetfile_name => puppetfile_name })
       elsif bn.correct?
        logger.warn _("Environment %{env_name} contained non-word characters, correcting name to %{corrected_env_name}") % {env_name: bn.name.inspect, corrected_env_name: bn.dirname}
         envs << R10K::Environment::Git.new(bn.name, @basedir, bn.dirname,
-                                       {:remote => remote, :ref => bn.name})
+                                       {:remote => remote, :ref => bn.name, :puppetfile_name => puppetfile_name})
       elsif bn.validate?
        logger.error _("Environment %{env_name} contained non-word characters, ignoring it.") % {env_name: bn.name.inspect}
       end

--- a/lib/r10k/source/svn.rb
+++ b/lib/r10k/source/svn.rb
@@ -50,10 +50,11 @@ class R10K::Source::SVN < R10K::Source::Base
   # @option options [String] :remote The URL to the base directory of the SVN repository
   # @option options [String] :username The SVN username
   # @option options [String] :password The SVN password
+  # @option options [String] :puppetfile_name The puppetfile name
   def initialize(name, basedir, options = {})
     super
 
-    setopts(options, {:remote => :self, :username => :self, :password => :self})
+    setopts(options, {:remote => :self, :username => :self, :password => :self, :puppetfile_name => :self })
     @environments = []
     @svn_remote = R10K::SVN::Remote.new(@remote, :username => @username, :password => @password)
   end

--- a/lib/r10k/source/svn.rb
+++ b/lib/r10k/source/svn.rb
@@ -82,7 +82,8 @@ class R10K::Source::SVN < R10K::Source::Base
       options = {
         :remote   => path,
         :username => @username,
-        :password => @password
+        :password => @password,
+        :puppetfile_name => puppetfile_name
       }
       R10K::Environment::SVN.new(branch.name, @basedir, branch.dirname, options)
     end

--- a/r10k.yaml.example
+++ b/r10k.yaml.example
@@ -37,6 +37,12 @@ sources:
     # for more information about the Puppet 'environmentpath' setting.
     #basedir: '/etc/puppetlabs/puppet/environments'
 
+    # The Puppetfile filename in the repo, defaults to 'Puppetfile'. This 
+    # setting can be used, to allow custom Puppetfile names to allow hybrid
+    # use of librarian-puppet (transitive dependency resolution) and r10k 
+    # (code management on the server). 
+    #puppetfile_name: 'Puppetfile.r10k'
+
   # One or more sources can be specified; each source is simple another entry
   # in the sources map.
   #qa:

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -5,6 +5,25 @@ describe R10K::Puppetfile do
 
   subject do
     described_class.new(
+      '/some/nonexistent/basedir',
+      nil,
+      nil,
+      'Puppetfile.r10k'
+    )
+  end
+
+  describe "a custom puppetfile Puppetfile.r10k" do
+    it "is the basedir joined with '/Puppetfile.r10k' path" do
+      expect(subject.puppetfile_path).to eq '/some/nonexistent/basedir/Puppetfile.r10k'
+    end
+  end
+
+end
+
+describe R10K::Puppetfile do
+
+  subject do
+    described_class.new(
       '/some/nonexistent/basedir'
     )
   end
@@ -14,6 +33,13 @@ describe R10K::Puppetfile do
       expect(subject.moduledir).to eq '/some/nonexistent/basedir/modules'
     end
   end
+
+  describe "the default puppetfile" do
+    it "is the basedir joined with '/Puppetfile' path" do
+      expect(subject.puppetfile_path).to eq '/some/nonexistent/basedir/Puppetfile'
+    end
+  end
+
 
   describe "setting moduledir" do
     it "changes to given moduledir if it is an absolute path" do


### PR DESCRIPTION
This is a refactoring of https://github.com/puppetlabs/r10k/pull/612 to allow "per source" setting of Puppetfile name.
