### PR TITLE
Add boolean flag support to setopts

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -22,8 +22,9 @@ module R10K
 
           super
 
-          # @force here is used to make it easier to reason about
-          @force = !@no_force
+          # If neither --force nor --no-force was specified, set a default
+          @force = true if @force.nil?
+
           @argv = @argv.map { |arg| arg.gsub(/\W/,'_') }
         end
 
@@ -146,7 +147,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self, :'no-force' => :self)
+          super.merge(puppetfile: :self, cachedir: :self, :force => :boolean)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -17,8 +17,8 @@ module R10K
 
           super
 
-          # @force here is used to make it easier to reason about
-          @force = !@no_force
+          # If neither --force nor --no-force was specified, set a default
+          @force = true if @force.nil?
         end
 
         def call
@@ -68,7 +68,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true, :'no-force' => :self)
+          super.merge(environment: true, :force => :boolean)
         end
       end
     end

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -26,7 +26,7 @@ module R10K
         end
 
         def visit_module(mod)
-          @force ||= false
+          @force = false if @force.nil?
           logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
 
           if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
@@ -37,7 +37,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :self )
+          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :boolean)
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -22,7 +22,8 @@ module R10K::CLI
         DESCRIPTION
 
         required nil, :cachedir, 'Specify a cachedir, overriding the value in config'
-        flag nil, :'no-force', 'Prevent the overwriting of local module modifications'
+        flag nil, :'force',    'Attempt to overwrite local modifications when deploying (default)'
+        flag nil, :'no-force', 'Prevent the overwriting of local modifications when deploying'
 
         run do |opts, args, cmd|
           puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -33,6 +33,7 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           required nil, :moduledir, 'Path to install modules to'
           required nil, :puppetfile, 'Path to puppetfile'
           flag     nil, :force, 'Force locally changed files to be overwritten'
+          flag     nil, :'no-force', 'Don\'t overwrite locally changed files (default)'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end
       end

--- a/spec/unit/util/setopts_spec.rb
+++ b/spec/unit/util/setopts_spec.rb
@@ -18,6 +18,15 @@ describe R10K::Util::Setopts do
     end
   end
 
+  let(:normalize_boolean_opts_spec) do
+    Class.new do
+      include R10K::Util::Setopts
+      def test(opts, allowed)
+        normalize_boolean_opts(opts, allowed)
+      end
+    end
+  end
+
   it "can handle an empty hash of options" do
     o = klass.new()
     expect(o.valid).to be_nil
@@ -55,5 +64,26 @@ describe R10K::Util::Setopts do
 
   it "ignores values that are marked as unhandled" do
     klass.new(:ignoreme => "IGNORE ME!")
+  end
+
+  it "normalizes boolean opts" do
+    result = normalize_boolean_opts_spec.new.test(
+      Hash[{
+        :flag1 => true,
+        :'no-flag2' => true,
+        :other => :value,
+      }],
+      Hash[{
+        :flag1 => :boolean,
+        :flag2 => :boolean,
+        :other => :self,
+      }]
+    )
+
+    expect(result).to eq Hash[{
+      :flag1 => true,
+      :flag2 => false,
+      :other => :value,
+    }]
   end
 end


### PR DESCRIPTION
This commit adds support to setopts for :boolean flags. Specifying a
boolean flag means the flag when passed directly, --flag, is boolean
true. When the flag is denoted boolean, it will also be possible to pass
--no-flag, which will set the flag to false.

In the R10K::CLI module, if you want both true and false to be valid
flags you must reference both of them. (If you only want one value to be
passable, provide only the true or false version of the flag, as you
like). Example:

    module R10K::CLI
      module Example
        def self.command
          @cmd ||= Cri::Command.define do
            name    'example'

            flag nil, :'flag',    'Lets the user set flag to true'
            flag nil, :'no-flag', 'Lets the user set flag to false'

            run { |opts, args, cmd| exit 0 }
          end
        end
      end
    end

In allowed_initialize_opts, it is only necessary to define the flag
name once. E.g. for a flag "flag":

    def allowed_initialize_opts
      super.merge(:flag => :boolean)
    end