### PR TITLE
(RK-311) Update yard dependency.

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
 
-  s.add_development_dependency 'yard', '~> 0.8.7.3'
+  s.add_development_dependency 'yard', '~> 0.9.11'
   s.add_development_dependency 'minitar', '~> 0.6.1'
 
   s.files        = %x[git ls-files].split($/)


### PR DESCRIPTION
r10k's dependency on yard needed to be updated due to a security
vulnerability seen in yard < 0.9.11. This updates the dependency to
~> 0.9.11.