### PR TITLE
Add option to install modules concurrently

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -73,6 +73,13 @@ proxy: 'http://user:password@proxy.example.com:3128'
 
 The proxy server being used will be logged at the "debug" level when r10k runs.
 
+### pool_size
+
+The pool_size setting is a number to determine how many threads should be spawn
+while updating modules. The default value is 1, which means the default behaviour
+is to update modules in a serial manner. Increasing this number should bring
+some performance gains.
+
 ### git
 
 The 'git' setting is a hash that contains Git specific settings.

--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -34,6 +34,7 @@ module R10K
 
         with_setting(:cachedir) { |value| R10K::Git::Cache.settings[:cache_root] = value }
         with_setting(:cachedir) { |value| R10K::Forge::ModuleRelease.settings[:cache_root] = value }
+        with_setting(:pool_size) { |value| R10K::Puppetfile.settings[:pool_size] = value }
 
         with_setting(:git) { |value| GitInitializer.new(value).call }
         with_setting(:forge) { |value| ForgeInitializer.new(value).call }

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -194,7 +194,8 @@ class Puppetfile
     Thread.new do
       begin
         while mod = mods_queue.pop(true) do mod.accept(visitor) end
-      rescue ThreadError
+      rescue ThreadError => e
+        logger.error _("Thread error during concurrent module deploy: %{message}") % {message: e.message}
         Thread.exit
       end
     end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -1,3 +1,4 @@
+require 'thread'
 require 'pathname'
 require 'r10k/module'
 require 'r10k/util/purgeable'
@@ -6,6 +7,10 @@ require 'r10k/errors'
 module R10K
 class Puppetfile
   # Defines the data members of a Puppetfile
+
+  include R10K::Settings::Mixin
+
+  def_setting_attr :pool_size, 1
 
   include R10K::Logging
 
@@ -152,6 +157,17 @@ class Puppetfile
   end
 
   def accept(visitor)
+    pool_size = self.settings[:pool_size]
+    if pool_size > 1
+      concurrent_accept(visitor, pool_size)
+    else
+      serial_accept(visitor)
+    end
+  end
+
+  private
+
+  def serial_accept(visitor)
     visitor.visit(:puppetfile, self) do
       modules.each do |mod|
         mod.accept(visitor)
@@ -159,7 +175,30 @@ class Puppetfile
     end
   end
 
-  private
+  def concurrent_accept(visitor, pool_size)
+    logger.debug _("Updating modules with %{pool_size} threads") % {pool_size: pool_size}
+    mods_queue = modules_queue(visitor)
+    thread_pool = pool_size.times.map { visitor_thread(visitor, mods_queue) }
+    thread_pool.each(&:join)
+  end
+
+  def modules_queue(visitor)
+    Queue.new.tap do |queue|
+      visitor.visit(:puppetfile, self) do
+        modules.each { |mod| queue << mod }
+      end
+    end
+  end
+
+  def visitor_thread(visitor, mods_queue)
+    Thread.new do
+      begin
+        while mod = mods_queue.pop(true) do mod.accept(visitor) end
+      rescue ThreadError
+        Thread.exit
+      end
+    end
+  end
 
   def puppetfile_contents
     File.read(@puppetfile_path)

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -158,6 +158,19 @@ module R10K
           end
         }),
 
+        Definition.new(:pool_size, {
+          :desc => "The amount of threads used to concurrently install modules. The default value is 1: install one module at a time.",
+          :default => 1,
+          :validate => lambda do |value|
+            if !value.is_a?(Integer)
+              raise ArgumentError, "The pool_size setting should be an integer, not a #{value.class}"
+            end
+            if !(value > 0)
+              raise ArgumentError, "The pool_size setting should be greater than zero."
+            end
+          end
+        }),
+
         URIDefinition.new(:proxy, {
           :desc => "Proxy to use for all r10k operations which occur over HTTP(S).",
           :default => lambda {

--- a/lib/r10k/settings/container.rb
+++ b/lib/r10k/settings/container.rb
@@ -32,7 +32,11 @@ class R10K::Settings::Container
     if @settings[key]
       @settings[key]
     elsif @parent && (pkey = @parent[key])
-      @settings[key] = pkey.dup
+      begin
+        @settings[key] = pkey.dup
+      rescue TypeError
+        @settings[key] = pkey
+      end
       @settings[key]
     end
   end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -165,6 +165,41 @@ describe R10K::Settings do
       end
     end
 
+    describe "pool_size" do
+      it "accepts integers greater than zero" do
+        output = subject.evaluate("pool_size" => 5)
+        expect(output[:pool_size]).to eq 5
+      end
+
+      it "rejects non integer values" do
+        expect {
+          subject.evaluate("pool_size" => "5")
+        }.to raise_error do |err|
+          expect(err.errors.size).to eq 1
+          expect(err.errors[:pool_size]).to be_a_kind_of(ArgumentError)
+          expect(err.errors[:pool_size].message).to match(/The pool_size setting should be an integer/)
+        end
+      end
+
+      it "rejects integers smaller than one" do
+        expect {
+          subject.evaluate("pool_size" => 0)
+        }.to raise_error do |err|
+          expect(err.errors.size).to eq 1
+          expect(err.errors[:pool_size]).to be_a_kind_of(ArgumentError)
+          expect(err.errors[:pool_size].message).to match(/The pool_size setting should be greater than zero/)
+        end
+
+        expect {
+          subject.evaluate("pool_size" => -3)
+        }.to raise_error do |err|
+          expect(err.errors.size).to eq 1
+          expect(err.errors[:pool_size]).to be_a_kind_of(ArgumentError)
+          expect(err.errors[:pool_size].message).to match(/The pool_size setting should be greater than zero/)
+        end
+      end
+    end
+
     describe "proxy" do
       it "accepts valid URIs" do
         output = subject.evaluate("proxy" => "http://proxy.tessier-ashpool.freeside:3128")


### PR DESCRIPTION
This pull request add the option to install/update modules concurrently.

It adds a `pool_size` setting with a default value equals to `1`:

```yaml
# /etc/puppetlabs/r10k/r10k.yaml
pool_size: 5
```

When the `Puppefile#accept` method is called, if the `pool_size` value is 1, the regular sequential install/update process starts. If the `pool_size` is greater than 1 a thread pool with `pool_size` threads is created to fetch the modules. A `pool_size` with value less or equal to zero is not allowed.

Since the default setting value is 1 this feature is _opt-in_.

The install/update process is heavily I/O based so there are some visible performance gains in the total (wall) time to install modules declared in a Puppetfile.

We've been using this patch for almost 5 months in production with no reported problems.

## Benchmarks

Puppetfile with 9 modules

|Flavor|Time|Comparison|
|--------|-------|----------------|
|Vanilla|69.846 s|base|
|pool_size=5|19.985  s|-71.39%|

Puppetfile with 608 modules

|Flavor|Time|Comparison|
|--------|-------|----------------|
|Vanilla|8.705 m|base|
|pool_size=5|2.056  m|-76.38%|
|pool_size=10|1.901  m|-78.16%|





