### PR TITLE
(RK-162) Remove PUPPETFILE and PUPPETFILE_DIR

### DIFF
--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -305,21 +305,3 @@ mod 'apache',
 The given 'install\_path' can be an absolute path or a path relative to the base of
 the environment. Note that r10k will exit with an error if you attempt to set the
 'path' option to a directory outside of the environment.
-
-## Environment variables
-
-It is possible to set an alternate name/location for your `Puppetfile` and
-`modules` directory. This is useful if you want to control multiple environments
-and have a single location for your `Puppetfile`.
-
-Example:
-
-    PUPPETFILE=/etc/r10k.d/Puppetfile.production \
-    PUPPETFILE_DIR=/etc/puppet/modules/production \
-    /usr/bin/r10k puppetfile install
-
-NOTE: using these environment variables is not a suggested configuration, and
-have different semantics than librarian-puppet. Specifically, the PUPPETFILE_DIR
-is the environment that r10k will install modules into, and it will take full
-control over that directory and _remove any unmanaged content_. Use these
-variables with caution.

--- a/lib/r10k/action/puppetfile/cri_runner.rb
+++ b/lib/r10k/action/puppetfile/cri_runner.rb
@@ -3,25 +3,16 @@ require 'r10k/action/cri_runner'
 module R10K
   module Action
     module Puppetfile
-      # Extend the default Cri Runner to use the PUPPETFILE environment
-      # variables.
+      # Extend the default Cri Runner with Puppetfile specific opts
       #
       # @api private
-      # @deprecated The use of these environment variables is deprecated and
-      #   will be removed in 2.0.0.
       class CriRunner < R10K::Action::CriRunner
         def handle_opts(opts)
           opts[:root]       ||= wd
-          opts[:moduledir]  ||= env['PUPPETFILE_DIR']
-          opts[:puppetfile] ||= env['PUPPETFILE']
           super(opts)
         end
 
         private
-
-        def env
-          ENV
-        end
 
         def wd
           Dir.getwd

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -31,8 +31,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage   'install'
           summary 'Install all modules from a Puppetfile'
 
-          required nil, :moduledir, 'Path to install modules to (can also be set with PUPPETFILE_DIR environment variable)'
-          required nil, :puppetfile, 'Path to Puppetfile (can also be set with PUPPETFILE environment variable)'
+          required nil, :moduledir, 'Path to install modules to'
+          required nil, :puppetfile, 'Path to Puppetfile'
           # @todo add --no-purge option
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end
@@ -46,7 +46,7 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'check'
           summary 'Try and load the Puppetfile to verify the syntax is correct.'
 
-          required nil, :puppetfile, 'Path to Puppetfile (can also be set with PUPPETFILE environment variable)'
+          required nil, :puppetfile, 'Path to Puppetfile'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Check)
         end
       end
@@ -59,8 +59,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'purge'
           summary 'Purge unmanaged modules from a Puppetfile managed directory'
 
-          required nil, :moduledir, 'Path to install modules to (can also be set with PUPPETFILE_DIR environment variable)'
-          required nil, :puppetfile, 'Path to Puppetfile (can also be set with PUPPETFILE environment variable)'
+          required nil, :moduledir, 'Path to install modules to'
+          required nil, :puppetfile, 'Path to Puppetfile'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Purge)
         end
       end

--- a/spec/unit/action/puppetfile/cri_runner_spec.rb
+++ b/spec/unit/action/puppetfile/cri_runner_spec.rb
@@ -31,32 +31,14 @@ describe R10K::Action::Puppetfile::CriRunner do
     end
 
     describe "for the moduledir" do
-      before do
-        allow(cri_runner).to receive(:env).and_return({'PUPPETFILE_DIR' => '/some/nonexistent/modules'})
-      end
-
-      it "sets the option from the environment when the cli option is not given" do
-        opts = {}
-        expect(cri_runner.handle_opts(opts)).to include(:moduledir => '/some/nonexistent/modules')
-      end
-
-      it "doesn't set the option from the environment when the cli option is given" do
+      it "sets the option from the cli option if given" do
         opts = {:moduledir => '/some/other/nonexistent/modules'}
         expect(cri_runner.handle_opts(opts)).to include(:moduledir => '/some/other/nonexistent/modules')
       end
     end
 
     describe "for the puppetfile path" do
-      before do
-        allow(cri_runner).to receive(:env).and_return({'PUPPETFILE' => '/some/nonexistent/Puppetfile'})
-      end
-
-      it "sets the option from the environment when the cli option is not given" do
-        opts = {}
-        expect(cri_runner.handle_opts(opts)).to include(:puppetfile => '/some/nonexistent/Puppetfile')
-      end
-
-      it "doesn't set the option from the environment when the cli option is given" do
+      it "sets the option from the cli option if given" do
         opts = {:puppetfile => '/some/other/nonexistent/modules'}
         expect(cri_runner.handle_opts(opts)).to include(:puppetfile => '/some/other/nonexistent/modules')
       end


### PR DESCRIPTION
This commit fully removes effect of the PUPPETFILE and
PUPPETFILE_DIR environment variables.