### PR TITLE
(RK-335) Fix postmap `modifiedenvs` feature

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -65,7 +65,7 @@ module R10K
         ensure
           if (postcmd = @settings[:postrun])
             if postcmd.grep('$modifiedenvs').any?
-              envs = deployment.environments.map { |e| e.name }
+              envs = deployment.environments.map { |e| e.dirname }
               envs.reject! { |e| !@argv.include?(e) } if @argv.any?
               postcmd = postcmd.map { |e| e.gsub('$modifiedenvs', envs.join(' ')) }
             end

--- a/spec/r10k-mocks/mock_source.rb
+++ b/spec/r10k-mocks/mock_source.rb
@@ -5,6 +5,9 @@ class R10K::Source::Mock < R10K::Source::Base
   R10K::Source.register(:mock, self)
 
   def environments
-    @options[:environments].map { |n| R10K::Environment::Mock.new(n, @basedir, n) }
+    corrected_environment_names = @options[:environments].map do |env|
+      R10K::Environment::Name.new(env, :prefix => @prefix, :invalid => 'correct_and_warn')
+    end
+    corrected_environment_names.map { |env| R10K::Environment::Mock.new(env.name, @basedir, env.dirname) }
   end
 end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -33,7 +33,8 @@ describe R10K::Action::Deploy::Environment do
           :control => {
             :type => :mock,
             :basedir => '/some/nonexistent/path/control',
-            :environments => %w[first second third],
+            :environments => %w[first second third env-that/will-be-corrected],
+            :prefix => 'PREFIX'
           }
         }
       )
@@ -76,7 +77,7 @@ describe R10K::Action::Deploy::Environment do
 
         subject do
           described_class.new( {config: "/some/nonexistent/path" },
-                               %w[first],
+                               %w[PREFIX_first],
                                settings                             )
         end
 
@@ -104,7 +105,7 @@ describe R10K::Action::Deploy::Environment do
 
           subject do
             described_class.new( {config: "/some/nonexistent/path" },
-                                 %w[first],
+                                 %w[PREFIX_first],
                                  settings                             )
           end
 
@@ -114,7 +115,7 @@ describe R10K::Action::Deploy::Environment do
             expect(mock_subprocess).to receive(:execute)
 
             expect(R10K::Util::Subprocess).to receive(:new).
-              with(["/generate/types/wrapper", "first"]).
+              with(["/generate/types/wrapper", "PREFIX_first"]).
               and_return(mock_subprocess)
 
             subject.call
@@ -140,7 +141,7 @@ describe R10K::Action::Deploy::Environment do
             expect(mock_subprocess).to receive(:execute)
 
             expect(R10K::Util::Subprocess).to receive(:new).
-              with(["/generate/types/wrapper", "first second third"]).
+              with(["/generate/types/wrapper", "PREFIX_first PREFIX_second PREFIX_third PREFIX_env_that_will_be_corrected"]).
               and_return(mock_subprocess)
 
             subject.call
@@ -160,7 +161,7 @@ describe R10K::Action::Deploy::Environment do
         expect(R10K::Deployment).to receive(:new).and_return(deployment)
       end
 
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true }, %w[first], settings) }
+      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true }, %w[PREFIX_first], settings) }
 
       describe "deployment purge level" do
         let(:purge_levels) { [:deployment] }


### PR DESCRIPTION
`e.name` is the branch name eg `feature/test-env`.  This doesn't
include any prefix that might be configured, and doesn't have illegal
chars converted to those allowed by puppet in environment names. In this
example, the actual environment name is eg.
`SOMEPREFIX_feature_test_env`.

`e.dirname` already holds the 'corrected' environment name we need to be
using.