### PR TITLE
(RK-308) Enable forge in Puppetfile to actually override one used.

### DIFF
--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -21,8 +21,23 @@ module R10K
 
         def visit_puppetfile(pf)
           pf.load!
+
+          original_forge = PuppetForge.host
+
+          if !pf.forge.nil?
+            if @settings[:forge][:allow_override]
+              logger.notice _("Using 'forge' value of '%{newforge}' declared in '%{puppetfile}'") % {puppetfile: pf.puppetfile_path, newforge: pf.forge}
+              PuppetForge.host = pf.forge
+            else
+              logger.notice _("Ignoring 'forge' value declared in '%{puppetfile}'") % {puppetfile: pf.puppetfile_path}
+            end
+          end
+
           yield
+
           pf.purge!
+        ensure
+          PuppetForge.host = original_forge
         end
 
         def visit_module(mod)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -50,7 +50,6 @@ class Puppetfile
 
     @modules = []
     @managed_content = {}
-    @forge   = 'forgeapi.puppetlabs.com'
 
     @loaded = false
   end
@@ -74,6 +73,9 @@ class Puppetfile
 
   # @param [String] forge
   def set_forge(forge)
+    unless @forge.nil?
+      raise R10K::Error.new(_('You cannot declare multiple \'forge\' settings in the same Puppetfile'))
+    end
     @forge = forge
   end
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -70,6 +70,12 @@ module R10K
         URIDefinition.new(:baseurl, {
           :desc => "The URL to the Puppet Forge to use for downloading modules."
         }),
+
+        Definition.new(:allow_override, {
+          :desc => "Whether or not to allow the Forge URL to be overridden by a 'forge' directive inside an environment Puppetfile.",
+          :default => lambda { false },
+          :normalize => lambda { |v| v.to_s.strip == 'true' },
+        }),
       ])
     end
 

--- a/r10k.yaml.example
+++ b/r10k.yaml.example
@@ -104,3 +104,8 @@ forge:
   # The 'baseurl' setting indicates where Forge modules should be installed
   # from. This defaults to 'https://forgeapi.puppetlabs.com'
   #baseurl: 'https://forgemirror.example.com'
+
+  # The 'allow_override' setting controls whether or not to allow the Forge
+  # 'baseurl' to be overridden by a 'forge' directive inside a Puppetfile.
+  # This defaults to 'false'.
+  #allow_override: true

--- a/spec/fixtures/unit/puppetfile/alternate-forge/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/alternate-forge/Puppetfile
@@ -1,0 +1,3 @@
+forge 'http://forge.example.com/'
+
+mod 'puppetlabs/stdlib'

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -9,6 +9,7 @@ describe R10K::Action::Puppetfile::Install do
 
   before(:each) do
     allow(puppetfile).to receive(:load!).and_return(nil)
+    allow(puppetfile).to receive(:forge).and_return(nil)
     allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, nil).and_return(puppetfile)
   end
 

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -181,6 +181,14 @@ describe R10K::Puppetfile do
       subject = described_class.new(path)
       expect { subject.load! }.not_to raise_error
     end
+
+    it "accepts alternate forge" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'alternate-forge')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect { subject.load! }.not_to raise_error
+      expect(subject).to have_attributes(:forge => 'http://forge.example.com/')
+    end
   end
 
   describe "accepting a visitor" do

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -90,6 +90,22 @@ describe R10K::Settings do
         end
       end
     end
+    describe "allow_override" do
+      it "defaults to false" do
+        output = subject.evaluate({})
+        expect(output[:allow_override]).to eq false
+      end
+
+      it "recognizes the string 'true' as boolean true" do
+        output = subject.evaluate("allow_override" => "true")
+        expect(output[:allow_override]).to eq true
+      end
+
+      it "treats all values other than 'true' as false" do
+        output = subject.evaluate("allow_override" => "yes")
+        expect(output[:allow_override]).to eq false
+      end
+    end
   end
 
   describe "deploy settings" do
@@ -192,7 +208,7 @@ describe R10K::Settings do
     describe "forge settings" do
       it "passes settings through to the forge settings" do
         output = subject.evaluate("forge" => {"baseurl" => "https://forge.tessier-ashpool.freeside", "proxy" => "https://proxy.tessier-ashpool.freesize:3128"})
-        expect(output[:forge]).to eq(:baseurl => "https://forge.tessier-ashpool.freeside", :proxy => "https://proxy.tessier-ashpool.freesize:3128")
+        expect(output[:forge]).to include(:baseurl => "https://forge.tessier-ashpool.freeside", :proxy => "https://proxy.tessier-ashpool.freesize:3128")
       end
     end
   end


### PR DESCRIPTION
Thanks to @jearls for this work... now the `forge` line in a Puppetfile will actually attempt to pull down from that. 

This has been tested with and without a forge line.