### PR TITLE
(RK-306) Remove dependency on semantic_puppet.

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -6,7 +6,7 @@ require 'r10k/forge/module_release'
 
 require 'pathname'
 require 'fileutils'
-require 'puppet_forge'
+require 'puppet_forge/util'
 
 class R10K::Module::Forge < R10K::Module::Base
 
@@ -17,7 +17,7 @@ class R10K::Module::Forge < R10K::Module::Base
   end
 
   def self.valid_version?(expected_version)
-    expected_version == :latest || expected_version.nil? || SemanticPuppet::Version.valid?(expected_version)
+    expected_version == :latest || expected_version.nil? || PuppetForge::Util.version_valid?(expected_version)
   end
 
   # @!attribute [r] metadata

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -28,8 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
 
-  s.add_dependency 'puppet_forge', '~> 2.2'
-  s.add_dependency 'semantic_puppet', '>= 0.1.4', '< 2.0'
+  s.add_dependency 'puppet_forge', '~> 2.2.8'
 
   s.add_dependency 'gettext-setup', '~> 0.5'
 


### PR DESCRIPTION
This commit uses a helper method in puppet_forge for version validation.
This change removes the direct dependency of r10k on semantic_puppet.