### PR TITLE
(RK-78) Use new :prune option for #fetch in Rugged::BareRepository

### DIFF
--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -49,9 +49,14 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
   #
   # @return [void]
   def fetch(remote_name='origin')
-    backup_branches = wipe_branches
     logger.debug1 { _("Fetching remote '%{remote_name}' at %{path}") % {remote_name: remote_name, path: @path } }
-    options = {:credentials => credentials}
+
+    # Check to see if we have a version of Rugged that supports "fetch --prune" and warn if not
+    if defined?(Rugged::Version) && !Gem::Dependency.new('rugged', '>= 0.24.0').match?('rugged', Rugged::Version)
+      logger.warn { _("Rugged versions prior to 0.24.0 do not support pruning stale branches during fetch, please upgrade your \'rugged\' gem. (Current version is: %{version})") % {version: Rugged::Version} }
+    end
+
+    options = {:credentials => credentials, :prune => true}
     refspecs = ['+refs/*:refs/*']
 
     remote = remotes[remote_name]
@@ -64,7 +69,6 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
 
     report_transfer(results, remote_name)
   rescue Rugged::SshError, Rugged::NetworkError => e
-    restore_branches(backup_branches)
     if e.message =~ /Unsupported proxy scheme for/
       message = e.message + "As of curl ver 7.50.2, unsupported proxy schemes no longer fall back to HTTP."
     else
@@ -72,34 +76,10 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     end
     raise R10K::Git::GitError.new(message, :git_dir => git_dir, :backtrace => e.backtrace)
   rescue
-    restore_branches(backup_branches)
     raise
   end
 
   def exist?
     @path.exist?
-  end
-
-  def wipe_branches
-    backup_branches = {}
-    with_repo do |repo|
-      repo.branches.each do |branch|
-        if !branch.head?
-          backup_branches[branch.name] = branch.target_id
-          repo.branches.delete(branch)
-        end
-      end
-    end
-    backup_branches
-  end
-
-  def restore_branches(backup_branches)
-    with_repo do |repo|
-      backup_branches.each_pair do |name, ref|
-        if !repo.branches.exist?(name)
-          repo.create_branch(name, ref)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Prior to rugged 0.24.0, the fetch operation did not support pruning
stale branch references from the local repo. We had implemented a
workaround but now that rugged 0.24.0 is out, we should use the built in
:prune option when fetching.