### PR TITLE
(RK-319) Cleanup /tmp folders for forge modules

### DIFF
--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -28,6 +28,10 @@ module R10K
       #   @return [Pathname] Where the module tarball will be downloaded to.
       attr_accessor :download_path
 
+      # @!attribute [rw] download_root
+      #   @return [Pathname] Directory where the module tarball will be downloaded to.
+      attr_accessor :download_root
+
       # @!attribute [rw] tarball_cache_path
       #   @return [Pathname] Where the module tarball will be cached to.
       attr_accessor :tarball_cache_path
@@ -44,6 +48,10 @@ module R10K
       #   @return [Pathname] Where the module will be unpacked to.
       attr_accessor :unpack_path
 
+      # @!attribute [rw] unpack_root
+      #   @return [Pathname] Directory where the module will be unpacked to.
+      attr_accessor :unpack_root
+
       # @param full_name [String] The hyphen separated name of the module
       # @param version [String] The version of the module
       def initialize(full_name, version)
@@ -58,14 +66,16 @@ module R10K
         @forge_release = PuppetForge::V3::Release.new({ :name => @full_name, :version => @version, :slug => "#{@full_name}-#{@version}" })
 
         tarball_name = @forge_release.slug + '.tar.gz'
-        @download_path = Pathname.new(Dir.mktmpdir) + (tarball_name)
+        @download_root = Pathname.new(Dir.mktmpdir)
+        @download_path = @download_root + (tarball_name)
         @tarball_cache_root = Pathname.new(settings[:cache_root]) + (@forge_release.slug + "/tarball/")
         @tarball_cache_path = @tarball_cache_root + tarball_name
 
         md5_filename = @forge_release.slug + '.md5'
         @md5_file_path = @tarball_cache_root + md5_filename
 
-        @unpack_path   = Pathname.new(Dir.mktmpdir) + @forge_release.slug
+        @unpack_root   = Pathname.new(Dir.mktmpdir)
+        @unpack_path   = @unpack_root + @forge_release.slug
       end
 
       # Download, unpack, and install this module release to the target directory.
@@ -174,21 +184,21 @@ module R10K
 
       # Remove all files created while downloading and unpacking the module.
       def cleanup
-        cleanup_unpack_path
-        cleanup_download_path
+        cleanup_unpack_root
+        cleanup_download_root
       end
 
       # Remove the temporary directory used for unpacking the module.
-      def cleanup_unpack_path
-        if unpack_path.exist?
-          unpack_path.rmtree
+      def cleanup_unpack_root
+        if unpack_root.exist?
+          unpack_root.rmtree
         end
       end
 
       # Remove the downloaded module release.
-      def cleanup_download_path
-        if download_path.exist?
-          download_path.delete
+      def cleanup_download_root
+        if download_root.exist?
+          download_root.rmtree
         end
       end
 

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -10,9 +10,11 @@ describe R10K::Forge::ModuleRelease do
   let(:md5_digest_class) { Digest::MD5 }
 
   let(:download_path) { instance_double('Pathname') }
+  let(:download_root) { instance_double('Pathname') }
   let(:tarball_cache_path) { instance_double('Pathname') }
   let(:tarball_cache_root) { instance_double('Pathname') }
   let(:unpack_path) { instance_double('Pathname') }
+  let(:unpack_root) { instance_double('Pathname') }
   let(:target_dir) { instance_double('Pathname') }
   let(:md5_file_path) { instance_double('Pathname') }
 
@@ -25,9 +27,11 @@ describe R10K::Forge::ModuleRelease do
 
   before do
     subject.download_path = download_path
+    subject.download_root = download_root
     subject.tarball_cache_path = tarball_cache_path
     subject.tarball_cache_root = tarball_cache_root
     subject.unpack_path = unpack_path
+    subject.unpack_root = unpack_root
     subject.md5_file_path = md5_file_path
   end
 
@@ -123,37 +127,37 @@ describe R10K::Forge::ModuleRelease do
 
   describe "#cleanup" do
     it "cleans up the unpack paths" do
-      expect(subject).to receive(:cleanup_unpack_path)
-      expect(subject).to receive(:cleanup_download_path)
+      expect(subject).to receive(:cleanup_unpack_root)
+      expect(subject).to receive(:cleanup_download_root)
       subject.cleanup
     end
   end
 
-  describe "#cleanup_unpack_path" do
-    it "ignores the unpack_path if it doesn't exist" do
-      expect(unpack_path).to receive(:exist?).and_return false
-      expect(unpack_path).to_not receive(:rmtree)
-      subject.cleanup_unpack_path
+  describe "#cleanup_unpack_root" do
+    it "ignores the unpack_root if it doesn't exist" do
+      expect(unpack_root).to receive(:exist?).and_return false
+      expect(unpack_root).to_not receive(:rmtree)
+      subject.cleanup_unpack_root
     end
 
-    it "removes the unpack_path if it exists" do
-      expect(unpack_path).to receive(:exist?).and_return true
-      expect(unpack_path).to receive(:rmtree)
-      subject.cleanup_unpack_path
+    it "removes the unpack_root if it exists" do
+      expect(unpack_root).to receive(:exist?).and_return true
+      expect(unpack_root).to receive(:rmtree)
+      subject.cleanup_unpack_root
     end
   end
 
-  describe "#cleanup_download_path" do
-    it "ignores the download_path if it doesn't exist" do
-      expect(download_path).to receive(:exist?).and_return false
-      expect(download_path).to_not receive(:delete)
-      subject.cleanup_download_path
+  describe "#cleanup_download_root" do
+    it "ignores the download_root if it doesn't exist" do
+      expect(download_root).to receive(:exist?).and_return false
+      expect(download_root).to_not receive(:rmtree)
+      subject.cleanup_download_root
     end
 
-    it "removes the download_path if it exists" do
-      expect(download_path).to receive(:exist?).and_return true
-      expect(download_path).to receive(:delete)
-      subject.cleanup_download_path
+    it "removes the download_root if it exists" do
+      expect(download_root).to receive(:exist?).and_return true
+      expect(download_root).to receive(:rmtree)
+      subject.cleanup_download_root
     end
   end
 


### PR DESCRIPTION
This PR fixed a bug where temporary folders in `/tmp` were left around after downloading and unpacking forge modules. It will ensure that the temporary folders and files in `/tmp` are removed. 