### PR TITLE
Always require cri as a whole

### DIFF
--- a/lib/r10k/cli/ext/logging.rb
+++ b/lib/r10k/cli/ext/logging.rb
@@ -1,4 +1,4 @@
-require 'cri/command_dsl'
+require 'cri'
 
 module Cri
   class CommandDSL


### PR DESCRIPTION
Fixes #853.

Requiring sub-files of Cri isn’t supported; cri/command_dsl for example assumes that other file(s) that define Cri::Error are already loaded.

I’m not quite sure whether it’s possible to write a (reasonable) regression test for this change.