### PR TITLE
Make --puppetfile and --moduledir to available to all puppetfile subcommands

### DIFF
--- a/lib/r10k/action/puppetfile/check.rb
+++ b/lib/r10k/action/puppetfile/check.rb
@@ -8,7 +8,7 @@ module R10K
       class Check < R10K::Action::Base
 
         def call
-          pf = R10K::Puppetfile.new(@root, @moduledir, @path)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
           begin
             pf.load!
             $stderr.puts _("Syntax OK")

--- a/lib/r10k/action/puppetfile/purge.rb
+++ b/lib/r10k/action/puppetfile/purge.rb
@@ -8,7 +8,7 @@ module R10K
       class Purge < R10K::Action::Base
 
         def call
-          pf = R10K::Puppetfile.new(@root, @moduledir, @path)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
           pf.load!
           pf.purge!
           true

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -31,8 +31,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage   'install'
           summary 'Install all modules from a Puppetfile'
 
-          required nil, :moduledir, 'Path to install modules to'
-          required nil, :puppetfile, 'Path to puppetfile'
+          required nil, :moduledir, 'Path to install modules to (can also be set with PUPPETFILE_DIR environment variable)'
+          required nil, :puppetfile, 'Path to Puppetfile (can also be set with PUPPETFILE environment variable)'
           # @todo add --no-purge option
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end
@@ -46,7 +46,7 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'check'
           summary 'Try and load the Puppetfile to verify the syntax is correct.'
 
-          required nil, :puppetfile, 'Path to puppetfile'
+          required nil, :puppetfile, 'Path to Puppetfile (can also be set with PUPPETFILE environment variable)'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Check)
         end
       end
@@ -59,8 +59,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'purge'
           summary 'Purge unmanaged modules from a Puppetfile managed directory'
 
-          required nil, :moduledir, 'Path to install modules to'
-          required nil, :puppetfile, 'Path to puppetfile'
+          required nil, :moduledir, 'Path to install modules to (can also be set with PUPPETFILE_DIR environment variable)'
+          required nil, :puppetfile, 'Path to Puppetfile (can also be set with PUPPETFILE environment variable)'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Purge)
         end
       end

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -45,6 +45,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           name  'check'
           usage 'check'
           summary 'Try and load the Puppetfile to verify the syntax is correct.'
+
+          required nil, :puppetfile, 'Path to puppetfile'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Check)
         end
       end
@@ -57,6 +59,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'purge'
           summary 'Purge unmanaged modules from a Puppetfile managed directory'
 
+          required nil, :moduledir, 'Path to install modules to'
+          required nil, :puppetfile, 'Path to puppetfile'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Purge)
         end
       end

--- a/spec/unit/action/puppetfile/check_spec.rb
+++ b/spec/unit/action/puppetfile/check_spec.rb
@@ -2,25 +2,40 @@ require 'spec_helper'
 require 'r10k/action/puppetfile/check'
 
 describe R10K::Action::Puppetfile::Check do
+  let(:default_opts) { {root: "/some/nonexistent/path"} }
+  let(:puppetfile) { instance_double('R10K::Puppetfile', :load! => true) }
 
-  subject { described_class.new({root: "/some/nonexistent/path"}, []) }
+  def checker(opts = {}, argv = [], settings = {})
+    opts = default_opts.merge(opts)
+    return described_class.new(opts, argv, settings)
+  end
 
-  let(:puppetfile) { instance_double('R10K::Puppetfile') }
-
-  before { allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile) }
+  before(:each) do
+    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
+  end
 
   it_behaves_like "a puppetfile action"
 
   it "prints 'Syntax OK' when the Puppetfile syntax could be validated" do
-    expect(puppetfile).to receive(:load!)
     expect($stderr).to receive(:puts).with("Syntax OK")
-    subject.call
+
+    checker.call
   end
 
   it "prints an error message when validating the Puppetfile syntax raised an error" do
-    expect(puppetfile).to receive(:load!).and_raise(R10K::Error.new("Boom!"))
-    expect(R10K::Errors::Formatting).to receive(:format_exception).with(instance_of(R10K::Error), anything).and_return("Formatted error message")
+    allow(puppetfile).to receive(:load!).and_raise(R10K::Error.new("Boom!"))
+    allow(R10K::Errors::Formatting).to receive(:format_exception).with(instance_of(R10K::Error), anything).and_return("Formatted error message")
+
     expect($stderr).to receive(:puts).with("Formatted error message")
