### PR TITLE
(RK-307) Ignore branches for deployment with specified prefixes

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -501,7 +501,7 @@ sources:
   app1_data:
     remote: 'git://git-server.site/my-org/app1-hieradata'
     basedir: '/etc/puppet/hieradata'
-    branch_filter: '^(prod-)\\w+$'
+    branch_filter: '^(prod-)\w+$'
 ```
 
 #### Filter branches - Match branches exactly

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -356,27 +356,30 @@ sources:
 * if `false` (default) environment folder will not be prefixed
 * if `String` environment folder will be prefixed with the `prefix` value.
 
-### branch_filter
+### ignore_branch_prefixes
 
-The 'branch_filter' setting restricts the environment that are deployed to only
-those that match the given filter. The filter is a regex string. Each branch in
-the 'git' repo will have its named tested against this regex and, if the regex
-matches the branch name, then an environment will be deployed for this branch.
-If no 'branch_filter' is specified, then all branches in the 'git' repo will
+The 'ignore_branch_prefixes' setting causes environments to be ignored which match in part or whole
+to any of the prefixes listed in the setting.
+The setting is a list of strings. Each branch in
+the 'git' repo will have its name tested against all prefixes and, if the prefix
+is found, then an environment will not be deployed for this branch.
+If no 'ignore_branch_prefixes' is specified, then all branches in the 'git' repo will
 be deployed (default behavior).
 
-#### branch_filter behaviour
+#### ignore_branch_prefixes behaviour
 * if empty, deploy environments for all branches
 * for each branch in git repo
-** if `branch.name` matches `branch_filter` regex, then deploy an environment for branch
+** if `branch.name` has a prefix found in `ignore_branch_prefixes`, then do not deploy an environment for branch
 
-Example: only deploy branches named 'prod' or 'qa'
+Example: do not deploy branches with names starting with (or completely named) 'test' or 'dev'.
 ```yaml
 ---
 sources:
   mysource:
     basedir: '/etc/puppet/environments'
-    branch_filter: '^(prod)|(qa)$'
+    ignore_branch_prefixes:
+      - 'test'
+      - 'dev'
 ```
 
 Examples
@@ -477,46 +480,3 @@ This will create the following directory structure:
 |-- app1_production  # app1 data repository, production branch
 |-- app1_develop     # app1 data repository, develop branch
 ```
-
-### Filtering branches
-
-#### Filtering branches - Exclude branches with a prefix
-
-If you would like to filter out all branches starting with and including "dev-".
-
-```yaml
----
-sources:
-  app1_data:
-    remote: 'git://git-server.site/my-org/app1-hieradata'
-    basedir: '/etc/puppet/hieradata'
-    branch_filter: '^(?!dev-).*$'
-```
-
-#### Filter branches - Include branches with a prefix
-
-If you would like to only deploy branches starting with a prefix "prod-" followed by word characters. Note: this does NOT match the "prod-" branch exactly due to the \w+.
-
-```yaml
----
-sources:
-  app1_data:
-    remote: 'git://git-server.site/my-org/app1-hieradata'
-    basedir: '/etc/puppet/hieradata'
-    branch_filter: '^(prod-)\w+$'
-```
-
-#### Filter branches - Match branches exactly
-
-If you would like to only deploy branches whose name matches exactly to 'master', or 'production'.
-
-```yaml
----
-sources:
-  app1_data:
-    remote: 'git://git-server.site/my-org/app1-hieradata'
-    basedir: '/etc/puppet/hieradata'
-    branch_filter: '^(master)|(production)$'
-```
-
-

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -478,6 +478,8 @@ This will create the following directory structure:
 |-- app1_develop     # app1 data repository, develop branch
 ```
 
+### Filtering branches
+
 #### Filtering branches - Exclude branches with a prefix
 
 If you would like to filter out all branches starting with and including "dev-".

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -356,6 +356,29 @@ sources:
 * if `false` (default) environment folder will not be prefixed
 * if `String` environment folder will be prefixed with the `prefix` value.
 
+### branch_filter
+
+The 'branch_filter' setting restricts the environment that are deployed to only
+those that match the given filter. The filter is a regex string. Each branch in
+the 'git' repo will have its named tested against this regex and, if the regex
+matches the branch name, then an environment will be deployed for this branch.
+If no 'branch_filter' is specified, then all branches in the 'git' repo will
+be deployed (default behavior).
+
+#### branch_filter behaviour
+* if empty, deploy environments for all branches
+* for each branch in git repo
+** if `branch.name` matches `branch_filter` regex, then deploy an environment for branch
+
+Example: only deploy branches named 'prod' or 'qa'
+```yaml
+---
+sources:
+  mysource:
+    basedir: '/etc/puppet/environments'
+    branch_filter: '^(prod)|(qa)$'
+```
+
 Examples
 --------
 
@@ -454,3 +477,44 @@ This will create the following directory structure:
 |-- app1_production  # app1 data repository, production branch
 |-- app1_develop     # app1 data repository, develop branch
 ```
