### PR TITLE
(RK-305) Add --no-force to deploy action.

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -13,7 +13,7 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
-        attr_reader :no_force
+        attr_reader :force
 
         def initialize(opts, argv, settings = nil)
           settings ||= {}
@@ -22,6 +22,8 @@ module R10K
 
           super
 
+          # @force here is used to make it easier to reason about
+          @force = !@no_force
           @argv = @argv.map { |arg| arg.gsub(/\W/,'_') }
         end
 
@@ -119,8 +121,7 @@ module R10K
 
         def visit_module(mod)
           logger.info _("Deploying Puppetfile content %{mod_path}") % {mod_path: mod.path}
-          # no_force here is the opposite of the expected value of force.
-          mod.sync(force: !@no_force)
+          mod.sync(force: @force)
         end
 
         def write_environment_info!(environment, started_at, success)

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -146,7 +146,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self, no_force: :self)
+          super.merge(puppetfile: :self, cachedir: :self, 'no-force': :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -146,7 +146,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self, 'no-force': :self)
+          super.merge(puppetfile: :self, cachedir: :self, :'no-force' => :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -13,6 +13,8 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
+        attr_reader :no_force
+
         def initialize(opts, argv, settings = nil)
           settings ||= {}
           @purge_levels = settings.fetch(:deploy, {}).fetch(:purge_levels, [])
@@ -117,7 +119,8 @@ module R10K
 
         def visit_module(mod)
           logger.info _("Deploying Puppetfile content %{mod_path}") % {mod_path: mod.path}
-          mod.sync
+          # no_force here is the opposite of the expected value of force.
+          mod.sync(force: !@no_force)
         end
 
         def write_environment_info!(environment, started_at, success)
@@ -142,7 +145,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self)
+          super.merge(puppetfile: :self, cachedir: :self, no_force: :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -68,7 +68,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true, no_force: :self)
+          super.merge(environment: true, 'no-force': :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -10,6 +10,8 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
+        attr_reader :no_force
+
         def call
           @visit_ok = true
 
@@ -50,14 +52,15 @@ module R10K
         def visit_module(mod)
           if @argv.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
-            mod.sync
+            # no_force here is the opposite of the expceted value of force
+            mod.sync(force: !@no_force)
           else
             logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @argv.inspect, mod_name: mod.name})
           end
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true)
+          super.merge(environment: true, no_force: :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -10,7 +10,16 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
-        attr_reader :no_force
+        attr_reader :force
+
+        def initialize(opts, argv, settings = nil)
+          settings ||= {}
+
+          super
+
+          # @force here is used to make it easier to reason about
+          @force = !@no_force
+        end
 
         def call
           @visit_ok = true
@@ -52,8 +61,7 @@ module R10K
         def visit_module(mod)
           if @argv.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
-            # no_force here is the opposite of the expceted value of force
-            mod.sync(force: !@no_force)
+            mod.sync(force: @force)
           else
             logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @argv.inspect, mod_name: mod.name})
           end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -68,7 +68,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true, 'no-force': :self)
+          super.merge(environment: true, :'no-force' => :self)
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -22,6 +22,7 @@ module R10K::CLI
         DESCRIPTION
 
         required nil, :cachedir, 'Specify a cachedir, overriding the value in config'
+        flag nil, :'no-force', 'Prevent the overwriting of local module modifications'
 
         run do |opts, args, cmd|
           puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/util/setopts.rb
+++ b/lib/r10k/util/setopts.rb
@@ -39,9 +39,11 @@ module R10K
             when NilClass, FalseClass
               # Ignore nil options
             when :self, TrueClass
-              instance_variable_set("@#{key}".to_sym, value)
+              # tr here is because instance variables cannot have hyphens in their names.
+              instance_variable_set("@#{key}".tr('-','_').to_sym, value)
             else
-              instance_variable_set("@#{rhs}".to_sym, value)
+              # tr here same as previous
+              instance_variable_set("@#{rhs}".tr('-','_').to_sym, value)
             end
           else
             raise ArgumentError, _("%{class_name} cannot handle option '%{key}'") % {class_name: self.class.name, key: key}

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -19,8 +19,8 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({puppetfile: true}, [])
     end
 
-    it "can accept a no_force option" do
-      described_class.new({no_force: true}, [])
+    it "can accept a no-force option" do
+      described_class.new({'no-force': true}, [])
     end
 
     it "normalizes environment names in the arg vector"
@@ -57,12 +57,16 @@ describe R10K::Action::Deploy::Environment do
       end
     end
 
