### PR TITLE
Add support for handling untracked files in Git repositories

### DIFF
--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -73,8 +73,11 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
     force = !opts.has_key?(:force) || opts[:force]
 
     with_repo do |repo|
-      repo.checkout(sha)
-      repo.reset(sha, :hard) if force
+      if force
+        repo.checkout(sha, {:strategy => [:force, :remove_untracked]})
+      else
+        repo.checkout(sha)
+      end
     end
   end
 
@@ -113,7 +116,7 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   end
 
   def dirty?
-    with_repo { |repo| repo.diff_workdir('HEAD').size > 0 }
+    with_repo { |repo| repo.diff_workdir('HEAD', {:include_untracked => true}).size > 0 }
   end
 
   private

--- a/lib/r10k/git/shellgit/working_repository.rb
+++ b/lib/r10k/git/shellgit/working_repository.rb
@@ -54,6 +54,7 @@ class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseReposito
     # :force defaults to true
     if !opts.has_key?(:force) || opts[:force]
       options << '--force'
+      git ['clean', '-f'], :path => @path.to_s
     end
 
     git options, :path => @path.to_s
@@ -91,7 +92,7 @@ class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseReposito
 
   # does the working tree have local modifications to tracked files?
   def dirty?
-    result = git(['diff-index', '--quiet','HEAD', '--'], :path => @path.to_s, :raise_on_fail => false)
-    result.exit_code != 0
+    result = git(['status', '--porcelain'], :path => @path.to_s, :raise_on_fail => true)
+    result.stdout != ""
   end
 end

--- a/lib/r10k/git/shellgit/working_repository.rb
+++ b/lib/r10k/git/shellgit/working_repository.rb
@@ -49,14 +49,14 @@ class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseReposito
   # @param ref [String] The git reference to check out
   # @param opts [Hash] Optional hash of additional options.
   def checkout(ref, opts = {})
+    options = ['checkout', ref]
+
     # :force defaults to true
     if !opts.has_key?(:force) || opts[:force]
-      force_opt = '--force'
-    else
-      force_opt = ''
+      options << '--force'
     end
 
-    git ['checkout', ref, force_opt], :path => @path.to_s
+    git options, :path => @path.to_s
   end
 
   def fetch(remote_name='origin')

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -158,4 +158,25 @@ RSpec.shared_examples "a git working repository" do
       expect(subject.origin).to eq remote
     end
   end
+
+  describe "checking out ref" do
+    before(:each) do
+      subject.clone(remote)
+      File.open(File.join(subject.path, 'README.markdown'), 'a') { |f| f.write('local modifications!') }
+    end
+
+    context "with force = true" do
+      it "should revert changes in managed files" do
+        subject.checkout(subject.head, {:force => true})
+        expect(File.read(File.join(subject.path, 'README.markdown')).include?('local modifications!')).to eq false
+      end
+    end
+
+    context "with force = false" do
+      it "should not revert changes in managed files" do
+        subject.checkout(subject.head, {:force => false})
+        expect(File.read(File.join(subject.path, 'README.markdown')).include?('local modifications!')).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
These commits add support to both shellgit and rugged to detect and (when force is enabled) remove untracked files from Git repositories.

Also included is a commit which fixes shellgit's checkout function to correctly preserve modified files when force is false, making the behavior consistent with rugged's behavior.

Spec tests are included for both sets of changes.