+
+#### Filtering branches - Exclude branches with a prefix
+
+If you would like to filter out all branches starting with and including "dev-".
+
+```yaml
+---
+sources:
+  app1_data:
+    remote: 'git://git-server.site/my-org/app1-hieradata'
+    basedir: '/etc/puppet/hieradata'
+    branch_filter: '^(?!dev-).*$'
+```
+
+#### Filter branches - Include branches with a prefix
+
+If you would like to only deploy branches starting with a prefix "prod-" followed by word characters. Note: this does NOT match the "prod-" branch exactly due to the \w+.
+
+```yaml
+---
+sources:
+  app1_data:
+    remote: 'git://git-server.site/my-org/app1-hieradata'
+    basedir: '/etc/puppet/hieradata'
+    branch_filter: '^(prod-)\\w+$'
+```
+
+#### Filter branches - Match branches exactly
+
+If you would like to only deploy branches whose name matches exactly to 'master', or 'production'.
+
+```yaml
+---
+sources:
+  app1_data:
+    remote: 'git://git-server.site/my-org/app1-hieradata'
+    basedir: '/etc/puppet/hieradata'
+    branch_filter: '^(master)|(production)$'
+```
+
+

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -13,7 +13,7 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
-        attr_reader :no_force
+        attr_reader :force
 
         def initialize(opts, argv, settings = nil)
           settings ||= {}
@@ -22,6 +22,8 @@ module R10K
 
           super
 
+          # @force here is used to make it easier to reason about
+          @force = !@no_force
           @argv = @argv.map { |arg| arg.gsub(/\W/,'_') }
         end
 
@@ -119,8 +121,7 @@ module R10K
 
         def visit_module(mod)
           logger.info _("Deploying Puppetfile content %{mod_path}") % {mod_path: mod.path}
-          # no_force here is the opposite of the expected value of force.
-          mod.sync(force: !@no_force)
+          mod.sync(force: @force)
         end
 
         def write_environment_info!(environment, started_at, success)

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -146,7 +146,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self, no_force: :self)
+          super.merge(puppetfile: :self, cachedir: :self, 'no-force': :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -146,7 +146,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self, 'no-force': :self)
+          super.merge(puppetfile: :self, cachedir: :self, :'no-force' => :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -13,6 +13,8 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
+        attr_reader :no_force
+
         def initialize(opts, argv, settings = nil)
           settings ||= {}
           @purge_levels = settings.fetch(:deploy, {}).fetch(:purge_levels, [])
@@ -117,7 +119,8 @@ module R10K
 
         def visit_module(mod)
           logger.info _("Deploying Puppetfile content %{mod_path}") % {mod_path: mod.path}
-          mod.sync
+          # no_force here is the opposite of the expected value of force.
+          mod.sync(force: !@no_force)
         end
 
         def write_environment_info!(environment, started_at, success)
@@ -142,7 +145,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self)
+          super.merge(puppetfile: :self, cachedir: :self, no_force: :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -68,7 +68,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true, no_force: :self)
+          super.merge(environment: true, 'no-force': :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -10,6 +10,8 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
+        attr_reader :no_force
+
         def call
           @visit_ok = true
 
@@ -50,14 +52,15 @@ module R10K
         def visit_module(mod)
           if @argv.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
-            mod.sync
+            # no_force here is the opposite of the expceted value of force
+            mod.sync(force: !@no_force)
           else
             logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @argv.inspect, mod_name: mod.name})
           end
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true)
+          super.merge(environment: true, no_force: :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -10,7 +10,16 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
-        attr_reader :no_force
+        attr_reader :force
+
+        def initialize(opts, argv, settings = nil)
+          settings ||= {}
+
+          super
+
+          # @force here is used to make it easier to reason about
+          @force = !@no_force
+        end
 
         def call
           @visit_ok = true
@@ -52,8 +61,7 @@ module R10K
         def visit_module(mod)
           if @argv.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
-            # no_force here is the opposite of the expceted value of force
-            mod.sync(force: !@no_force)
+            mod.sync(force: @force)
           else
             logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @argv.inspect, mod_name: mod.name})
           end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -68,7 +68,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true, 'no-force': :self)
+          super.merge(environment: true, :'no-force' => :self)
         end
       end
     end

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -10,7 +10,7 @@ module R10K
 
         def call
           @visit_ok = true
-          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil , @update_force)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil , @force)
           pf.accept(self)
           @visit_ok
         end
@@ -26,18 +26,18 @@ module R10K
         end
 
         def visit_module(mod)
-          @update_force    = @update_force || false
+          @force ||= false
           logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
 
           if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
             logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})
           end
 
-          mod.sync(force: @update_force)
+          mod.sync(force: @force)
         end
 
         def allowed_initialize_opts
-          super.merge(root: :self, puppetfile: :self, moduledir: :self, update_force: :self )
+          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :self )
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -22,6 +22,7 @@ module R10K::CLI
         DESCRIPTION
 
         required nil, :cachedir, 'Specify a cachedir, overriding the value in config'
