### PR TITLE
(RK-285) Update minitar dependency to 0.6.1

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'puppet_forge', '~> 2.2'
   s.add_dependency 'semantic_puppet', '~> 0.1.0'
-  s.add_dependency 'minitar', '0.5.4'
 
   s.add_dependency 'gettext-setup', '~> 0.5'
 
@@ -39,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
 
   s.add_development_dependency 'yard', '~> 0.8.7.3'
+  s.add_development_dependency 'minitar', '~> 0.6.1'
 
   s.files        = %x[git ls-files].split($/)
   s.require_path = 'lib'


### PR DESCRIPTION
This commit updates the minitar dependency to 0.6.1 and moves it to a
development dependency, as it is only strictly needed by tests.