-    describe "with no_force" do
+    describe "with no-force" do
 
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, no_force: true}, %w[first]) }
+      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, 'no-force': true}, %w[first]) }
 
       it "tries to preserve local modifications" do
         expect(subject.force).to equal(false)
+      end
+
+      it "logs that a modified environment is skipped when 'no-force' is true" do
+          
       end
     end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -19,6 +19,10 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({puppetfile: true}, [])
     end
 
+    it "can accept a no_force option" do
+      described_class.new({no_force: true}, [])
+    end
+
     it "normalizes environment names in the arg vector"
   end
 
@@ -50,6 +54,15 @@ describe R10K::Action::Deploy::Environment do
         expect(subject.logger).to receive(:error).with("Environment(s) 'not_an_environment' cannot be found in any source and will not be deployed.")
         logger = subject.logger
         expect(subject.call).to eq false
+      end
+    end
+
+    describe "with no_force" do
+
+      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, no_force: true}, %w[first]) }
+
+      it "tries to preserve local modifications" do
+        expect(subject.no_force).to equal(true)
       end
     end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -20,7 +20,7 @@ describe R10K::Action::Deploy::Environment do
     end
 
     it "can accept a no-force option" do
-      described_class.new({'no-force': true}, [])
+      described_class.new({:'no-force' => true}, [])
     end
 
     it "normalizes environment names in the arg vector"
@@ -58,15 +58,10 @@ describe R10K::Action::Deploy::Environment do
     end
 
     describe "with no-force" do
-
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, 'no-force': true}, %w[first]) }
+      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, :'no-force' => true}, %w[first]) }
 
       it "tries to preserve local modifications" do
         expect(subject.force).to equal(false)
-      end
-
-      it "logs that a modified environment is skipped when 'no-force' is true" do
-          
       end
     end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -62,7 +62,7 @@ describe R10K::Action::Deploy::Environment do
       subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, no_force: true}, %w[first]) }
 
       it "tries to preserve local modifications" do
-        expect(subject.no_force).to equal(true)
+        expect(subject.force).to equal(false)
       end
     end
 

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -24,7 +24,7 @@ describe R10K::Action::Deploy::Module do
     subject { described_class.new({ config: "/some/nonexistent/path", no_force: true}, [] )}
 
     it "tries to preserve local modifications" do
-      expect(subject.no_force).to equal(true)
+      expect(subject.force).to equal(false)
     end
   end
 end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -13,5 +13,18 @@ describe R10K::Action::Deploy::Module do
     it "accepts an environment option" do
       described_class.new({environment: "production"}, [])
     end
+
+    it "can accept a no_force option" do
+      described_class.new({no_force: true}, [])
+    end
+  end
+
+  describe "with no_force" do
+
+    subject { described_class.new({ config: "/some/nonexistent/path", no_force: true}, [] )}
+
+    it "tries to preserve local modifications" do
+      expect(subject.no_force).to equal(true)
+    end
   end
 end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -15,13 +15,13 @@ describe R10K::Action::Deploy::Module do
     end
 
     it "can accept a no-force option" do
-      described_class.new({'no-force': true}, [])
+      described_class.new({:'no-force' => true}, [])
     end
   end
 
   describe "with no-force" do
 
-    subject { described_class.new({ config: "/some/nonexistent/path", 'no-force': true}, [] )}
+    subject { described_class.new({ config: "/some/nonexistent/path", :'no-force' => true}, [] )}
 
     it "tries to preserve local modifications" do
       expect(subject.force).to equal(false)

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -14,14 +14,14 @@ describe R10K::Action::Deploy::Module do
       described_class.new({environment: "production"}, [])
     end
 
-    it "can accept a no_force option" do
-      described_class.new({no_force: true}, [])
+    it "can accept a no-force option" do
+      described_class.new({'no-force': true}, [])
     end
   end
 
-  describe "with no_force" do
+  describe "with no-force" do
 
-    subject { described_class.new({ config: "/some/nonexistent/path", no_force: true}, [] )}
+    subject { described_class.new({ config: "/some/nonexistent/path", 'no-force': true}, [] )}
 
     it "tries to preserve local modifications" do
       expect(subject.force).to equal(false)


### PR DESCRIPTION
 This commit adds a --no-force flag to the deploy action. The default of the r10k deploy action is to deploy all environments regardless of local modifications in the modules. The --no-force flag, the user can choose to have the deploy skip environments where local modifications have occurred to the modules.
