### PR TITLE
(maint) Remove cache between tests

### DIFF
--- a/integration/lib/r10k_utils.rb
+++ b/integration/lib/r10k_utils.rb
@@ -76,6 +76,10 @@ def r10k_revert_environment(host, commit_sha, git_repo_path)
   #Force push changes to remote.
   git_on(host, 'push origin --mirror --force', git_repo_path)
   git_on(host, 'push origin --mirror --force', git_repo_path)
+
+  #Remove r10k cache
+  cachedir = '/var/r10k/cache'
+  on(master, "rm -rf #{cachedir}")
 end
 
 # Clean-up the r10k environment on the master to bring it back to a known good state.


### PR DESCRIPTION
This will remove the /var/r10k/cache directory on environment resets which only happen on clean_up_r10k at this point.

Note that every time that a cachedir is set, it is set to /var/r10k/cache. This does not mean it's set to this for every test. The default value is $HOME/.r10k/cache for forge modules, but the two test of interest currently set it to /var/r10k/cache and if it does not exist when rm -rf is performed, that still returns a 0 exit code.