### PR TITLE
Changed r10k.yaml cache option to /var/cache/r10k.

### DIFF
--- a/doc/dynamic-environments/quickstart.mkd
+++ b/doc/dynamic-environments/quickstart.mkd
@@ -95,7 +95,7 @@ Configure r10k by creating the following directory structure and file `/etc/pupp
 
 ```
 # The location to use for storing cached Git repos
-:cachedir: '/opt/puppetlabs/r10k/cache'
+:cachedir: '/var/cache/r10k'
 
 # A list of git repositories to create
 :sources:


### PR DESCRIPTION
The /etc filesystem is for host-specific configuration information.
Cache data is not configuration information and is better suited for
/var/cache, per the Linux Foundation's Filesystem Hierarchy Standard.
See "FHS 3.0" section "5.5. /var/cache : Application cache data".

In application of the standard the new setting is: /var/cache/r10k

Link:
- http://refspecs.linuxfoundation.org/fhs.shtml
