### PR TITLE
Fix force=false behavior on shellgit checkout

### DIFF
--- a/lib/r10k/git/shellgit/working_repository.rb
+++ b/lib/r10k/git/shellgit/working_repository.rb
@@ -49,14 +49,14 @@ class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseReposito
   # @param ref [String] The git reference to check out
   # @param opts [Hash] Optional hash of additional options.
   def checkout(ref, opts = {})
+    argv = ['checkout', ref]
+
     # :force defaults to true
     if !opts.has_key?(:force) || opts[:force]
-      force_opt = '--force'
-    else
-      force_opt = ''
+      argv << '--force'
     end
 
-    git ['checkout', ref, force_opt], :path => @path.to_s
+    git argv, :path => @path.to_s
   end
 
   def fetch(remote_name='origin')

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -158,4 +158,25 @@ RSpec.shared_examples "a git working repository" do
       expect(subject.origin).to eq remote
     end
   end
+
+  describe "checking out ref" do
+    before(:each) do
+      subject.clone(remote)
+      File.open(File.join(subject.path, 'README.markdown'), 'a') { |f| f.write('local modifications!') }
+    end
+
+    context "with force = true" do
+      it "should revert changes in managed files" do
+        subject.checkout(subject.head, {:force => true})
+        expect(File.read(File.join(subject.path, 'README.markdown')).include?('local modifications!')).to eq false
+      end
+    end
+
+    context "with force = false" do
+      it "should not revert changes in managed files" do
+        subject.checkout(subject.head, {:force => false})
+        expect(File.read(File.join(subject.path, 'README.markdown')).include?('local modifications!')).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add spec tests for the git.checkout method covering both
force=true and force=false.

Fix the behavior with shellgit's checkout to behavior according
to the documentation and to be consistent with rugged's behavior.