### PR TITLE
RK-301 Fix dependencies for puppet_forge 2.2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: "bundle exec rspec --color --format documentation spec/unit"
 notifications:
   email: false
 sudo: false
+before_install: gem update bundler
 rvm:
   - "2.3.0"
   - "2.2.0"

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json', '~> 1.10'
 
   s.add_dependency 'puppet_forge', '~> 2.2'
-  s.add_dependency 'semantic_puppet', '~> 0.1.0'
+  s.add_dependency 'semantic_puppet', '>= 0.1.4', '< 2.0'
 
   s.add_dependency 'gettext-setup', '~> 0.5'
 


### PR DESCRIPTION
This commit updates the dependencies for semantic_puppet so that v 1.0.x
can be used. This allows r10k to pull puppet_forge 2.2.7. The old
versions are permissible to allow older agent versions.