+        flag nil, :'no-force', 'Prevent the overwriting of local module modifications'
 
         run do |opts, args, cmd|
           puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -32,7 +32,7 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           summary 'Install all modules from a Puppetfile'
           required nil, :moduledir, 'Path to install modules to'
           required nil, :puppetfile, 'Path to puppetfile'
-          flag     nil, :update_force, 'Force locally changed files to be overwritten'
+          flag     nil, :force, 'Force locally changed files to be overwritten'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end
       end

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -6,7 +6,7 @@ require 'r10k/forge/module_release'
 
 require 'pathname'
 require 'fileutils'
-require 'puppet_forge'
+require 'puppet_forge/util'
 
 class R10K::Module::Forge < R10K::Module::Base
 
@@ -17,7 +17,7 @@ class R10K::Module::Forge < R10K::Module::Base
   end
 
   def self.valid_version?(expected_version)
-    expected_version == :latest || expected_version.nil? || SemanticPuppet::Version.valid?(expected_version)
+    expected_version == :latest || expected_version.nil? || PuppetForge::Util.version_valid?(expected_version)
   end
 
   # @!attribute [r] metadata

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -33,18 +33,18 @@ class Puppetfile
   #   @return [R10K::Environment] Optional R10K::Environment that this Puppetfile belongs to.
   attr_accessor :environment
 
-  # @!attribute [rw] update_force
-  #   @return [Boolean] Force update the modules and overwrite the locally made changes
-  attr_accessor :update_force
+  # @!attribute [rw] force
+  #   @return [Boolean] Overwrite any locally made changes
+  attr_accessor :force
 
   # @param [String] basedir
   # @param [String] moduledir The directory to install the modules, default to #{basedir}/modules
   # @param [String] puppetfile_path The path to the Puppetfile, default to #{basedir}/Puppetfile
   # @param [String] puppetfile_name The name of the Puppetfile, default to 'Puppetfile'
-  # @param [Boolean] update_force Shall we overwrite locally made changes?
-  def initialize(basedir, moduledir = nil, puppetfile_path = nil, puppetfile_name = nil, update_force = nil )
+  # @param [Boolean] force Shall we overwrite locally made changes?
+  def initialize(basedir, moduledir = nil, puppetfile_path = nil, puppetfile_name = nil, force = nil )
     @basedir         = basedir
-    @update_force    = update_force || false
+    @force           = force || false
     @moduledir       = moduledir  || File.join(basedir, 'modules')
     @puppetfile_path = puppetfile_path || File.join(basedir, 'Puppetfile')
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -52,8 +52,8 @@ module R10K
               :default => :inherit,
             }),
             
-            Definition.new(:branch_filter, {
-              :desc => "Regex string used to match branch names that will be deployed as environments.",
+            Definition.new(:ignore_branch_prefixes, {
+              :desc => "Array of strings used to prefix branch names that will not be deployed as environments.",
             }),
           ])
         },

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -51,6 +51,10 @@ module R10K
               :desc => "An optional proxy server to use when interacting with Git sources via HTTP(S).",
               :default => :inherit,
             }),
