### PR TITLE
RK-310 Fix constant CHECKSUM MISMATCH on Windows.

### DIFF
--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -108,7 +108,7 @@ module R10K
       def verify
         logger.debug1 "Verifying that #{@tarball_cache_path} matches checksum"
 
-        md5_of_tarball = Digest::MD5.hexdigest(File.read(@tarball_cache_path))
+        md5_of_tarball = Digest::MD5.hexdigest(File.read(@tarball_cache_path, mode: 'rb'))
 
         if @md5_file_path.exist?
           verify_from_md5_file(md5_of_tarball)


### PR DESCRIPTION
Forge module caching was constantly causing a CHECKSUM MISMATCH when
calculating the MD5 of the downloaded module tarball. This commit fixes
that issue by forcing the File.read of the tarball to be binary.