### PR TITLE
(RK-264) Add --update_force flag to puppetfile install

### DIFF
--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -10,7 +10,7 @@ module R10K
 
         def call
           @visit_ok = true
-          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil , @update_force)
           pf.accept(self)
           @visit_ok
         end
@@ -26,17 +26,18 @@ module R10K
         end
 
         def visit_module(mod)
+          @update_force    = @update_force || false
           logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
 
           if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
             logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})
           end
 
-          mod.sync(force: false) # Don't force sync for 'puppetfile install' RK-265
+          mod.sync(force: @update_force)
         end
 
         def allowed_initialize_opts
-          super.merge(root: :self, puppetfile: :self, moduledir: :self)
+          super.merge(root: :self, puppetfile: :self, moduledir: :self, update_force: :self )
         end
       end
     end

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -30,10 +30,9 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           name    'install'
           usage   'install'
           summary 'Install all modules from a Puppetfile'
-
           required nil, :moduledir, 'Path to install modules to'
           required nil, :puppetfile, 'Path to puppetfile'
-          # @todo add --no-purge option
+          flag     nil, :update_force, 'Force locally changed files to be overwritten'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end
       end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -33,11 +33,18 @@ class Puppetfile
   #   @return [R10K::Environment] Optional R10K::Environment that this Puppetfile belongs to.
   attr_accessor :environment
 
+  # @!attribute [rw] update_force
+  #   @return [Boolean] Force update the modules and overwrite the locally made changes
+  attr_accessor :update_force
+
   # @param [String] basedir
   # @param [String] moduledir The directory to install the modules, default to #{basedir}/modules
   # @param [String] puppetfile_path The path to the Puppetfile, default to #{basedir}/Puppetfile
-  def initialize(basedir, moduledir = nil, puppetfile_path = nil)
+  # @param [String] puppetfile_name The name of the Puppetfile, default to 'Puppetfile'
+  # @param [Boolean] update_force Shall we overwrite locally made changes?
+  def initialize(basedir, moduledir = nil, puppetfile_path = nil, puppetfile_name = nil, update_force = nil )
     @basedir         = basedir
+    @update_force    = update_force || false
     @moduledir       = moduledir  || File.join(basedir, 'modules')
     @puppetfile_path = puppetfile_path || File.join(basedir, 'Puppetfile')
 

--- a/spec/shared-examples/puppetfile-action.rb
+++ b/spec/shared-examples/puppetfile-action.rb
@@ -13,5 +13,27 @@ shared_examples_for "a puppetfile action" do
     it "accepts the :moduledir option" do
       described_class.new({moduledir: "/some/nonexistent/path/modules"}, [])
     end
+
+  end
+end
+
+shared_examples_for "a puppetfile install action" do
+  describe "initializing" do
+    it "accepts the :root option" do
+      described_class.new({root: "/some/nonexistent/path"}, [])
+    end
+
+    it "accepts the :puppetfile option" do
+      described_class.new({puppetfile: "/some/nonexistent/path/Puppetfile"}, [])
+    end
+
+    it "accepts the :moduledir option" do
+      described_class.new({moduledir: "/some/nonexistent/path/modules"}, [])
+    end
+
+    it "accepts the :update_force option" do
+      described_class.new({update_force: true}, [])
+    end
+
   end
 end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -73,9 +73,9 @@ describe R10K::Action::Puppetfile::Install do
     end
 
     it "can use the force overwrite option" do
+      subject = described_class.new({root: "/some/nonexistent/path", update_force: true}, [])
       expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, true).and_return(puppetfile)
-
-      installer({update_force: true}).call
+      subject.call
     end
 
   end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -7,11 +7,12 @@ describe R10K::Action::Puppetfile::Install do
 
   let(:puppetfile) { R10K::Puppetfile.new('/some/nonexistent/path', nil, nil) }
 
-  before do
-    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
+  before(:each) do
+    allow(puppetfile).to receive(:load!).and_return(nil)
+    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, nil).and_return(puppetfile)
   end
 
-  it_behaves_like "a puppetfile action"
+  it_behaves_like "a puppetfile install action"
 
   describe "installing modules" do
     let(:modules) do
@@ -55,14 +56,27 @@ describe R10K::Action::Puppetfile::Install do
 
     it "can use a custom puppetfile path" do
       subject = described_class.new({root: "/some/nonexistent/path", puppetfile: "/some/other/path/Puppetfile"}, [])
-      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/some/other/path/Puppetfile").and_return(puppetfile)
+      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/some/other/path/Puppetfile", nil, nil).and_return(puppetfile)
       subject.call
     end
 
     it "can use a custom moduledir path" do
       subject = described_class.new({root: "/some/nonexistent/path", moduledir: "/some/other/path/site-modules"}, [])
-      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", "/some/other/path/site-modules", nil).and_return(puppetfile)
+      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", "/some/other/path/site-modules", nil, nil, nil).and_return(puppetfile)
       subject.call
     end
+  end
+
+  describe "forcing to overwrite local changes" do
+    before do
+      allow(puppetfile).to receive(:modules).and_return([])
+    end
+
+    it "can use the force overwrite option" do
+      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, true).and_return(puppetfile)
+
+      installer({update_force: true}).call
+    end
+
   end
 end


### PR DESCRIPTION
This PR adds a --update_force flag to the puppetfile install action and subcommand. This will force the overwrite of modules which have local changes.
