### PR TITLE
(RK-297) Workaround rugged/r10k issue in r10k_utils.rb

### DIFF
--- a/integration/lib/r10k_utils.rb
+++ b/integration/lib/r10k_utils.rb
@@ -106,6 +106,13 @@ def clean_up_r10k(master, commit_sha, git_repo_path)
   step 'Reset Git Repo to Known Good State'
   r10k_revert_environment(master, commit_sha, git_repo_path)
 
+  # RK-297 workaround. Without this, tests will fail with an error like the following:
+  # [2017-06-02 11:11:46 - ERROR] Object not found - no match for id (60e4ea82c9fdf86974a13f78b839a497325de04b)
+  # This cleanup should not be necessary when RK-297 has been resolved.
+  #
+  step 'Remove git directories from codedir to prevent cache errors'
+  on(master, "find #{environment_path } -name .git -type d -print0 | xargs -r0 -- rm -r")
+
   step 'Restore Original "production" Environment'
   on(master, "#{r10k_fqp} deploy environment -v")
 


### PR DESCRIPTION
Cleaning up the r10k cache between test runs exposed a bug in r10k's
rugged provider. If the cache has been removed and the control repo
history has been rewritten, deploys will fail with errors that mention
object not found. In order to work around this bug, this commit adds a
call to remove the git history of codedir as part of the clean_up_r10k
method. This allows deploys with the rugged provider to proceed
successfully.