+            
+            Definition.new(:branch_filter, {
+              :desc => "Regex string used to match branch names that will be deployed as environments.",
+            }),
           ])
         },
         {

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -116,7 +116,7 @@ class R10K::Source::Git < R10K::Source::Base
   end
 
   def filter_branches(branches, ignore_prefixes)
-    filter = Regexp.new("^(#{ignore_prefixes.join('|')})")
+    filter = Regexp.new("^#{Regexp.union(ignore_prefixes)}")
     branches = branches.reject do |branch|
       result = filter.match(branch)
       if result

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -124,7 +124,7 @@ class R10K::Source::Git < R10K::Source::Base
       branches = branches.select do |branch|
         result = branch[/#{@branch_filter}/]
         if result.nil?
-          logger.debug _("Branch %{branch} filtered out by branch_filter regex %{regex}") % {branch: branch, regex: @branch_filter}
+          logger.warn _("Branch %{branch} filtered out by branch_filter regex %{regex}") % {branch: branch, regex: @branch_filter}
         end
         result
       end

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -40,7 +40,7 @@ class R10K::Source::Git < R10K::Source::Base
   #   @return [Array<String>] Array of strings used to remove repository branches
   #     that will be deployed as environments.
   attr_reader :ignore_branch_prefixes
-  
+
   # Initialize the given source.
   #
   # @param name [String] The identifier for this source.
@@ -58,9 +58,9 @@ class R10K::Source::Git < R10K::Source::Base
 
     @environments = []
 
-    @remote           = options[:remote]
+    @remote = options[:remote]
     @invalid_branches = (options[:invalid_branches] || 'correct_and_warn')
-    @ignore_branch_prefixes    = options[:ignore_branch_prefixes]
+    @ignore_branch_prefixes = options[:ignore_branch_prefixes]
 
     @cache  = R10K::Git.cache.generate(@remote)
   end
@@ -115,19 +115,19 @@ class R10K::Source::Git < R10K::Source::Base
     environments.map {|env| env.dirname }
   end
 
-  private
-
   def filter_branches(branches, ignore_prefixes)
-    filter = Regexp.new("^(#{ignore_prefixes.join('|')}).?")
-    branches = branches.select do |branch|
+    filter = Regexp.new("^(#{ignore_prefixes.join('|')})")
+    branches = branches.reject do |branch|
       result = filter.match(branch)
       if result
         logger.warn _("Branch %{branch} filtered out by ignore_branch_prefixes %{ibp}") % {branch: branch, ibp: @ignore_branch_prefixes}
       end
-      !result
+      result
     end
     branches
   end
+
+  private
 
   def branch_names
     opts = {:prefix => @prefix, :invalid => @invalid_branches, :source => @name}

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -117,17 +117,23 @@ class R10K::Source::Git < R10K::Source::Base
 
   private
 
-  def branch_names
-    opts = {:prefix => @prefix, :invalid => @invalid_branches, :source => @name}
-    branches = @cache.branches
-    if !@branch_filter.nil? && !@branch_filter.empty?
+  def filter_branches(branches, filter)
       branches = branches.select do |branch|
-        result = branch[/#{@branch_filter}/]
+        result = filter.match(branch)
         if result.nil?
           logger.warn _("Branch %{branch} filtered out by branch_filter regex %{regex}") % {branch: branch, regex: @branch_filter}
         end
         result
       end
+      branches
+  end
+
+  def branch_names
+    opts = {:prefix => @prefix, :invalid => @invalid_branches, :source => @name}
+    branches = @cache.branches
+    if @branch_filter && !@branch_filter.empty?
+      filter = Regexp.new(@branch_filter)
+      branches = filter_branches(branches, filter)
     end
     branches.map do |branch|
       R10K::Environment::Name.new(branch, opts)

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -36,6 +36,11 @@ class R10K::Source::Git < R10K::Source::Base
   #     Puppet environments will be handled.
   attr_reader :invalid_branches
 
+  # @!attribute [r] branch_filter
+  #   @return [String] Regex used to match branches from the repository that
+  #     that will be deployed as environments.
+  attr_reader :branch_filter
+  
   # Initialize the given source.
   #
   # @param name [String] The identifier for this source.
@@ -55,6 +60,7 @@ class R10K::Source::Git < R10K::Source::Base
 
     @remote           = options[:remote]
     @invalid_branches = (options[:invalid_branches] || 'correct_and_warn')
+    @branch_filter    = options[:branch_filter]
 
     @cache  = R10K::Git.cache.generate(@remote)
   end
@@ -113,7 +119,17 @@ class R10K::Source::Git < R10K::Source::Base
 
   def branch_names
     opts = {:prefix => @prefix, :invalid => @invalid_branches, :source => @name}
-    @cache.branches.map do |branch|
+    branches = @cache.branches
+    if !@branch_filter.nil? && !@branch_filter.empty?
+      branches = branches.select do |branch|
+        result = branch[/#{@branch_filter}/]
+        if result.nil?
+          logger.debug _("Branch %{branch} filtered out by branch_filter regex %{regex}") % {branch: branch, regex: @branch_filter}
+        end
+        result
+      end
+    end
+    branches.map do |branch|
       R10K::Environment::Name.new(branch, opts)
     end
   end

--- a/lib/r10k/source/svn.rb
+++ b/lib/r10k/source/svn.rb
@@ -115,7 +115,7 @@ class R10K::Source::SVN < R10K::Source::Base
       if !@branch_filter.nil? && !@branch_filter.empty?
         result = branch[/#{@branch_filter}/]
         if result.nil?
-          logger.debug _("Branch %{branch} filtered out by branch_filter regex %{regex}") % {branch: branch, regex: @branch_filter}
+          logger.warn _("Branch %{branch} filtered out by branch_filter regex %{regex}") % {branch: branch, regex: @branch_filter}
           next
         end
       end

--- a/lib/r10k/util/setopts.rb
+++ b/lib/r10k/util/setopts.rb
@@ -39,9 +39,11 @@ module R10K
             when NilClass, FalseClass
               # Ignore nil options
             when :self, TrueClass
-              instance_variable_set("@#{key}".to_sym, value)
+              # tr here is because instance variables cannot have hyphens in their names.
+              instance_variable_set("@#{key}".tr('-','_').to_sym, value)
             else
-              instance_variable_set("@#{rhs}".to_sym, value)
+              # tr here same as previous
+              instance_variable_set("@#{rhs}".tr('-','_').to_sym, value)
             end
           else
             raise ArgumentError, _("%{class_name} cannot handle option '%{key}'") % {class_name: self.class.name, key: key}

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
-  s.add_dependency 'json'
 
   s.add_dependency 'puppet_forge', '~> 2.2.8'
 

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
+  s.add_dependency 'json'
 
   s.add_dependency 'puppet_forge', '~> 2.2.8'
 

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
+  s.add_dependency 'json'
 
   s.add_dependency 'puppet_forge', '~> 2.2'
   s.add_dependency 'semantic_puppet', '>= 0.1.4', '< 2.0'

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -28,8 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
 
-  s.add_dependency 'puppet_forge', '~> 2.2'
-  s.add_dependency 'semantic_puppet', '>= 0.1.4', '< 2.0'
+  s.add_dependency 'puppet_forge', '~> 2.2.8'
 
   s.add_dependency 'gettext-setup', '~> 0.5'
 

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
-  s.add_dependency 'json'
 
   s.add_dependency 'puppet_forge', '~> 2.2'
   s.add_dependency 'semantic_puppet', '>= 0.1.4', '< 2.0'

--- a/spec/shared-examples/puppetfile-action.rb
+++ b/spec/shared-examples/puppetfile-action.rb
@@ -31,8 +31,8 @@ shared_examples_for "a puppetfile install action" do
       described_class.new({moduledir: "/some/nonexistent/path/modules"}, [])
     end
 
-    it "accepts the :update_force option" do
-      described_class.new({update_force: true}, [])
+    it "accepts the :force option" do
+      described_class.new({force: true}, [])
     end
 
   end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -19,8 +19,8 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({puppetfile: true}, [])
     end
 
-    it "can accept a no_force option" do
-      described_class.new({no_force: true}, [])
+    it "can accept a no-force option" do
+      described_class.new({'no-force': true}, [])
     end
 
     it "normalizes environment names in the arg vector"
@@ -57,12 +57,16 @@ describe R10K::Action::Deploy::Environment do
       end
     end
 
-    describe "with no_force" do
+    describe "with no-force" do
 
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, no_force: true}, %w[first]) }
+      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, 'no-force': true}, %w[first]) }
 
       it "tries to preserve local modifications" do
         expect(subject.force).to equal(false)
