### PR TITLE
(CODEMGMT-1064) Remove expected_error for RK-101

### DIFF
--- a/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
@@ -40,12 +40,8 @@ git_add_commit_push(master, 'production', 'Add modules.', git_environments_path)
 #Tests
 step 'Attempt to Deploy via r10k'
 on(master, "#{r10k_fqp} deploy environment -v -p", :acceptable_exit_codes => [0, 1]) do |result|
-  expect_failure('Expected exit code to be wrong due to RK-101') do
-    assert_equal(1, result.exit_code, "Expected command to indicate error with exit code")
-  end
+  assert_equal(1, result.exit_code, "Expected command to indicate error with exit code")
 
-  expect_failure('Expected module to be deployed twice due to RK-101') do
-    matches = result.stderr.scan(deploy_str)
-    assert_equal(1, matches.size, "Expected motd module to be deployed once, but deployed #{matches.size}) times")
-  end
+  matches = result.stderr.scan(deploy_str)
+  assert_equal(1, matches.size, "Expected motd module to be deployed once, but deployed #{matches.size}) times")
 end


### PR DESCRIPTION
This commit removes the expected_error related to duplicate module names
now that we properly error out on duplicate module names in r10k.