### PR TITLE
(RK-321) Use git protocol to clone

### DIFF
--- a/integration/pre-suite/30_test_utils.rb
+++ b/integration/pre-suite/30_test_utils.rb
@@ -11,7 +11,7 @@ SCRIPT
 
 step 'Install "filebucket" File Generator'
 create_remote_file(master, filebucket_script_path, filebucket_script)
-on(master, "git clone https://github.com/cowofevil/filebucket.git #{filebucket_path}")
+on(master, "git clone git://github.com/cowofevil/filebucket.git #{filebucket_path}")
 
 on(master, "chmod 755 #{filebucket_script_path}")
 on(master, "chmod 755 #{filebucket_path}/filebucketapp.py")


### PR DESCRIPTION
In order to avoid TLS issues, this commit updates the filebucket test
util to clone using the git protocol instead of HTTPS.