+      end
+
+      it "logs that a modified environment is skipped when 'no-force' is true" do
+          
       end
     end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -19,6 +19,10 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({puppetfile: true}, [])
     end
 
+    it "can accept a no_force option" do
+      described_class.new({no_force: true}, [])
+    end
+
     it "normalizes environment names in the arg vector"
   end
 
@@ -50,6 +54,15 @@ describe R10K::Action::Deploy::Environment do
         expect(subject.logger).to receive(:error).with("Environment(s) 'not_an_environment' cannot be found in any source and will not be deployed.")
         logger = subject.logger
         expect(subject.call).to eq false
+      end
+    end
+
+    describe "with no_force" do
+
+      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, no_force: true}, %w[first]) }
+
+      it "tries to preserve local modifications" do
+        expect(subject.no_force).to equal(true)
       end
     end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -20,7 +20,7 @@ describe R10K::Action::Deploy::Environment do
     end
 
     it "can accept a no-force option" do
-      described_class.new({'no-force': true}, [])
+      described_class.new({:'no-force' => true}, [])
     end
 
     it "normalizes environment names in the arg vector"
@@ -58,15 +58,10 @@ describe R10K::Action::Deploy::Environment do
     end
 
     describe "with no-force" do
-
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, 'no-force': true}, %w[first]) }
+      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, :'no-force' => true}, %w[first]) }
 
       it "tries to preserve local modifications" do
         expect(subject.force).to equal(false)
-      end
-
-      it "logs that a modified environment is skipped when 'no-force' is true" do
-          
       end
     end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -62,7 +62,7 @@ describe R10K::Action::Deploy::Environment do
       subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, no_force: true}, %w[first]) }
 
       it "tries to preserve local modifications" do
-        expect(subject.no_force).to equal(true)
+        expect(subject.force).to equal(false)
       end
     end
 

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -24,7 +24,7 @@ describe R10K::Action::Deploy::Module do
     subject { described_class.new({ config: "/some/nonexistent/path", no_force: true}, [] )}
 
     it "tries to preserve local modifications" do
-      expect(subject.no_force).to equal(true)
+      expect(subject.force).to equal(false)
     end
   end
 end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -13,5 +13,18 @@ describe R10K::Action::Deploy::Module do
     it "accepts an environment option" do
       described_class.new({environment: "production"}, [])
     end
+
+    it "can accept a no_force option" do
+      described_class.new({no_force: true}, [])
+    end
+  end
+
+  describe "with no_force" do
+
+    subject { described_class.new({ config: "/some/nonexistent/path", no_force: true}, [] )}
+
+    it "tries to preserve local modifications" do
+      expect(subject.no_force).to equal(true)
+    end
   end
 end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -15,13 +15,13 @@ describe R10K::Action::Deploy::Module do
     end
 
     it "can accept a no-force option" do
-      described_class.new({'no-force': true}, [])
+      described_class.new({:'no-force' => true}, [])
     end
   end
 
   describe "with no-force" do
 
-    subject { described_class.new({ config: "/some/nonexistent/path", 'no-force': true}, [] )}
+    subject { described_class.new({ config: "/some/nonexistent/path", :'no-force' => true}, [] )}
 
     it "tries to preserve local modifications" do
       expect(subject.force).to equal(false)

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -14,14 +14,14 @@ describe R10K::Action::Deploy::Module do
       described_class.new({environment: "production"}, [])
     end
 
