### PR TITLE
(CODEMGMT-702) Update rugged code for rugged behavior

### DIFF
--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -73,6 +73,8 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
     force = !opts.has_key?(:force) || opts[:force]
 
     with_repo do |repo|
+      # rugged/libgit2 will not update (at least) the execute bit a file if the SHA is already at
+      # the value being reset to, so this is now changed to an if ... else
       if force
         repo.reset(sha, :hard)
       else

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -73,8 +73,11 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
     force = !opts.has_key?(:force) || opts[:force]
 
     with_repo do |repo|
-      repo.checkout(sha)
-      repo.reset(sha, :hard) if force
+      if force
+        repo.reset(sha, :hard)
+      else
+        repo.checkout(sha)
+      end
     end
   end
 

--- a/spec/integration/git/rugged/working_repository_spec.rb
+++ b/spec/integration/git/rugged/working_repository_spec.rb
@@ -19,4 +19,30 @@ describe R10K::Git::Rugged::WorkingRepository, :if => R10K::Features.available?(
       }.to raise_error(R10K::Git::GitError, /Unable to check out unresolvable ref 'unresolvable'/)
     end
   end
+
+  context "checking out a specific SHA" do
+    let(:_rugged_repo) { double("Repository") }
+
+    before do
+      subject.clone(remote)
+      allow(subject).to receive(:with_repo).and_yield(_rugged_repo)
+      allow(subject).to receive(:resolve).and_return("157011a4eaa27f1202a9d94335ee4876b26d377e")
+    end
+
+    describe "with force" do
+      it "does not receive a checkout call" do
+        expect(_rugged_repo).to_not receive(:checkout)
+        expect(_rugged_repo).to receive(:reset)
+        subject.checkout("157011a4eaa27f1202a9d94335ee4876b26d377e", {:force => true})
+      end
+    end
+
+    describe "without force" do
+      it "does receive a checkout call" do
+        expect(_rugged_repo).to receive(:checkout)
+        expect(_rugged_repo).to_not receive(:reset)
+        subject.checkout("157011a4eaa27f1202a9d94335ee4876b26d377e", {:force => false})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit changes the behavior of a checkout in the rugged provider to
deal with the execute bit behavior (not updating) of rugged/libgit2
around reset-ting to a SHA that the working directory is already at.