### PR TITLE
Add some context to errors and warnings

### DIFF
--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -92,13 +92,17 @@ class R10K::Module::Base
 
   private
 
+  def context
+    @environment.nil? ? dirname : @environment.dirname
+  end
+
   def parse_title(title)
     if (match = title.match(/\A(\w+)\Z/))
       [nil, match[1]]
     elsif (match = title.match(/\A(\w+)[-\/](\w+)\Z/))
       [match[1], match[2]]
     else
-      raise ArgumentError, _("Module name (%{title}) must match either 'modulename' or 'owner/modulename'") % {title: title}
+      raise ArgumentError, _("%{context}: Module name (%{title}) must match either 'modulename' or 'owner/modulename'") % {context: context, title: title}
     end
   end
 end

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -67,7 +67,7 @@ class R10K::Module::Forge < R10K::Module::Base
       begin
         @expected_version = @v3_module.current_release.version
       rescue Faraday::ResourceNotFound => e
-        raise PuppetForge::ReleaseNotFound, _("The module %{title} does not exist on %{url}.") % {title: @title, url: PuppetForge::V3::Release.conn.url_prefix}, e.backtrace
+        raise PuppetForge::ReleaseNotFound, _("%{context}: The module %{title} does not exist on %{url}.") % {context: context, title: @title, url: PuppetForge::V3::Release.conn.url_prefix}, e.backtrace
       end
     end
     @expected_version
@@ -92,7 +92,7 @@ class R10K::Module::Forge < R10K::Module::Base
     begin
       @v3_module.fetch && @v3_module.has_attribute?('deprecated_at') && !@v3_module.deprecated_at.nil?
     rescue Faraday::ResourceNotFound => e
-      raise PuppetForge::ReleaseNotFound, _("The module %{title} does not exist on %{url}.") % {title: @title, url: PuppetForge::V3::Release.conn.url_prefix}, e.backtrace
+      raise PuppetForge::ReleaseNotFound, _("%{context}: The module %{title} does not exist on %{url}.") % {context: context, title: @title, url: PuppetForge::V3::Release.conn.url_prefix}, e.backtrace
     end
   end
 
@@ -138,7 +138,7 @@ class R10K::Module::Forge < R10K::Module::Base
 
   def install
     if deprecated?
-      logger.warn "Puppet Forge module '#{@v3_module.slug}' has been deprecated, visit https://forge.puppet.com/#{@v3_module.slug.tr('-','/')} for more information."
+      logger.warn "#{context}: Puppet Forge module '#{@v3_module.slug}' has been deprecated, visit https://forge.puppet.com/#{@v3_module.slug.tr('-','/')} for more information."
     end
 
     parent_path = @path.parent
@@ -167,7 +167,7 @@ class R10K::Module::Forge < R10K::Module::Base
     if (match = title.match(/\A(\w+)[-\/](\w+)\Z/))
       [match[1], match[2]]
     else
-      raise ArgumentError, _("Forge module names must match 'owner/modulename'")
+      raise ArgumentError, _("%{context}: Forge module names must match 'owner/modulename'" % {context: context })
     end
   end
 end

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -60,8 +60,8 @@ class R10K::Module::Git < R10K::Module::Base
     elsif default && @repo.resolve(default)
       return default
     else
-      msg = ["Unable to manage Puppetfile content '%{name}':"]
-      vars = {name: @name}
+      msg = ["%{context}: Unable to manage Puppetfile content '%{name}':"]
+      vars = {context: context, name: @name}
 
       if desired == :control_branch
         msg << "Could not resolve control repo branch"
@@ -89,7 +89,7 @@ class R10K::Module::Git < R10K::Module::Base
 
     unhandled = options.keys - known_opts
     unless unhandled.empty?
-      raise ArgumentError, _("Unhandled options %{unhandled} specified for %{class}") % {unhandled: unhandled, class: self.class}
+      raise ArgumentError, _("%{context}: Unhandled options %{unhandled} specified for %{class}") % {context: context, unhandled: unhandled, class: self.class}
     end
 
     @remote = options[:git]

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -31,6 +31,6 @@ class R10K::Module::Local < R10K::Module::Base
   end
 
   def sync(opts={})
-    logger.debug1 _("Module %{title} is a local module, always indicating synced.") % {title: title}
+    logger.debug1 _("%{context}: Module %{title} is a local module, always indicating synced.") % {context: context, title: title}
   end
 end

--- a/lib/r10k/module/metadata_file.rb
+++ b/lib/r10k/module/metadata_file.rb
@@ -22,7 +22,7 @@ class R10K::Module::MetadataFile
           metadata = PuppetForge::Metadata.new
           metadata.update(JSON.load(f), false)
         rescue JSON::ParserError => e
-          exception = R10K::Error.wrap(e, _("Could not read metadata.json"))
+          exception = R10K::Error.wrap(e, _("Could not parse metadata file %{path}" % { path: @metadata_file_path }))
           raise exception
         end
       end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -59,7 +59,7 @@ class Puppetfile
     if File.readable? @puppetfile_path
       self.load!
     else
-      logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile_path.inspect}
+      logger.debug _("%{dirname}: Puppetfile %{path} missing or unreadable") % {dirname: dirname, path: @puppetfile_path.inspect}
     end
   end
 
