### PR TITLE
Add mbaynton/SimplePuppetProvisioner to list of webhook listeners

### DIFF
--- a/doc/common-patterns.mkd
+++ b/doc/common-patterns.mkd
@@ -42,3 +42,4 @@ publicly available hook. These include:
 * [Reaktor](https://github.com/pzim/reaktor)
 * [zack/r10k's Webhooks](https://forge.puppetlabs.com/zack/r10k#webhook-support)
 (Puppet Enterprise only)
+* [Simple Puppet Provisioner](https://github.com/mbaynton/SimplePuppetProvisioner)


### PR DESCRIPTION
A modest documentation update ;)

I think it's worth a mention because it's simpler to deploy than alternatives that may require web servers and application frameworks, redis etc to be set up, and because it has other functionality like client certificate signing via http API that may be interesting to some users.