### PR TITLE
Add support for running `puppet generate types`

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -297,6 +297,26 @@ deploy:
   write_lock: "Deploying code is disallowed until the next maintenance window (2038-01-19)"
 ```
 
+#### generate\_types
+
+The `generate_types` setting controls whether r10k should update generated types
+after a successful environment update. See [Environment isolation](https://puppet.com/docs/puppet/latest/environment\_isolation.html)
+for more information on generated types. Defaults to false.
+
+```yaml
+deploy:
+  generate_types: true
+```
+
+#### puppet\_path
+
+The path to the puppet executable used for generating types. Defaults to `/opt/puppetlabs/bin/puppet`.
+
+```yaml
+deploy:
+  puppet_path: '/usr/local/bin/puppet'
+```
+
 Source options
 --------------
 

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -62,13 +62,17 @@ module R10K
           if @argv.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
             mod.sync(force: @force)
+            if mod.environment && @generate_types
+              logger.debug("Generating puppet types for environment '#{mod.environment.dirname}'...")
+              mod.environment.generate_types!
+            end
           else
             logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @argv.inspect, mod_name: mod.name})
           end
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true, :'no-force' => :self)
+          super.merge(environment: true, 'no-force': :self, 'generate-types': :self, 'puppet-path': :self)
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -23,6 +23,14 @@ module R10K::CLI
 
         required nil, :cachedir, 'Specify a cachedir, overriding the value in config'
         flag nil, :'no-force', 'Prevent the overwriting of local module modifications'
+        flag nil, :'generate-types', 'Run `puppet generate types` after updating an environment'
+        option nil, :'puppet-path', 'Path to puppet executable', argument: :required do |value, cmd|
+          unless File.executable? value
+            $stderr.puts "The specified puppet executable #{value} is not executable."
+            puts cmd.help
+            exit 1
+          end
+        end
 
         run do |opts, args, cmd|
           puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -1,3 +1,5 @@
+require 'r10k/util/subprocess'
+
 # This class defines a common interface for environment implementations.
 #
 # @since 1.3.0
@@ -132,5 +134,17 @@ class R10K::Environment::Base
     end
 
     list.to_a
+  end
+
+  def generate_types!
+    argv = [R10K::Settings.puppet_path, 'generate', 'types', '--environment', dirname, '--environmentpath', basedir]
+    subproc = R10K::Util::Subprocess.new(argv)
+    subproc.raise_on_fail = true
+    subproc.logger = logger
+    result = subproc.execute
+    unless result.stderr.empty?
+      logger.warn "There were problems generating types for environment #{dirname}:"
+      result.stderr.split(%r{\n}).map { |msg| logger.warn msg }
+    end
   end
 end

--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -30,11 +30,19 @@ module R10K
           logger.warn(_("the purgedirs key in r10k.yaml is deprecated. it is currently ignored."))
         end
 
+        with_setting(:deploy) { |value| DeployInitializer.new(value).call }
+
         with_setting(:cachedir) { |value| R10K::Git::Cache.settings[:cache_root] = value }
         with_setting(:cachedir) { |value| R10K::Forge::ModuleRelease.settings[:cache_root] = value }
 
         with_setting(:git) { |value| GitInitializer.new(value).call }
         with_setting(:forge) { |value| ForgeInitializer.new(value).call }
+      end
+    end
+
+    class DeployInitializer < BaseInitializer
+      def call
+        with_setting(:puppet_path) { |value| R10K::Settings.puppet_path = value }
       end
     end
 

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -27,6 +27,10 @@ class R10K::Module::Base
   #   @return [Pathname] The full path of the module
   attr_reader :path
 
+  # @!attribute [r] environment
+  #   @return [R10K::Environment, nil] The parent environment of the module
+  attr_reader :environment
+
   # There's been some churn over `author` vs `owner` and `full_name` over
   # `title`, so in the short run it's easier to support both and deprecate one
   # later.

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -9,6 +9,11 @@ module R10K
     require 'r10k/settings/definition'
     require 'r10k/settings/list'
 
+    class << self
+      # Path to puppet executable
+      attr_accessor :puppet_path
+    end
+
     def self.git_settings
       R10K::Settings::Collection.new(:git, [
 
@@ -107,6 +112,24 @@ module R10K
         Definition.new(:purge_whitelist, {
           :desc => "A list of filename patterns to be excluded from any purge operations. Patterns are matched relative to the root of each deployed environment, if you want a pattern to match recursively you need to use the '**' glob in your pattern. Basic shell style globs are supported.",
           :default => [],
+        }),
+
+        Definition.new(:generate_types, {
+          :desc => "Controls whether to generate puppet types after deploying an environment. Defaults to false.",
+          :default => false,
+          :normalize => lambda do |input|
+            input.to_s == 'true'
+          end,
+        }),
+
+        Definition.new(:puppet_path, {
+          :desc => "Path to puppet executable. Defaults to /opt/puppetlabs/bin/puppet.",
+          :default => '/opt/puppetlabs/bin/puppet',
+          :validate => lambda do |value|
+            unless File.executable? value
+              raise ArgumentError, "The specified puppet executable #{value} is not executable"
+            end
+          end
         }),
       ])
     end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -17,6 +17,14 @@ describe R10K::Action::Deploy::Module do
     it "can accept a no-force option" do
       described_class.new({:'no-force' => true}, [])
     end
+
+    it 'can accept a generate-types option' do
+      described_class.new({ 'generate-types': true }, [])
+    end
+
+    it 'can accept a puppet-path option' do
+      described_class.new({ 'puppet-path': '/nonexistent' }, [])
+    end
   end
 
   describe "with no-force" do
@@ -25,6 +33,94 @@ describe R10K::Action::Deploy::Module do
 
     it "tries to preserve local modifications" do
       expect(subject.force).to equal(false)
+    end
+  end
+
+  describe 'generate-types' do
+    let(:deployment) do
+      R10K::Deployment.new(
+        sources: {
+          control: {
+            type: :mock,
+            basedir: '/some/nonexistent/path/control',
+            environments: %w[first second]
+          }
+        }
+      )
+    end
+
+    before do
+      allow(R10K::Deployment).to receive(:new).and_return(deployment)
+    end
+
+    context 'with generate-types enabled' do
+      subject do
+        described_class.new(
+          {
+            config: '/some/nonexistent/path',
+            'generate-types': true
+          },
+          %w[first]
+        )
+      end
+
+      before do
+        allow(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
+          expect(environment.puppetfile).to receive(:modules).and_return(
+            [R10K::Module::Local.new(environment.name, '/fakedir', [], environment)]
+          )
+          original.call(environment, &block)
+        end
+      end
+
+      it 'generate_types is true' do
+        expect(subject.instance_variable_get(:@generate_types)).to eq(true)
+      end
+
+      it 'only calls puppet generate types on environments with specified module' do
+        expect(subject).to receive(:visit_module).and_wrap_original do |original, mod, &block|
+          if mod.name == 'first'
+            expect(mod.environment).to receive(:generate_types!)
+          else
+            expect(mod.environment).not_to receive(:generate_types!)
+          end
+          original.call(mod, &block)
+        end.twice
+        subject.call
+      end
+    end
+
+    context 'with generate-types disabled' do
+      subject do
+        described_class.new(
+          {
+            config: '/some/nonexistent/path',
+            'generate-types': false
+          },
+          %w[first]
+        )
+      end
+
+      it 'generate_types is false' do
+        expect(subject.instance_variable_get(:@generate_types)).to eq(false)
+      end
+
+      it 'does not call puppet generate types' do |it|
+        expect(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
+          expect(environment).not_to receive(:generate_types!)
+          original.call(environment, &block)
+        end.twice
+        subject.call
+      end
+    end
+  end
+
+  describe 'with puppet-path' do
+
+    subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-path': '/nonexistent' }, []) }
+
+    it 'sets puppet_path' do
+      expect(subject.instance_variable_get(:@puppet_path)).to eq('/nonexistent')
     end
   end
 end

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -25,6 +25,10 @@ describe R10K::Action::Runner do
 
   subject(:runner) { described_class.new({:opts => :yep}, %w[args yes], action_class) }
 
+  before(:each) do
+    expect(runner.logger).not_to receive(:error)
+  end
+
   describe "instantiating the wrapped class" do
     it "creates an instance of the class" do
       expect(runner.instance).to be_a_kind_of action_class

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -117,6 +117,18 @@ describe R10K::Settings do
         end
       end
     end
+
+    describe 'puppet_path' do
+      it 'when executable raises no error' do
+        expect(File).to receive(:executable?).with('/nonexistent').and_return(true)
+        expect { subject.evaluate('puppet_path' => '/nonexistent') }.not_to raise_error
+      end
+
+      it 'when not executable raises error' do
+        expect(File).to receive(:executable?).with('/nonexistent')
+        expect { subject.evaluate('puppet_path' => '/nonexistent') }.to raise_error(R10K::Settings::Collection::ValidationError)
+      end
+    end
   end
 
   describe "global settings" do


### PR DESCRIPTION
This adds support for running `puppet generate types` after a successful environment or module deployment. See https://puppet.com/docs/puppet/latest/environment_isolation.html
for more information on generated types.

Should solve #693.