### PR TITLE
(RK-317) Reorder git source selection

### DIFF
--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -84,7 +84,7 @@ class R10K::Module::Git < R10K::Module::Base
   end
 
   def parse_options(options)
-    ref_opts = [:branch, :tag, :commit, :ref]
+    ref_opts = [:commit, :tag, :branch, :ref]
     known_opts = [:git, :default_branch] + ref_opts
 
     unhandled = options.keys - known_opts


### PR DESCRIPTION
This changes the order in which the source reference is chosen - prioritizing them in the descending order of accuracy instead.