@@ -69,7 +69,7 @@ class Puppetfile
     validate_no_duplicate_names(@modules)
     @loaded = true
   rescue SyntaxError, LoadError, ArgumentError => e
-    raise R10K::Error.wrap(e, _("Failed to evaluate %{path}") % {path: @puppetfile_path})
+    raise R10K::Error.wrap(e, _("%{dirname}: Failed to evaluate %{path}") % {dirname: dirname, path: @puppetfile_path})
   end
 
   # @param [String] forge
@@ -83,8 +83,8 @@ class Puppetfile
             .group_by { |mod| mod.name }
             .select { |_, v| v.size > 1 }.map(&:first)
     unless dupes.empty?
-      logger.warn _('Puppetfiles should not contain duplicate module names and will result in an error in r10k v3.x.')
-      logger.warn _("Remove the duplicates of the following modules: %{dupes}" % {dupes: dupes.join(" ")})
+      logger.warn _("%{dirname}: Puppetfiles should not contain duplicate module names and will result in an error in r10k v3.x." % {dirname: dirname})
+      logger.warn _("%{dirname}: Remove the duplicates of the following modules: %{dupes}" % {dirname: dirname, dupes: dupes.join(" ")})
     end
   end
 
@@ -176,10 +176,14 @@ class Puppetfile
     real_basedir = Pathname.new(basedir).cleanpath.to_s
 
     unless /^#{Regexp.escape(real_basedir)}.*/ =~ path
-      raise R10K::Error.new("Puppetfile cannot manage content '#{modname}' outside of containing environment: #{path} is not within #{real_basedir}")
+      raise R10K::Error.new("#{dirname}: Puppetfile cannot manage content '#{modname}' outside of containing environment: #{path} is not within #{real_basedir}")
     end
 
     true
+  end
+
+  def dirname
+    File.basename(@basedir)
   end
 
   class DSL

--- a/spec/unit/module/base_spec.rb
+++ b/spec/unit/module/base_spec.rb
@@ -24,7 +24,7 @@ describe R10K::Module::Base do
     it "raises an error when the title is not correctly formatted" do
       expect {
         described_class.new('branan!eight_hundred', '/moduledir', [])
-      }.to raise_error(ArgumentError, "Module name (branan!eight_hundred) must match either 'modulename' or 'owner/modulename'")
+      }.to raise_error(ArgumentError, "/moduledir: Module name (branan!eight_hundred) must match either 'modulename' or 'owner/modulename'")
     end
   end
 

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -191,7 +191,7 @@ describe R10K::Module::Git do
       end
 
       context "specifying branch to :control_branch" do
-        let(:mock_env) { instance_double("R10K::Environment::Git", ref: 'env_branch') }
+        let(:mock_env) { instance_double("R10K::Environment::Git", ref: 'env_branch', dirname: 'env_name') }
 
         context "when module belongs to an environment and matching branch is resolvable" do
           before(:each) do

--- a/spec/unit/module/metadata_file_spec.rb
+++ b/spec/unit/module/metadata_file_spec.rb
@@ -61,7 +61,7 @@ describe R10K::Module::MetadataFile do
 
     it "raises an error" do
       a_metadata_file = R10K::Module::MetadataFile.new(fixture_path)
-      expect {a_metadata_file.read}.to raise_error(R10K::Error, "Could not read metadata.json")
+      expect {a_metadata_file.read}.to raise_error(R10K::Error, "Could not parse metadata file #{fixture_path}")
     end
   end
 

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -129,9 +129,9 @@ describe R10K::Puppetfile do
   end
 
   describe "evaluating a Puppetfile" do
-    def expect_wrapped_error(orig, pf_path, wrapped_error)
+    def expect_wrapped_error(orig, pf_path, wrapped_error, pf_dirname)
       expect(orig).to be_a_kind_of(R10K::Error)
-      expect(orig.message).to eq("Failed to evaluate #{pf_path}")
+      expect(orig.message).to eq("#{pf_dirname}: Failed to evaluate #{pf_path}")
       expect(orig.original).to be_a_kind_of(wrapped_error)
     end
 
@@ -142,7 +142,7 @@ describe R10K::Puppetfile do
       expect {
         subject.load!
       }.to raise_error do |e|
-        expect_wrapped_error(e, pf_path, SyntaxError)
+        expect_wrapped_error(e, pf_path, SyntaxError, File.basename(path))
       end
     end
 
@@ -153,7 +153,7 @@ describe R10K::Puppetfile do
       expect {
         subject.load!
       }.to raise_error do |e|
-        expect_wrapped_error(e, pf_path, LoadError)
+        expect_wrapped_error(e, pf_path, LoadError, File.basename(path))
       end
     end
 
@@ -164,7 +164,7 @@ describe R10K::Puppetfile do
       expect {
         subject.load!
       }.to raise_error do |e|
-        expect_wrapped_error(e, pf_path, ArgumentError)
+        expect_wrapped_error(e, pf_path, ArgumentError, File.basename(path))
       end
     end
 


### PR DESCRIPTION
These changes prefix module and Puppetfile warning and error messages with a bit of context to aid in isolating which environment triggered the messages. If multiple environments are being managed, it can be difficult to determine which environment triggered the messages during a full `r10k deploy environment --puppetfile` run.