### PR TITLE
Add option to specify module to install for puppetfile command

### DIFF
--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -10,7 +10,7 @@ module R10K
 
         def call
           @visit_ok = true
-          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil , @force)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil, @force, @module)
           pf.accept(self)
           @visit_ok
         end
@@ -26,6 +26,7 @@ module R10K
         end
 
         def visit_module(mod)
+          return if mod.name != @module && !@module.nil?
           @force ||= false
           logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
 
@@ -37,7 +38,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :self )
+          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :self, module: :self)
         end
       end
     end

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -29,9 +29,10 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
         @cmd ||= Cri::Command.define do
           name    'install'
           usage   'install'
-          summary 'Install all modules from a Puppetfile'
+          summary 'Install modules from a Puppetfile, by default installs all modules'
           required nil, :moduledir, 'Path to install modules to'
           required nil, :puppetfile, 'Path to puppetfile'
+          required nil, :module, 'Specify a module to install from the puppetfile'
           flag     nil, :force, 'Force locally changed files to be overwritten'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end

--- a/spec/fixtures/unit/action/puppetfile/specify-modules/Puppetfile
+++ b/spec/fixtures/unit/action/puppetfile/specify-modules/Puppetfile
@@ -1,0 +1,2 @@
+mod 'author/foomodule', :latest
+mod 'author/bazmodule', :latest

--- a/spec/unit/action/puppetfile/cri_runner_spec.rb
+++ b/spec/unit/action/puppetfile/cri_runner_spec.rb
@@ -43,5 +43,12 @@ describe R10K::Action::Puppetfile::CriRunner do
         expect(cri_runner.handle_opts(opts)).to include(:puppetfile => '/some/other/nonexistent/modules')
       end
     end
+
+    describe "for the module" do
+      it "sets the option from the cli option if given" do
+        opts = {:module => 'foo/puppet-baz'}
+        expect(cri_runner.handle_opts(opts)).to include(:module => 'foo/puppet-baz')
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds the option --module [modname] to the r10k puppetfile install command
to choose a particular module from the Puppetfile to be installed/updated.

Closes #33