### PR TITLE
(MAINT) Add more specific logging when local modifications are found.

### DIFF
--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -118,7 +118,16 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   end
 
   def dirty?
-    with_repo { |repo| repo.diff_workdir('HEAD').size > 0 }
+    with_repo do |repo|
+      diff = repo.diff_workdir('HEAD')
+
+      diff.each_patch do |p|
+        logger.debug(_("Found local modifications in %{file_path}" % {file_path: File.join(@path, p.delta.old_file[:path])}))
+        logger.debug1(p.to_s)
+      end
+
+      return diff.size > 0
+    end
   end
 
   private

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -179,4 +179,29 @@ RSpec.shared_examples "a git working repository" do
       end
     end
   end
+
+  describe "checking if worktree is dirty" do
+    before do
+      subject.clone(remote)
+    end
+
+    context "with no local changes" do
+      it "reports worktree as not dirty" do
+        expect(subject.dirty?).to be false
+      end
+    end
+
+    context "with local changes" do
+      before(:each) do
+        File.open(File.join(subject.path, 'README.markdown'), 'a') { |f| f.write('local modifications!') }
+      end
+
+      it "logs and reports worktree as dirty" do
+        expect(subject.logger).to receive(:debug).with(/found local modifications in.*README\.markdown/i)
+        expect(subject.logger).to receive(:debug1)
+
+        expect(subject.dirty?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds some logging at DEBUG and DEBUG1 when the #dirty? method of
the WorkingRepository classes (for both rugged and shellgit providers)
find local modifications. This allows users to determine what files r10k
thinks are locally modified, as well as how it thinks those files have
been modified (when logging at DEBUG1).
