### PR TITLE
Quickstart update: Add hieradata path to hiera.yaml

### DIFF
--- a/doc/dynamic-environments/quickstart.mkd
+++ b/doc/dynamic-environments/quickstart.mkd
@@ -61,6 +61,13 @@ Configure the Puppet master by editing `/etc/puppetlabs/puppet/puppet.conf` and 
     server = $_Insert FQDN of Puppet Master Here_$
 ```
 
+Configure hiera lookup to use the environment path by editing '`/etc/puppetlabs/puppet/hiera.yaml` and ensure the datadir has been set: 
+```
+defaults:
+  data_hash: yaml_data        # Use the YAML backend
+  datadir: "/etc/puppetlabs/code/environments/%{::environment}/hieradata"
+```
+
 Restart the Puppet master service.
 
 ```


### PR DESCRIPTION
Current manual is not working with a fresh install, the hiera path needs to be set in hiera.yaml


