### PR TITLE
(RK-161) Deprecate the usage of PUPPETFILE and PUPPETFILE_DIR

### DIFF
--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -306,7 +306,7 @@ The given 'install\_path' can be an absolute path or a path relative to the base
 the environment. Note that r10k will exit with an error if you attempt to set the
 'path' option to a directory outside of the environment.
 
-## Environment variables
+## Environment variables (**DEPRECATED** as of 2.5.6)
 
 It is possible to set an alternate name/location for your `Puppetfile` and
 `modules` directory. This is useful if you want to control multiple environments

--- a/lib/r10k/action/puppetfile/cri_runner.rb
+++ b/lib/r10k/action/puppetfile/cri_runner.rb
@@ -8,10 +8,16 @@ module R10K
       #
       # @api private
       # @deprecated The use of these environment variables is deprecated and
-      #   will be removed in 2.0.0.
+      #   will be removed in 3.0.0.
       class CriRunner < R10K::Action::CriRunner
+
+        include R10K::Logging
+
         def handle_opts(opts)
           opts[:root]       ||= wd
+          if env['PUPPETFILE_DIR'] || env['PUPPETFILE']
+            logger.warn _("The use of the PUPPETFILE and PUPPETFILE_DIR environment variables is deprecated.")
+          end
           opts[:moduledir]  ||= env['PUPPETFILE_DIR']
           opts[:puppetfile] ||= env['PUPPETFILE']
           super(opts)


### PR DESCRIPTION
The effect of these two environment variables will be removed in v3.0.0.
This commit causes a warning of the deprecation.