### PR TITLE
(RK-321) More python and git fixes

### DIFF
--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
@@ -15,7 +15,7 @@ r10k_fqp = get_r10k_fqp(master)
 
 #File
 puppet_file = <<-PUPPETFILE
-mod 'broken', :git => 'https://github.com/puppetlabs/puppetlabs-broken'
+mod 'broken', :git => 'git://github.com/puppetlabs/puppetlabs-broken'
 PUPPETFILE
 
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
@@ -20,8 +20,15 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 tmpfs_path = '/mnt/tmpfs'
 
+if on(master, 'which python', :acceptable_exit_codes => [0, 1]).exit_code == 1
+    python_bin = 'python3'
+else
+    python_bin = 'python'
+end
+
 file_bucket_path = '/opt/filebucket'
 file_bucket_command_path = File.join(file_bucket_path, 'filebucketapp.py')
+file_bucket_command = "#{python_bin} #{file_bucket_command_path}"
 pattern_file_path = File.join(file_bucket_path, 'psuedo_random_128k.pat')
 
 test_files_path = File.join(git_environments_path, 'test_files')
@@ -66,7 +73,7 @@ on(master, "mount -osize=10m tmpfs #{tmpfs_path} -t tmpfs")
 step 'Create Large Binary File'
 create_remote_file(master, File.join(git_environments_path, '.gitattributes'), '*.file binary')
 on(master, "mkdir -p #{test_files_path}")
-on(master, "#{file_bucket_command_path} -s 11 -f #{test_files_path}/test.file -d #{pattern_file_path}")
+on(master, "#{file_bucket_command} -s 11 -f #{test_files_path}/test.file -d #{pattern_file_path}")
 
 step 'Push Changes'
 git_add_commit_push(master, 'production', 'Add large file.', git_environments_path)


### PR DESCRIPTION
These apparently slipped through the cracks from
02555695b918e6e512ac27dae34095d571903bc8 and
728620d0ac05a03820d6b60ad8bb3f73a10f7546.