### PR TITLE
(maint) Respect env vars for test gem versions

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -1,6 +1,16 @@
 source ENV['GEM_SOURCE'] || 'https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
 
-gem 'beaker', '~> 2.7'
-gem 'beaker-abs', '~> 0.2'
+def location_for(place, fake_version = nil)
+  if place =~ /^(git:[^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.33')
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
 gem 'rototiller', '= 0.1.0'
-gem 'beaker-hostgenerator', '~> 0.7.0'


### PR DESCRIPTION
This commit updates the gems to the minimum versions necessary
for testing on Ubuntu 18.04 Bionic, while also updating the gemfile to
respect the evironment variables set by Jenkins to control those gem
versions.