### PR TITLE
Support $environment variable in postrun

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -183,6 +183,9 @@ postrun: ['/usr/bin/curl', '-F', 'deploy=done', 'http://my-app.site/endpoint']
 
 The postrun setting can only be set once.
 
+Occurrences of the string `$modifiedenvs` in the postrun command will be
+replaced with the current environment(s) being deployed.
+
 ### sources
 
 The `sources` setting specifies what repositories should be used for creating

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -64,6 +64,11 @@ module R10K
           end
         ensure
           if (postcmd = @settings[:postrun])
+            if postcmd.grep('$modifiedenvs').any?
+              envs = deployment.environments.map { |e| e.name }
+              envs.reject! { |e| !@argv.include?(e) } if @argv.any?
+              postcmd = postcmd.map { |e| e.gsub('$modifiedenvs', envs.join(' ')) }
+            end
             subproc = R10K::Util::Subprocess.new(postcmd)
             subproc.logger = logger
             subproc.execute

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -92,6 +92,61 @@ describe R10K::Action::Deploy::Environment do
           subject.call
         end
       end
+
+      context "supports environments" do
+        context "when one environment" do
+          let(:settings) { { postrun: ["/generate/types/wrapper", "$modifiedenvs"] } }
+          let(:deployment) { R10K::Deployment.new(mock_config.merge(settings)) }
+
+          before do
+            expect(R10K::Deployment).to receive(:new).and_return(deployment)
+          end
+
+          subject do
+            described_class.new( {config: "/some/nonexistent/path" },
+                                 %w[first],
+                                 settings                             )
+          end
+
+          it "properly substitutes the environment" do
+            mock_subprocess = double
+            allow(mock_subprocess).to receive(:logger=)
+            expect(mock_subprocess).to receive(:execute)
+
+            expect(R10K::Util::Subprocess).to receive(:new).
+              with(["/generate/types/wrapper", "first"]).
+              and_return(mock_subprocess)
+
+            subject.call
+          end
+        end
+        context "when many environments" do
+          let(:settings) { { postrun: ["/generate/types/wrapper", "$modifiedenvs"] } }
+          let(:deployment) { R10K::Deployment.new(mock_config.merge(settings)) }
+
+          before do
+            expect(R10K::Deployment).to receive(:new).and_return(deployment)
+          end
+
+          subject do
+            described_class.new( {config: "/some/nonexistent/path" },
+                                 [],
+                                 settings                             )
+          end
+
+          it "properly substitutes the environment" do
+            mock_subprocess = double
+            allow(mock_subprocess).to receive(:logger=)
+            expect(mock_subprocess).to receive(:execute)
+
+            expect(R10K::Util::Subprocess).to receive(:new).
+              with(["/generate/types/wrapper", "first second third"]).
+              and_return(mock_subprocess)
+
+            subject.call
+          end
+        end
+      end
     end
 
     describe "purge_levels" do

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -65,6 +65,35 @@ describe R10K::Action::Deploy::Environment do
       end
     end
 
+    describe "postrun" do
+      context "basic postrun hook" do
+        let(:settings) { { postrun: ["/path/to/executable", "arg1", "arg2"] } }
+        let(:deployment) { R10K::Deployment.new(mock_config.merge(settings)) }
+
+        before do
+          expect(R10K::Deployment).to receive(:new).and_return(deployment)
+        end
+
+        subject do
+          described_class.new( {config: "/some/nonexistent/path" },
+                               %w[first],
+                               settings                             )
+        end
+
+        it "is passed to Subprocess" do
+          mock_subprocess = double
+          allow(mock_subprocess).to receive(:logger=)
+          expect(mock_subprocess).to receive(:execute)
+
+          expect(R10K::Util::Subprocess).to receive(:new).
+            with(["/path/to/executable", "arg1", "arg2"]).
+            and_return(mock_subprocess)
+
+          subject.call
+        end
+      end
+    end
+
     describe "purge_levels" do
       let(:settings) { { deploy: { purge_levels: purge_levels } } }
 


### PR DESCRIPTION
This implements https://github.com/puppetlabs/r10k/issues/697, allowing to pass `$environment` as a `postrun` hook to run e.g. `puppet generate types --environment $environment`.