### PR TITLE
Add a new local_directory module

### DIFF
--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -290,6 +290,43 @@ module.
 For more information see the [FAQ entry](faq.mkd#how-do-i-prevent-r10k-from-removing-modules-in-the-modules-directory-of-my-git-repository)
 on managing internal and external modules in the same directory.
 
+### Local directory
+
+In case you have a module in a local directory, e.g. because it is updated via different means (say: a package manager),
+this module allows to copy a module from a local directory.
+
+For instance, if you have a module called foo in /usr/share/puppet/modules.available/foo and would like to have it
+included in the current environment, you could add it as a local_directory:
+
+```
+mod 'foo', :local_directory => '/usr/share/puppet/modules.available/foo'
+
+# Include your other modules as normal
+mod 'branan/eight_hundred'
+mod 'puppetlabs/apache'
+```
+
+If the module is a proper forge module with a metadata file, this will keep the module updated based
+on the version in the metadata file. Otherwise it will *always* replace the module with the latest version.
+
+To prevent the module from being updated after adding it, you can add a :version parameter with a value
+of :keep or :current:
+
+```
+mod 'foo', :local_directory => '/usr/share/puppet/modules.available/foo',
+    :version => :keep
+```
+This allows for a controlled update if the module is about to be updated. If the module is not yet in the environment
+it will install it anyway.
+
+#### Caveats
+
+This module does not do any versioning, so it's not possible to have different versions
+of a module in different environment, except for already deployed environments.
+
+Thus it's recommended to include modules in the control repo or use one of the other types in all
+but very special cases.
+
 ### Per-Item Install Path
 
 Git and SVN content types support installing into an alternate path without changing

--- a/lib/r10k/module.rb
+++ b/lib/r10k/module.rb
@@ -34,5 +34,6 @@ module R10K::Module
   require 'r10k/module/git'
   require 'r10k/module/svn'
   require 'r10k/module/local'
+  require 'r10k/module/local_directory'
   require 'r10k/module/forge'
 end

--- a/lib/r10k/module/local_directory.rb
+++ b/lib/r10k/module/local_directory.rb
@@ -1,0 +1,88 @@
+require 'r10k/module'
+require 'r10k/logging'
+
+# A module type that can be used to include modules from a local directory
+# e.g. for modules which are updated by some external mechanism
+class R10K::Module::LocalDirectory < R10K::Module::Base
+
+  R10K::Module.register(self)
+
+  def self.implement?(name, args)
+    args.is_a?(Hash) && args[:local_directory]
+  end
+
+  attr_accessor :local_directory
+  attr_accessor :expected_version
+
+  def initialize(title, dirname, args, environment=nil)
+    super
+
+    @local_directory = args[:local_directory]
+
+    @metadata_file = R10K::Module::MetadataFile.new(path + 'metadata.json')
+    @metadata = @metadata_file.read
+
+    @expected_version = args[:version] || current_version || :latest
+  end
+
+  # @return [String] The version of the currently installed module
+  def current_version
+    @metadata ? @metadata.version : nil
+  end
+
+  include R10K::Logging
+
+  def properties
+    {
+        :expected => expected_version,
+        :actual   => current_version,
+        :type     => :local_directory
+    }
+  end
+
+  def exist?
+    path.exist?
+  end
+
+  # Determine the status of the local directory module.
+  #
+  # @return [Symbol] :absent If the directory doesn't exist
+  # @return [Symbol] :outdated If the installed module is older than expected
+  # @return [Symbol] :no_metadata If no metadata file is available
+  # @return [Symbol] :insync If the module is in the desired state
+  def status
+    if not self.exist?
+      return :absent
+    elsif expected_version == :current || :keep
+      return :insync
+    elsif not File.exist?(@path + 'metadata.json')
+      # The directory exists but doesn't have a metadata file; it probably
+      # isn't a forge module.
+      return :no_metadata
+    end
+
+    # The module is present and has a metadata file, read the metadata to
+    # determine the state of the module.
+    @metadata = @metadata_file.read(@path + 'metadata.json')
+
+
+    if expected_version && (expected_version != @metadata.version)
+      return :outdated
+    end
+
+    return :insync
+  end
+
+  def reinstall
+    FileUtils.rm_rf full_path
+    parent_path = @path.parent
+    if !parent_path.exist?
+      parent_path.mkpath
+    end
+    FileUtils.cp_r(local_directory, full_path)
+  end
+
+  def sync(opts={})
+    reinstall unless status == :insync
+  end
+end


### PR DESCRIPTION
This commit introduces a new module type, which allows to include
modules by copying them from a specified directory.
This can be used to include modules which are updated by different
means, but should be part of this environment.