### PR TITLE
(CODEMGMT-1097) Remove assertion during duplicate module test

### DIFF
--- a/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_duplicate_module_names.rb
@@ -41,7 +41,4 @@ git_add_commit_push(master, 'production', 'Add modules.', git_environments_path)
 step 'Attempt to Deploy via r10k'
 on(master, "#{r10k_fqp} deploy environment -v -p", :acceptable_exit_codes => [0, 1]) do |result|
   assert_equal(1, result.exit_code, "Expected command to indicate error with exit code")
-
-  matches = result.stderr.scan(deploy_str)
-  assert_equal(1, matches.size, "Expected motd module to be deployed once, but deployed #{matches.size}) times")
 end


### PR DESCRIPTION
The integration test which tests what happens when duplicate module
names are found in an environment expects that one of the modules gets
deployed once but the actual behavior (as an outcome of the fix) leads
to an error and nonzero exit code from the r10k deploy. This commit
removes the erroneous test assertion.