-    it "can accept a no_force option" do
-      described_class.new({no_force: true}, [])
+    it "can accept a no-force option" do
+      described_class.new({'no-force': true}, [])
     end
   end
 
-  describe "with no_force" do
+  describe "with no-force" do
 
-    subject { described_class.new({ config: "/some/nonexistent/path", no_force: true}, [] )}
+    subject { described_class.new({ config: "/some/nonexistent/path", 'no-force': true}, [] )}
 
     it "tries to preserve local modifications" do
       expect(subject.force).to equal(false)

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -73,7 +73,7 @@ describe R10K::Action::Puppetfile::Install do
     end
 
     it "can use the force overwrite option" do
-      subject = described_class.new({root: "/some/nonexistent/path", update_force: true}, [])
+      subject = described_class.new({root: "/some/nonexistent/path", force: true}, [])
       expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, true).and_return(puppetfile)
       subject.call
     end

--- a/spec/unit/source/git_spec.rb
+++ b/spec/unit/source/git_spec.rb
@@ -63,53 +63,26 @@ describe R10K::Source::Git do
     end
   end
 
-  describe "generating environments with branch filter" do
+  describe "generating environments without the ignore_branch_prefixes" do
     before do
-      allow(subject.cache).to receive(:branches).and_return ['master', 'development', 'production', 'dev-test']
-      subject.instance_variable_set(:@branch_filter, "(dev.*)|(mast.*)")
+      allow(subject.cache).to receive(:branches).and_return ['master', 'development', 'production', 'dev-test', 'dev', 'test_2']
+      subject.instance_variable_set(:@ignore_branch_prefixes, ['dev', 'test'])
     end
 
     let(:environments) { subject.generate_environments }
 
-    it "creates an environment for each branch that matches the filter" do
-      expect(subject.generate_environments.size).to eq(3)
+    it "creates an environment for each branch not in ignore_branch_prefixes" do
+      expect(subject.generate_environments.size).to eq(2)
     end
 
     it "copies the source remote to the environment" do
       expect(environments[0].remote).to eq subject.remote
       expect(environments[1].remote).to eq subject.remote
-      expect(environments[2].remote).to eq subject.remote
     end
 
     it "uses the branch name as the directory by default" do
       expect(environments[0].dirname).to eq 'master'
-      expect(environments[1].dirname).to eq 'development'
-      expect(environments[2].dirname).to eq 'dev_test'
-    end
-  end
-
-  describe "generating environments with branch filter exclude prefix" do
-    before do
-      allow(subject.cache).to receive(:branches).and_return ['master', 'development', 'production', 'dev-test']
-      subject.instance_variable_set(:@branch_filter, "^(?!dev-)\\w+$")
-    end
-
-    let(:environments) { subject.generate_environments }
-
-    it "creates an environment for each branch that matches the filter" do
-      expect(subject.generate_environments.size).to eq(3)
-    end
-
-    it "copies the source remote to the environment" do
-      expect(environments[0].remote).to eq subject.remote
-      expect(environments[1].remote).to eq subject.remote
-      expect(environments[2].remote).to eq subject.remote
-    end
-
-    it "uses the branch name as the directory by default" do
-      expect(environments[0].dirname).to eq 'master'
-      expect(environments[1].dirname).to eq 'development'
-      expect(environments[2].dirname).to eq 'production'
+      expect(environments[1].dirname).to eq 'production'
     end
   end
 end

--- a/spec/unit/source/git_spec.rb
+++ b/spec/unit/source/git_spec.rb
@@ -62,6 +62,56 @@ describe R10K::Source::Git do
       expect(master_env.dirname).to eq 'master'
     end
   end
+
+  describe "generating environments with branch filter" do
+    before do
+      allow(subject.cache).to receive(:branches).and_return ['master', 'development', 'production', 'dev-test']
+      subject.instance_variable_set(:@branch_filter, "(dev.*)|(mast.*)")
+    end
+
+    let(:environments) { subject.generate_environments }
+
+    it "creates an environment for each branch that matches the filter" do
+      expect(subject.generate_environments.size).to eq(3)
+    end
+
+    it "copies the source remote to the environment" do
+      expect(environments[0].remote).to eq subject.remote
+      expect(environments[1].remote).to eq subject.remote
+      expect(environments[2].remote).to eq subject.remote
+    end
+
+    it "uses the branch name as the directory by default" do
+      expect(environments[0].dirname).to eq 'master'
+      expect(environments[1].dirname).to eq 'development'
+      expect(environments[2].dirname).to eq 'dev_test'
+    end
+  end
+
+  describe "generating environments with branch filter exclude prefix" do
+    before do
+      allow(subject.cache).to receive(:branches).and_return ['master', 'development', 'production', 'dev-test']
+      subject.instance_variable_set(:@branch_filter, "^(?!dev-)\\w+$")
+    end
+
+    let(:environments) { subject.generate_environments }
+
+    it "creates an environment for each branch that matches the filter" do
+      expect(subject.generate_environments.size).to eq(3)
+    end
+
+    it "copies the source remote to the environment" do
+      expect(environments[0].remote).to eq subject.remote
+      expect(environments[1].remote).to eq subject.remote
+      expect(environments[2].remote).to eq subject.remote
+    end
+
+    it "uses the branch name as the directory by default" do
+      expect(environments[0].dirname).to eq 'master'
+      expect(environments[1].dirname).to eq 'development'
+      expect(environments[2].dirname).to eq 'production'
+    end
+  end
 end
 
 describe R10K::Source::Git, "handling invalid branch names" do

