### PR TITLE
(RK-316) Updated docs for private forge support

### DIFF
--- a/doc/faq.mkd
+++ b/doc/faq.mkd
@@ -106,13 +106,18 @@ modulepath = modules:external-modules
 
 Lastly, you can simply move your locally versioned modules to a separate
 directory to avoid conflicting over the `/modules` directory entirely. With this
-example as well you can use the `environment.conf file to tell Puppet which
+example as well you can use the `environment.conf` file to tell Puppet which
 directories contain modules.
 
 ```
 # environment.conf
 modulepath = internal-modules:modules
 ```
+
+#### Does R10K support Local/Private Forge?
+
+Yes. Set the Forge to use _globally_ in `r10k.yaml`. see [Configuration](/doc/dynamic-environments/configuration.mkd#baseurl) for details.
+
 
 #### What does the name mean?
 

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -54,6 +54,8 @@ The `forge` setting specifies which server that Forge based modules are fetched
 from. This is currently a noop and is provided for compatibility with
 librarian-puppet.
 
+R10k supports setting the Forge to use _globally_ in `r10k.yaml`. see [Configuration](/doc/dynamic-environments/configuration.mkd#baseurl) for details.
+
 ### moduledir
 
 The `moduledir` setting specifies where modules from the Puppetfile will be


### PR DESCRIPTION
Added an FAQ entry and updated the docs for Puppetfile to point users to configuration docs
where forge can be set globally. Closed an unclosed backtick.