### PR TITLE
(RK-324) Improve reliability on Ubuntu Bionic

### DIFF
--- a/lib/r10k/util/subprocess/runner/posix.rb
+++ b/lib/r10k/util/subprocess/runner/posix.rb
@@ -28,15 +28,15 @@ class R10K::Util::Subprocess::Runner::POSIX < R10K::Util::Subprocess::Runner
 
     @stdout_pump = R10K::Util::Subprocess::Runner::Pump.new(@stdout_r)
     @stderr_pump = R10K::Util::Subprocess::Runner::Pump.new(@stderr_r)
-    @stdout_pump.start
-    @stderr_pump.start
-
     pid = fork do
       exec_r.close
       execute_child(exec_w)
     end
 
     exec_w.close
+    @stdout_pump.start
+    @stderr_pump.start
+
     execute_parent(exec_r, pid)
 
     @result


### PR DESCRIPTION
Previously on Bionic we would see issues where the Ruby interpreter
would die with an "ASYNC BUG EPIPE" message and no meaningful
stacktrace.

When attempting to strace, when registering listeners for various
syscalls with sysdig, or when attaching to a debug build of Ruby with
gdb this issue no longer presents itself.

This seems to happen when forking during the while loop of
R10K::Util::Subprocess::Pump#pump though smaller reproducers that only
run the while loop and fork seem to rarely ever trigger this issue,
there maybe be some requirement on calling IO#reopen as we do on STDOUT
and STDERR.

This commit moves starting the pipe output pumping until after the
subprocess fork which seems to avoid the problematic code.