### PR TITLE
(RK-239) Fail fast on Puppetfiles with duplicate module names

### DIFF
--- a/spec/fixtures/unit/puppetfile/duplicate-module-error/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/duplicate-module-error/Puppetfile
@@ -1,0 +1,10 @@
+forge "http://forge.puppetlabs.com"
+
+mod "puppetlabs/stdlib", '4.11.0'
+mod "puppetlabs/stdlib", '4.12.0'
+mod "puppetlabs/concat", '2.1.0'
+mod "otheruser/concat", '2.1.0'
+
+mod 'apache',
+  :git    => 'https://github.com/puppetlabs/puppetlabs-apache',
+  :branch => 'docs_experiment'

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -194,6 +194,15 @@ describe R10K::Puppetfile do
       end
     end
 
+    it "rejects Puppetfiles with duplicate module names" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'duplicate-module-error')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect {
+        subject.load!
+      }.to raise_error(R10K::Error, /Puppetfiles cannot contain duplicate module names/i)
+    end
+
     it "accepts a forge module with a version" do
       path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
       pf_path = File.join(path, 'Puppetfile')


### PR DESCRIPTION
This commit fails fast when loading environments where the Puppetfile
contains duplicate module names.