### PR TITLE
(RK-321) Pull in beaker-pe gem

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -10,7 +10,8 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.33')
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.33')
+gem 'beaker-pe', '~> 1.22'
+gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1.1')
+gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.4')
 gem 'rototiller', '= 0.1.0'


### PR DESCRIPTION
Updating to the latest version of beaker means that we now also need to
pull in beaker-pe, due to some method refactoring.