### PR TITLE
(maint) Don't tag 2.5.x containers with 'latest'

### DIFF
--- a/docker/ci/build
+++ b/docker/ci/build
@@ -16,7 +16,7 @@ function build_and_test_image() {
   : ===
   : === build and test $container_name
   : ===
-  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version"
+  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version" --no-latest
   bundle exec puppet-docker spec "$container_name"
 }
 
@@ -26,7 +26,7 @@ function push_image() {
   : ===
   : === push $container_name
   : ===
-  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version"
+  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version" --no-latest
 }
 
 : ===

--- a/docker/ci/build
+++ b/docker/ci/build
@@ -16,7 +16,7 @@ function build_and_test_image() {
   : ===
   : === build and test $container_name
   : ===
-  bundle exec puppet-docker build "$container_name" --no-cache --repository pcr-internal.puppet.net/release-engineering --version "$version"
+  bundle exec puppet-docker build "$container_name" --no-cache --repository puppet --version "$version"
   bundle exec puppet-docker spec "$container_name"
 }
 
@@ -26,7 +26,7 @@ function push_image() {
   : ===
   : === push $container_name
   : ===
-  bundle exec puppet-docker push "$container_name" --repository pcr-internal.puppet.net/release-engineering --version "$container_version"
+  bundle exec puppet-docker push "$container_name" --repository puppet --version "$container_version"
 }
 
 : ===


### PR DESCRIPTION
With #840, we're getting ready to build 2.6.x containers. Those should be tagged with latest instead of the 2.5.x ones.