### PR TITLE
(PF-1317) Fixup module deprecation check for old Forge APIs.

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -94,7 +94,7 @@ class R10K::Module::Forge < R10K::Module::Base
 
   def deprecated?
     begin
-      !@v3_module.deprecated_at.nil?
+      @v3_module.fetch && @v3_module.has_attribute?('deprecated_at') && !@v3_module.deprecated_at.nil?
     rescue Faraday::ResourceNotFound => e
       raise PuppetForge::ReleaseNotFound, _("The module %{title} does not exist on %{url}.") % {title: @title, url: PuppetForge::V3::Release.conn.url_prefix}, e.backtrace
     end


### PR DESCRIPTION
This prevents an exception if we are talking to a Forge API implementation that doesn't include the deprecation fields.