--- a/spec/unit/source/git_spec.rb
+++ b/spec/unit/source/git_spec.rb
@@ -85,6 +85,15 @@ describe R10K::Source::Git do
       expect(environments[1].dirname).to eq 'production'
     end
   end
+
+  describe "filtering branches with ignore prefixes" do
+    let(:branches) { ['master', 'development', 'production', 'dev-test', 'dev', 'test_2'] }
+    let(:ignore_prefixes) { ['dev', 'test'] }
+
+    it "filters branches" do
+      expect(subject.filter_branches(branches, ignore_prefixes)).to eq(['master', 'production'])
+    end
+  end
 end
 
 describe R10K::Source::Git, "handling invalid branch names" do

--- a/spec/unit/source/git_spec.rb
+++ b/spec/unit/source/git_spec.rb
@@ -63,35 +63,37 @@ describe R10K::Source::Git do
     end
   end
 
-  describe "generating environments without the ignore_branch_prefixes" do
+  describe "generate_environments respects ignore_branch_prefixes setting" do
     before do
-      allow(subject.cache).to receive(:branches).and_return ['master', 'development', 'production', 'dev-test', 'dev', 'test_2']
+      allow(subject.cache).to receive(:branches).and_return ['master', 'development', 'production', 'not_dev_test_me', 'dev_test', 'dev', 'test_2']
       subject.instance_variable_set(:@ignore_branch_prefixes, ['dev', 'test'])
     end
 
     let(:environments) { subject.generate_environments }
 
     it "creates an environment for each branch not in ignore_branch_prefixes" do
-      expect(subject.generate_environments.size).to eq(2)
+      expect(subject.generate_environments.size).to eq(3)
     end
 
     it "copies the source remote to the environment" do
       expect(environments[0].remote).to eq subject.remote
       expect(environments[1].remote).to eq subject.remote
+      expect(environments[2].remote).to eq subject.remote
     end
 
     it "uses the branch name as the directory by default" do
       expect(environments[0].dirname).to eq 'master'
       expect(environments[1].dirname).to eq 'production'
+      expect(environments[2].dirname).to eq 'not_dev_test_me'
     end
   end
 
   describe "filtering branches with ignore prefixes" do
-    let(:branches) { ['master', 'development', 'production', 'dev-test', 'dev', 'test_2'] }
+    let(:branches) { ['master', 'development', 'production', 'not_dev_test_me', 'dev_test', 'dev', 'test_2'] }
     let(:ignore_prefixes) { ['dev', 'test'] }
 
     it "filters branches" do
-      expect(subject.filter_branches(branches, ignore_prefixes)).to eq(['master', 'production'])
+      expect(subject.filter_branches(branches, ignore_prefixes)).to eq(['master', 'production', 'not_dev_test_me'])
     end
   end
 end

--- a/spec/unit/source/svn_spec.rb
+++ b/spec/unit/source/svn_spec.rb
@@ -62,30 +62,31 @@ describe R10K::Source::SVN do
     end
   end
 
-  describe "generating environments with branch filter exclude prefix" do
+  describe "generate_environments respects ignore_branch_prefixes setting" do
     before do
-      allow(subject.svn_remote).to receive(:branches).and_return ['master', 'development', 'dev-test', 'dev', 'test_2']
+      allow(subject.svn_remote).to receive(:branches).and_return ['master', 'development', 'not_dev_test_me', 'dev_test', 'dev', 'test_2']
       subject.instance_variable_set(:@ignore_branch_prefixes, ['dev', 'test'])
     end
 
     let(:environments) { subject.generate_environments }
 
     it "creates an environment for each branch not in ignore_branch_prefixes" do
-      expect(subject.generate_environments.size).to eq(2)
+      expect(subject.generate_environments.size).to eq(3)
     end
 
     it "uses the branch name as the directory by default" do
       expect(environments[0].name).to eq 'production'
       expect(environments[1].name).to eq 'master'
+      expect(environments[2].name).to eq 'not_dev_test_me'
     end
   end
 
   describe "filtering branches with ignore prefixes" do
-    let(:branches) { ['master', 'development', 'production', 'dev-test', 'dev', 'test_2'] }
+    let(:branches) { ['master', 'development', 'production', 'not_dev_test_me', 'dev_test', 'dev', 'test_2'] }
     let(:ignore_prefixes) { ['dev', 'test'] }
 
     it "filters branches" do
