### PR TITLE
(RK-336) Update tests to point to artifactory instead of int-resources

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -10,8 +10,8 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 3.33')
-gem 'beaker-pe', '~> 1.22'
+gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 4.5')
+gem 'beaker-pe', '~> 2.0'
 gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1.1')
 gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.4')
 gem 'rototiller', '= 0.1.0'

--- a/integration/pre-suite/00_pe_install.rb
+++ b/integration/pre-suite/00_pe_install.rb
@@ -1,3 +1,5 @@
+require 'beaker-pe'
+
 test_name 'CODEMGMT-20 - C48 - Install Puppet Enterprise'
 
 step 'Install PE'

--- a/integration/tests/basic_functionality/install_pe_only_module_with_puppetfile.rb
+++ b/integration/tests/basic_functionality/install_pe_only_module_with_puppetfile.rb
@@ -58,8 +58,8 @@ on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
 step 'Update the "r10k" Config'
 create_remote_file(master, r10k_config_path, r10k_conf)
 
-step 'Download license file from int-resources'
-curl_on(master, 'http://int-resources.ops.puppetlabs.net/QA_resources/r10k/license.key -o /etc/puppetlabs/license.key')
+step 'Download license file from artifactory'
+curl_on(master, 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/r10k_test_license.key -o /etc/puppetlabs/license.key')
 
 step 'Inject New "site.pp" to the "production" Environment'
 inject_site_pp(master, site_pp_path, site_pp)

--- a/integration/tests/basic_functionality/proxy_with_pe_only_module.rb
+++ b/integration/tests/basic_functionality/proxy_with_pe_only_module.rb
@@ -86,8 +86,8 @@ on(master, "mv #{r10k_config_path} #{r10k_config_bak_path}")
 step 'Update the "r10k" Config'
 create_remote_file(master, r10k_config_path, r10k_conf)
 
-step 'Download license file from int-resources'
-curl_on(master, 'http://int-resources.ops.puppetlabs.net/QA_resources/r10k/license.key -o /etc/puppetlabs/license.key')
+step 'Download license file from artifactory'
+curl_on(master, 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/r10k_test_license.key -o /etc/puppetlabs/license.key')
 
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)


### PR DESCRIPTION
Our internal test fixture servers changed, so this commit updates the
tests to use the new download location.