### PR TITLE
Update cri dependency to 2.7.0

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_dependency 'colored',   '1.2'
-  s.add_dependency 'cri',       '~> 2.6.1'
+  s.add_dependency 'cri',       '~> 2.7.0'
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
tests are still :green_heart: for me
