### PR TITLE
(MAINT) Fixup Forge module deprecation check performance

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -43,10 +43,6 @@ class R10K::Module::Forge < R10K::Module::Base
   end
 
   def sync(opts={})
-    if deprecated?
-      logger.warn "Puppet Forge module '#{@v3_module.slug}' has been deprecated, visit https://forge.puppet.com/#{@v3_module.slug.tr('-','/')} for more information."
-    end
-
     case status
     when :absent
       install
@@ -141,6 +137,10 @@ class R10K::Module::Forge < R10K::Module::Base
   end
 
   def install
+    if deprecated?
+      logger.warn "Puppet Forge module '#{@v3_module.slug}' has been deprecated, visit https://forge.puppet.com/#{@v3_module.slug.tr('-','/')} for more information."
+    end
+
     parent_path = @path.parent
     if !parent_path.exist?
       parent_path.mkpath

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -63,15 +63,15 @@ describe R10K::Module::Forge do
   context "when a module is deprecated" do
     subject { described_class.new('puppetlabs/corosync', fixture_modulepath, :latest) }
 
-    it "warns on sync" do
-      allow(subject).to receive(:install)
+    it "warns on install" do
+      allow(R10K::Forge::ModuleRelease).to receive(:new).and_return(double('mod_release', install: true))
 
       logger_dbl = double(Log4r::Logger)
       allow_any_instance_of(described_class).to receive(:logger).and_return(logger_dbl)
 
       expect(logger_dbl).to receive(:warn).with(/puppet forge module.*puppetlabs-corosync.*has been deprecated/i)
 
-      subject.sync
+      subject.install
     end
   end
 

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -63,7 +63,9 @@ describe R10K::Module::Forge do
   context "when a module is deprecated" do
     subject { described_class.new('puppetlabs/corosync', fixture_modulepath, :latest) }
 
-    it "warns on install" do
+    it "warns on sync if module is not already insync" do
+      allow(subject).to receive(:status).and_return(:absent)
+
       allow(R10K::Forge::ModuleRelease).to receive(:new).and_return(double('mod_release', install: true))
 
       logger_dbl = double(Log4r::Logger)
@@ -71,7 +73,18 @@ describe R10K::Module::Forge do
 
       expect(logger_dbl).to receive(:warn).with(/puppet forge module.*puppetlabs-corosync.*has been deprecated/i)
 
-      subject.install
+      subject.sync
+    end
+
+    it "does not warn on sync if module is already insync" do
+      allow(subject).to receive(:status).and_return(:insync)
+
+      logger_dbl = double(Log4r::Logger)
+      allow_any_instance_of(described_class).to receive(:logger).and_return(logger_dbl)
+
+      expect(logger_dbl).to_not receive(:warn).with(/puppet forge module.*puppetlabs-corosync.*has been deprecated/i)
+
+      subject.sync
     end
   end
 


### PR DESCRIPTION
Before it was checking for module deprecation on every pass, but this
change makes it check only when it has decided it needs to
install/reinstall/upgrade anyway so there should be little to no
performance impact.