### PR TITLE
(CODEMGMT-1152) Implement basemod Puppetfile feature

### DIFF
--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -305,3 +305,36 @@ mod 'apache',
 The given 'install\_path' can be an absolute path or a path relative to the base of
 the environment. Note that r10k will exit with an error if you attempt to set the
 'path' option to a directory outside of the environment.
+
+### Basemod
+
+The special directive `basemod` can be used to deploy the contents of a Git
+repository to the directory containing the Puppetfile, rather than to a
+`modules/` (or `modulepath`) subdirectory. Using basemod allows the contents of
+the control repo to be reduced to _only_ the Puppetfile, and for all other
+content (environment.conf, hiera.yaml, site-modules) to be versioned and
+developed in a separate repo as if they too were just another module.
+
+#### Example
+
+```
+##
+# SITE-SPECIFIC CONTENT
+#
+# Main environment content, like hiera.yaml and environment.conf.
+# Should be assigned a specific version; tag or commit (except when developing)
+#
+basemod 'site',
+  :git => 'https://github.com/reidmv/puppet-site-code.git',
+  :ref => '1.0'
+
+##
+# MODULES
+#
+# Each module here should be assigned a specific version; tag or commit (except
+# when developing)
+#
+mod 'puppetlabs/stdlib',
+  :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git',
+  :ref => '4.20.0'
+```

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -120,7 +120,7 @@ module R10K
         end
 
         def visit_module(mod)
-          logger.info _("Deploying Puppetfile content %{mod_path}") % {mod_path: mod.path}
+          logger.info _("Deploying Puppetfile content %{mod_path}") % {mod_path: mod.printpath}
           mod.sync(force: @force)
         end
 

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -85,6 +85,14 @@ module R10K
           status = environment.status
           logger.info _("Deploying environment %{env_path}") % {env_path: environment.path}
 
+          # Suppress normal dirty/force warnings if a basemod is in use. A
+          # basemod is expected to "dirty" the environment.
+          if (@puppetfile &&
+              environment.puppetfile.load &&
+              environment.puppetfile.modules.find { |mod| mod.is_basemod })
+            environment.repo.expect_dirty = true
+          end
+
           environment.sync
           logger.info _("Environment %{env_dir} is now at %{env_signature}") % {env_dir: environment.dirname, env_signature: environment.signature}
 

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -60,7 +60,7 @@ module R10K
 
         def visit_module(mod)
           if @argv.include?(mod.name)
-            logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
+            logger.info _("Deploying module %{mod_path}") % {mod_path: mod.printpath}
             mod.sync(force: @force)
           else
             logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @argv.inspect, mod_name: mod.name})

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -27,7 +27,7 @@ module R10K
 
         def visit_module(mod)
           @force ||= false
-          logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
+          logger.info _("Updating module %{mod_path}") % {mod_path: mod.printpath}
 
           if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
             logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -3,10 +3,10 @@ require 'r10k/git/rugged/working_repository'
 require 'r10k/git/rugged/cache'
 
 class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
-  def initialize(basedir, dirname, cache_repo)
+  def initialize(basedir, dirname, gitdirname, cache_repo)
     @cache_repo = cache_repo
 
-    super(basedir, dirname)
+    super(basedir, dirname, gitdirname)
   end
 
   # Clone this git repository
@@ -29,8 +29,9 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
     # update 'objects/info/alternates' with the path. We don't actually
     # fetch any objects because we don't need them, and we don't actually
     # use any refs in this repository so we skip all those steps.
-    ::Rugged::Repository.init_at(@path.to_s, false)
-    @_rugged_repo = ::Rugged::Repository.new(@path.to_s, :alternates => [cache_objects_dir])
+    ::Rugged::Repository.init_at(@git_dir.to_s, true)
+    @_rugged_repo = ::Rugged::Repository.new(@git_dir.to_s, :alternates => [cache_objects_dir])
+    @_rugged_repo.workdir = @path.to_s
     alternates << cache_objects_dir
 
     with_repo do |repo|

--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -8,9 +8,9 @@ require 'r10k/git/shellgit/working_repository'
 # making new clones very lightweight.
 class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingRepository
 
-  def initialize(basedir, dirname, cache_repo)
+  def initialize(basedir, dirname, gitdirname, cache_repo)
     @cache_repo = cache_repo
-    super(basedir, dirname)
+    super(basedir, dirname, gitdirname)
   end
 
   # Clone this git repository
@@ -36,11 +36,11 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
 
   # @return [String] The origin remote URL
   def cache
-    git(['config', '--get', 'remote.cache.url'], :path => @path.to_s, :raise_on_fail => false).stdout
+    git(['config', '--get', 'remote.cache.url'], :raise_on_fail => false).stdout
   end
 
   def tracked_paths(ref="HEAD")
