### PR TITLE
(RK-269) Update 'puppetfile' subcommands to handle control repo branch tracking.

### DIFF
--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -27,6 +27,11 @@ module R10K
 
         def visit_module(mod)
           logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
+
+          if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
+            logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})
+          end
+
           mod.sync(force: false) # Don't force sync for 'puppetfile install' RK-265
         end
 


### PR DESCRIPTION
`default_branch` value will be used if available during `puppetfile install` operation, otherwise command will exit with an error.

`puppetfile check` and `puppetfile purge` should run without issue.