-      expect(subject.filter_branches(branches, ignore_prefixes)).to eq(['master', 'production'])
+      expect(subject.filter_branches(branches, ignore_prefixes)).to eq(['master', 'production', 'not_dev_test_me'])
     end
   end
 end

--- a/spec/unit/source/svn_spec.rb
+++ b/spec/unit/source/svn_spec.rb
@@ -62,44 +62,32 @@ describe R10K::Source::SVN do
     end
   end
 
-  describe "generating environments with branch filter" do
-    before do
-      allow(subject.svn_remote).to receive(:branches).and_return ['test', 'development', 'dev-test']
-      subject.instance_variable_set(:@branch_filter, "(dev.*)")
-    end
-
-    let(:environments) { subject.generate_environments }
-
-    it "creates an environment for each branch that matches the filter" do
-      expect(subject.generate_environments.size).to eq(3)
-    end
-
-    it "uses the branch name as the directory by default" do
-      expect(environments[0].name).to eq 'production'
-      expect(environments[1].name).to eq 'development'
-      expect(environments[2].name).to eq 'dev-test'
-    end
-  end
-
   describe "generating environments with branch filter exclude prefix" do
     before do
-      allow(subject.svn_remote).to receive(:branches).and_return ['test', 'development', 'dev-test']
-      subject.instance_variable_set(:@branch_filter, "^(?!dev-)\\w+$")
+      allow(subject.svn_remote).to receive(:branches).and_return ['master', 'development', 'dev-test', 'dev', 'test_2']
+      subject.instance_variable_set(:@ignore_branch_prefixes, ['dev', 'test'])
     end
 
     let(:environments) { subject.generate_environments }
 
-    it "creates an environment for each branch that matches the filter" do
-      expect(subject.generate_environments.size).to eq(3)
+    it "creates an environment for each branch not in ignore_branch_prefixes" do
+      expect(subject.generate_environments.size).to eq(2)
     end
 
     it "uses the branch name as the directory by default" do
       expect(environments[0].name).to eq 'production'
-      expect(environments[1].name).to eq 'test'
-      expect(environments[2].name).to eq 'development'
+      expect(environments[1].name).to eq 'master'
     end
   end
 
+  describe "filtering branches with ignore prefixes" do
+    let(:branches) { ['master', 'development', 'production', 'dev-test', 'dev', 'test_2'] }
+    let(:ignore_prefixes) { ['dev', 'test'] }
+
+    it "filters branches" do
+      expect(subject.filter_branches(branches, ignore_prefixes)).to eq(['master', 'production'])
+    end
+  end
 end
 
 describe R10K::Source::SVN, 'when prefixing is enabled' do

--- a/spec/unit/source/svn_spec.rb
+++ b/spec/unit/source/svn_spec.rb
@@ -61,6 +61,45 @@ describe R10K::Source::SVN do
       expect(environments[3].dirname).to eq 'robobutler'
     end
   end
+
+  describe "generating environments with branch filter" do
+    before do
+      allow(subject.svn_remote).to receive(:branches).and_return ['test', 'development', 'dev-test']
+      subject.instance_variable_set(:@branch_filter, "(dev.*)")
+    end
+
+    let(:environments) { subject.generate_environments }
+
+    it "creates an environment for each branch that matches the filter" do
+      expect(subject.generate_environments.size).to eq(3)
+    end
+
+    it "uses the branch name as the directory by default" do
+      expect(environments[0].name).to eq 'production'
+      expect(environments[1].name).to eq 'development'
+      expect(environments[2].name).to eq 'dev-test'
+    end
+  end
+
+  describe "generating environments with branch filter exclude prefix" do
+    before do
+      allow(subject.svn_remote).to receive(:branches).and_return ['test', 'development', 'dev-test']
+      subject.instance_variable_set(:@branch_filter, "^(?!dev-)\\w+$")
+    end
+
+    let(:environments) { subject.generate_environments }
+
+    it "creates an environment for each branch that matches the filter" do
+      expect(subject.generate_environments.size).to eq(3)
+    end
+
+    it "uses the branch name as the directory by default" do
+      expect(environments[0].name).to eq 'production'
+      expect(environments[1].name).to eq 'test'
+      expect(environments[2].name).to eq 'development'
+    end
+  end
+
 end
 
 describe R10K::Source::SVN, 'when prefixing is enabled' do


### PR DESCRIPTION
This is a partial implementation of feature request #574

This PR implements ignoring branches based on a prefix list provided in the r10k.yaml configuration file for a given source. There is a new setting option for a source called ignore_branch_prefixes:. If specified, then only branches that do not start with a string in the list will be deployed into environments. If ignore_branch_prefixes: is not specified, then all branches will be deployed. This makes it a backwards compatible change.

Please see the updated documentation for configuration in this PR for examples.

Comments and reviews appreciated.

The original work for this came from @nmaludy and is adapted from #757 