-    git(['ls-tree', '-t', '-r', '--name-only', ref], :path => @path.to_s).stdout.split("\n")
+    git(['ls-tree', '-t', '-r', '--name-only', ref]).stdout.split("\n")
   end
 
   private

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -20,10 +20,10 @@ class R10K::Git::StatefulRepository
   # @param remote  [String] The git remote to use for the repo
   # @param basedir [String] The path containing the Git repo
   # @param dirname [String] The directory name of the Git repo
-  def initialize(remote, basedir, dirname)
+  def initialize(remote, basedir, dirname, gitdirname = '.git')
     @remote = remote
     @cache = R10K::Git.cache.generate(@remote)
-    @repo = R10K::Git.thin_repository.new(basedir, dirname, @cache)
+    @repo = R10K::Git.thin_repository.new(basedir, dirname, gitdirname, @cache)
   end
 
   def resolve(ref)
@@ -43,12 +43,12 @@ class R10K::Git::StatefulRepository
     workdir_status = status(ref)
 
     case workdir_status
-    when :absent
+    when :absent, :uninitialized
       logger.debug(_("Cloning %{repo_path} and checking out %{ref}") % {repo_path: @repo.path, ref: ref })
       @repo.clone(@remote, {:ref => sha})
     when :mismatched
       logger.debug(_("Replacing %{repo_path} and checking out %{ref}") % {repo_path: @repo.path, ref: ref })
-      @repo.path.rmtree
+      @repo.git_dir.rmtree
       @repo.clone(@remote, {:ref => sha})
     when :outdated
       logger.debug(_("Updating %{repo_path} to %{ref}") % {repo_path: @repo.path, ref: ref })
@@ -70,7 +70,7 @@ class R10K::Git::StatefulRepository
     if !@repo.exist?
       :absent
     elsif !@repo.git_dir.exist?
-      :mismatched
+      :uninitialized
     elsif !@repo.git_dir.directory?
       :mismatched
     elsif !(@repo.origin == @remote)

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -27,6 +27,10 @@ class R10K::Module::Base
   #   @return [Pathname] The full path of the module
   attr_reader :path
 
+  # @!attribute [r] is_basemod
+  #   @return [Boolean] Whether or not this module is a basemod-type module
+  attr_reader :is_basemod
+
   # There's been some churn over `author` vs `owner` and `full_name` over
   # `title`, so in the short run it's easier to support both and deprecate one
   # later.
@@ -41,6 +45,10 @@ class R10K::Module::Base
     @dirname = dirname
     @args    = args
     @owner, @name = parse_title(@title)
+
+    @is_basemod = !!(args.is_a?(Hash) && args[:is_basemod])
+    @name = "[#{@name}]" if @is_basemod
+
     @path = Pathname.new(File.join(@dirname, @name))
     @environment = environment
   end

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -12,6 +12,10 @@ class R10K::Module::Base
   #   @return [String] The name of the module
   attr_reader :name
 
+  # @!attribute [r] printpath
+  #   @return [String] A print-ready version of the module's path
+  attr_reader :printpath
+
   # @param [r] dirname
   #   @return [String] The name of the directory containing this module
   attr_reader :dirname
@@ -45,12 +49,16 @@ class R10K::Module::Base
     @dirname = dirname
     @args    = args
     @owner, @name = parse_title(@title)
-
-    @is_basemod = !!(args.is_a?(Hash) && args[:is_basemod])
-    @name = "[#{@name}]" if @is_basemod
-
-    @path = Pathname.new(File.join(@dirname, @name))
     @environment = environment
+    @is_basemod = !!(args.is_a?(Hash) && args[:is_basemod])
+
+    if @is_basemod
+      @path = Pathname.new(@dirname)
+      @printpath = "#{@path.to_s} (#{@name})"
+    else
+      @path = Pathname.new(File.join(@dirname, @name))
+      @printpath = @path.to_s
+    end
   end
 
   # @deprecated

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -29,6 +29,10 @@ class R10K::Module::Git < R10K::Module::Base
     parse_options(@args)
 
     @repo = R10K::Git::StatefulRepository.new(@remote, @dirname, @worktreename, @gitdirname)
+
+    if args[:is_basemod]
+      repo.expect_dirty = true
+    end
   end
 
   def version

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -28,7 +28,7 @@ class R10K::Module::Git < R10K::Module::Base
 
     parse_options(@args)
 
-    @repo = R10K::Git::StatefulRepository.new(@remote, @dirname, @name)
+    @repo = R10K::Git::StatefulRepository.new(@remote, @dirname, @name, @gitdirname)
   end
 
   def version
@@ -85,7 +85,7 @@ class R10K::Module::Git < R10K::Module::Base
 
   def parse_options(options)
     ref_opts = [:branch, :tag, :commit, :ref]
-    known_opts = [:git, :default_branch] + ref_opts
+    known_opts = [:git, :gitdirname, :default_branch] + ref_opts
 
     unhandled = options.keys - known_opts
     unless unhandled.empty?
