### PR TITLE
(RK-239) Fail fast on Puppetfiles with duplicate module names

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -63,9 +63,21 @@ class Puppetfile
   def load!
     dsl = R10K::Puppetfile::DSL.new(self)
     dsl.instance_eval(puppetfile_contents, @puppetfile_path)
+    validate_no_duplicate_names(@modules)
     @loaded = true
   rescue SyntaxError, LoadError, ArgumentError, NameError => e
     raise R10K::Error.wrap(e, _("Failed to evaluate %{path}") % {path: @puppetfile_path})
+  end
+
+  # @param [Array<String>] modules
+  def validate_no_duplicate_names(modules)
+    dupes = modules
+            .group_by { |mod| mod.name }
+            .select { |_, v| v.size > 1 }
+            .map(&:first)
+    unless dupes.empty?
+      raise R10K::Error.new(_("Puppetfiles cannot contain duplicate module names. Please remove the remove the duplicates of the following modules:\n%{dupes}" % {dupes: dupes.join("\n")}))
+    end
   end
 
   # @param [String] forge

--- a/spec/fixtures/unit/puppetfile/duplicate-module-error/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/duplicate-module-error/Puppetfile
@@ -1,0 +1,10 @@
+forge "http://forge.puppetlabs.com"
+
+mod "puppetlabs/stdlib", '4.11.0'
+mod "puppetlabs/stdlib", '4.12.0'
+mod "puppetlabs/concat", '2.1.0'
+mod "otheruser/concat", '2.1.0'
+
+mod 'apache',
+  :git    => 'https://github.com/puppetlabs/puppetlabs-apache',
+  :branch => 'docs_experiment'

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -194,6 +194,15 @@ describe R10K::Puppetfile do
       end
     end
 
+    it "rejects Puppetfiles with duplicate module names" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'duplicate-module-error')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect {
+        subject.load!
+      }.to raise_error(R10K::Error, /Puppetfiles cannot contain duplicate module names/i)
+    end
+
     it "wraps and re-raises name errors" do
       path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'name-error')
       pf_path = File.join(path, 'Puppetfile')


### PR DESCRIPTION
This commit fails fast when loading environments where the Puppetfile
contains duplicate module names.