### PR TITLE
(CODEMGMT-1064) Inline the installation of dev repos function

### DIFF
--- a/integration/component/pre-suite/05_install_dev_r10k.rb
+++ b/integration/component/pre-suite/05_install_dev_r10k.rb
@@ -2,17 +2,9 @@ test_name "Install PE r10k" do
 
   step "Install PE r10k" do
 
-    install_pe_product_on(master, 'pe-r10k', ENV['SHA'])
+    # taken from beaker-pe/lib/beaker-pe/pe-client-tools/install_helper.rb
+    install_dev_repos_on('pe-r10k', master, ENV['SHA'], '/tmp/repo_configs', {:dev_builds_url => 'http://builds.delivery.puppetlabs.net'})
+    host.install_package('pe-r10k')
 
   end
 end
-
-# taken from beaker-pe/lib/beaker-pe/pe-client-tools/install_helper.rb
-def install_pe_product_on(hosts, product, product_sha)
-
-    block_on hosts do |host|
-      variant, version, arch, codename = host['platform'].to_array
-        install_dev_repos_on(product, host, product_sha, '/tmp/repo_configs', {:dev_builds_url => 'http://builds.delivery.puppetlabs.net'})
-        host.install_package(product)
-    end
-  end


### PR DESCRIPTION
This commit changes the installation of the dev repos of r10k in testing
to be inline rather than def'd as a function which wasn't loading in
ruby during testing.