### PR TITLE
(maint) Use internal mirror for gem sources

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -1,4 +1,4 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'http://rubygems.delivery.puppetlabs.net'
 
 gem 'beaker', '~> 3.0'
 gem 'beaker-pe'


### PR DESCRIPTION
In https://github.com/puppetlabs/r10k/commit/43cd81133106065f22d3a1f8b1e608d947401c5e gems were added that are not available on rubygems.org. In order to ensure that tests can find the gems that they need, this commit updates the integration Gemfile to use the internal gems server, which does have those non-public gems.