@@ -100,5 +100,7 @@ class R10K::Module::Git < R10K::Module::Base
     if @desired_ref == :control_branch && @environment && @environment.respond_to?(:ref)
       @desired_ref = @environment.ref
     end
+
+    @gitdirname = options[:gitdirname] || '.git'
   end
 end

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -28,7 +28,7 @@ class R10K::Module::Git < R10K::Module::Base
 
     parse_options(@args)
 
-    @repo = R10K::Git::StatefulRepository.new(@remote, @dirname, @name, @gitdirname)
+    @repo = R10K::Git::StatefulRepository.new(@remote, @dirname, @worktreename, @gitdirname)
   end
 
   def version
@@ -85,7 +85,7 @@ class R10K::Module::Git < R10K::Module::Base
 
   def parse_options(options)
     ref_opts = [:branch, :tag, :commit, :ref]
-    known_opts = [:git, :gitdirname, :default_branch] + ref_opts
+    known_opts = [:git, :gitdirname, :default_branch, :is_basemod] + ref_opts
 
     unhandled = options.keys - known_opts
     unless unhandled.empty?
@@ -101,6 +101,7 @@ class R10K::Module::Git < R10K::Module::Base
       @desired_ref = @environment.ref
     end
 
+    @worktreename = options[:is_basemod] ? '.' : @name
     @gitdirname = options[:gitdirname] || '.git'
   end
 end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -59,6 +59,7 @@ class Puppetfile
   end
 
   def load
+    return true if @loaded
     if File.readable? @puppetfile_path
       self.load!
     else

--- a/spec/integration/git/rugged/thin_repository_spec.rb
+++ b/spec/integration/git/rugged/thin_repository_spec.rb
@@ -6,9 +6,11 @@ describe R10K::Git::Rugged::ThinRepository, :if => R10K::Features.available?(:ru
 
   let(:dirname) { 'working-repo' }
 
+  let(:gitdirname) { '.git' }
+
   let(:cacherepo) { R10K::Git::Rugged::Cache.generate(remote) }
 
-  subject { described_class.new(basedir, dirname, cacherepo) }
+  subject { described_class.new(basedir, dirname, gitdirname, cacherepo) }
 
   it_behaves_like "a git thin repository"
 end

--- a/spec/integration/git/shellgit/thin_repository_spec.rb
+++ b/spec/integration/git/shellgit/thin_repository_spec.rb
@@ -6,9 +6,11 @@ describe R10K::Git::ShellGit::ThinRepository do
 
   let(:dirname) { 'working-repo' }
 
+  let(:gitdirname) { '.git' }
+
   let(:cacherepo) { R10K::Git::ShellGit::Cache.generate(remote) }
 
-  subject { described_class.new(basedir, dirname, cacherepo) }
+  subject { described_class.new(basedir, dirname, gitdirname, cacherepo) }
 
   it_behaves_like "a git thin repository"
 end

--- a/spec/integration/git/stateful_repository_spec.rb
+++ b/spec/integration/git/stateful_repository_spec.rb
@@ -6,9 +6,10 @@ describe R10K::Git::StatefulRepository do
   include_context 'Git integration'
 
   let(:dirname) { 'working-repo' }
+  let(:gitdirname) { '.git' }
 
   let(:cacherepo) { R10K::Git.cache.generate(remote) }
-  let(:thinrepo) { R10K::Git.thin_repository.new(basedir, dirname, cacherepo) }
+  let(:thinrepo) { R10K::Git.thin_repository.new(basedir, dirname, gitdirname, cacherepo) }
   let(:ref) { '0.9.x' }
 
   subject { described_class.new(remote, basedir, dirname) }
@@ -21,16 +22,16 @@ describe R10K::Git::StatefulRepository do
     end
 
     describe "when the directory is not a git repository" do
-      it "is mismatched" do
+      it "is uninitialized" do
         thinrepo.path.mkdir
-        expect(subject.status(ref)).to eq :mismatched
+        expect(subject.status(ref)).to eq :uninitialized
       end
     end
 
     describe "when the directory has a .git file" do
       it "is mismatched" do
         thinrepo.path.mkdir
-        File.open("#{thinrepo.path}/.git", "w") {}
+        File.open("#{thinrepo.path}/#{gitdirname}", "w") {}
         expect(subject.status(ref)).to eq :mismatched
       end
     end

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -174,7 +174,7 @@ RSpec.shared_examples "a git working repository" do
 
     context "with force = false" do
       it "should not revert changes in managed files" do
-        subject.checkout(subject.head, {:force => false})
+        expect { subject.checkout(subject.head, {:force => false}).to raise_error(Rugged::CheckoutError) }
         expect(File.read(File.join(subject.path, 'README.markdown')).include?('local modifications!')).to eq true
       end
     end


### PR DESCRIPTION
A basemod is a git repository checked out into the environment's basedir, layered alongside any content defined directly in the control-repo. The intended use case is to reduce the content in a control-repo to ONLY the Puppetfile. More information in CODEMGMT-1152.