-    subject.call
+
+    checker.call
+  end
+
+  it "respects --puppetfile option" do
+    allow($stderr).to receive(:puts)
+
+    expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/custom/puppetfile/path").and_return(puppetfile)
+
+    checker({puppetfile: "/custom/puppetfile/path"}).call
   end
 end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -2,12 +2,16 @@ require 'spec_helper'
 require 'r10k/action/puppetfile/install'
 
 describe R10K::Action::Puppetfile::Install do
-
-  subject { described_class.new({root: "/some/nonexistent/path"}, []) }
-
+  let(:default_opts) { {root: "/some/nonexistent/path"} }
   let(:puppetfile) { R10K::Puppetfile.new('/some/nonexistent/path', nil, nil) }
 
-  before do
+  def installer(opts = {}, argv = [], settings = {})
+    opts = default_opts.merge(opts)
+    return described_class.new(opts, argv, settings)
+  end
+
+  before(:each) do
+    allow(puppetfile).to receive(:load!).and_return(nil)
     allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
   end
 
@@ -24,45 +28,42 @@ describe R10K::Action::Puppetfile::Install do
     end
 
     it "syncs each module in the Puppetfile" do
-      expect(puppetfile).to receive(:load!)
       modules.each { |m| expect(m).to receive(:sync) }
-      expect(subject.call).to eq true
+
+      expect(installer.call).to eq true
     end
 
     it "returns false if a module failed to install" do
-      expect(puppetfile).to receive(:load!)
-
       modules[0..2].each { |m| expect(m).to receive(:sync) }
       expect(modules[3]).to receive(:sync).and_raise
-      expect(subject.call).to eq false
+
+      expect(installer.call).to eq false
     end
   end
 
   describe "purging" do
     before do
-      allow(puppetfile).to receive(:load!)
       allow(puppetfile).to receive(:modules).and_return([])
     end
 
     it "purges the moduledir after installation" do
       expect(puppetfile).to receive(:purge!)
-      subject.call
+
+      installer.call
     end
   end
 
   describe "using custom paths" do
-    let(:puppetfile) { instance_double("R10K::Puppetfile", load!: nil, accept: nil, purge!: nil) }
-
     it "can use a custom puppetfile path" do
-      subject = described_class.new({root: "/some/nonexistent/path", puppetfile: "/some/other/path/Puppetfile"}, [])
       expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/some/other/path/Puppetfile").and_return(puppetfile)
-      subject.call
+
+      installer({puppetfile: "/some/other/path/Puppetfile"}).call
     end
 
     it "can use a custom moduledir path" do
-      subject = described_class.new({root: "/some/nonexistent/path", moduledir: "/some/other/path/site-modules"}, [])
       expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", "/some/other/path/site-modules", nil).and_return(puppetfile)
-      subject.call
+
+      installer({moduledir: "/some/other/path/site-modules"}).call
     end
   end
 end

--- a/spec/unit/action/puppetfile/purge_spec.rb
+++ b/spec/unit/action/puppetfile/purge_spec.rb
@@ -2,18 +2,41 @@ require 'spec_helper'
 require 'r10k/action/puppetfile/purge'
 
 describe R10K::Action::Puppetfile::Purge do
+  let(:default_opts) { {root: "/some/nonexistent/path"} }
+  let(:puppetfile) { instance_double('R10K::Puppetfile', :load! => nil) }
 
-  subject { described_class.new({root: "/some/nonexistent/path"}, []) }
+  def purger(opts = {}, argv = [], settings = {})
+    opts = default_opts.merge(opts)
+    return described_class.new(opts, argv, settings)
+  end
 
-  let(:puppetfile) { instance_double('R10K::Puppetfile') }
-
-  before { allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile) }
+  before(:each) do
+    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
+  end
 
   it_behaves_like "a puppetfile action"
 
   it "purges unmanaged entries in the Puppetfile moduledir" do
-    allow(puppetfile).to receive(:load!)
     expect(puppetfile).to receive(:purge!)
-    subject.call
+
+    purger.call
+  end
+
+  describe "using custom paths" do
+    before(:each) do
+      allow(puppetfile).to receive(:purge!)
+    end
+
+    it "can use a custom puppetfile path" do
+      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/some/other/path/Puppetfile").and_return(puppetfile)
+
+      purger({puppetfile: "/some/other/path/Puppetfile"}).call
+    end
+
+    it "can use a custom moduledir path" do
+      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", "/some/other/path/site-modules", nil).and_return(puppetfile)
+
+      purger({moduledir: "/some/other/path/site-modules"}).call
+    end
   end
 end


### PR DESCRIPTION
Specifically, make both options available to `puppetfile purge` and the `--puppetfile` option available to `puppetfile check`.

This is the other half of #651 