### PR TITLE
(maint) Use semver pre-release version

### DIFF
--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -1,3 +1,3 @@
 module R10K
-  VERSION = '3.0.0.dev'
+  VERSION = '3.0.0-dev'
 end


### PR DESCRIPTION
This updates R10K's version to use a dash between the release version
and the pre-release identifier, more closely following semver (see
https://semver.org/#spec-item-9).

This is required for newer internal automation.