### PR TITLE
(RK-321) Fix the last bad git clone URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Gemfile.lock
 bundle
 coverage
 locales/r10k.pot
+integration/log
+integration/junit
+integration/configs

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module_ref.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module_ref.rb
@@ -12,7 +12,7 @@ r10k_fqp = get_r10k_fqp(master)
 #File
 puppet_file = <<-PUPPETFILE
 mod 'broken',
-  :git => 'https://github.com/puppetlabs/puppetlabs-motd',
+  :git => 'git://github.com/puppetlabs/puppetlabs-motd',
   :ref => 'does_not_exist'
 PUPPETFILE
 


### PR DESCRIPTION
This commit also updates the gitignore to include files generated by
running beaker tests.