### PR TITLE
2.5.x to 3.0.x mergeup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,30 @@
 ---
 language: ruby
+services:
+  - docker
 bundler_args: "--without system"
 script: "bundle exec rspec --color --format documentation spec/unit"
 notifications:
   email: false
 sudo: false
-before_install: gem update bundler
-rvm:
-  - "2.3.0"
-  - "2.2.0"
-  - "2.1.0"
-  - "2.0.0"
-  - "1.9.3"
-  - "jruby-19mode"
 jdk:
-    - oraclejdk8
+  - oraclejdk8
+before_install: gem update bundler
+matrix:
+  include:
+    - stage: r10k tests
+      rvm: 2.3.0
+    - stage: r10k tests
+      rvm: 2.2.0
+    - stage: r10k tests
+      rvm: 2.1.0
+    - stage: r10k tests
+      rvm: 2.0.0
+    - stage: r10k tests
+      rvm: 1.9.3
+    - stage: r10k tests
+      rvm: jruby-19mode
+    - stage: r10k container tests
+      language: generic
+      script:
+        - cd docker && make lint && make build && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
 sudo: false
 jdk:
   - oraclejdk8
-before_install: gem update bundler
+before_install: gem install bundler -v '< 2' --no-document
 matrix:
   include:
     - stage: r10k tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ pool:
   name: Default
 
 variables:
-  BUILD_REPOSITORY: 127.0.0.1
+  NAMESPACE: puppet
 
 steps:
 - powershell: |
@@ -46,24 +46,24 @@ steps:
   name: hostinfo
 - powershell: |
     . ./docker/ci/build.ps1
-    Invoke-ContainerBuildSetup
-  displayName: Prepare Build Environment
-  name: build_prepare
+    Lint-Dockerfile -Path ./docker/r10k/Dockerfile
+  displayName: Lint r10k Dockerfile
+  name: lint_dockerfile
 - powershell: |
     . ./docker/ci/build.ps1
-    Build-Container -Name r10k -Repository $ENV:BUILD_REPOSITORY
-  displayName: Build r10k
-  name: build_r10k
+    Build-Container -Namespace $ENV:NAMESPACE
+  displayName: Build r10k Container
+  name: build_r10k_container
 - powershell: |
     . ./docker/ci/build.ps1
-    Invoke-ContainerTest -Name r10k -Repository $ENV:BUILD_REPOSITORY
+    Invoke-ContainerTest -Namespace $ENV:NAMESPACE
   displayName: Test r10k
   name: test_r10k
 - task: PublishTestResults@2
   displayName: Publish r10k test results
   inputs:
     testResultsFormat: 'JUnit'
-    testResultsFiles: 'docker/**/TEST-*.xml'
+    testResultsFiles: 'docker/TEST-*.xml'
     testRunTitle: r10k Test Results
 - powershell: |
     . ./docker/ci/build.ps1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,8 @@ variables:
   NAMESPACE: puppet
 
 steps:
+- checkout: self
+  clean: true
 - powershell: |
     $line = '=' * 80
     Write-Host "$line`nWindows`n$line`n"

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+TEST-rspec.xml

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -10,5 +10,5 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'puppet_docker_tools', *location_for(ENV['PUPPET_DOCKER_LOCATION'] || '~> 0.2')
+gem 'rspec'
 gem 'rspec_junit_formatter'

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -19,27 +19,43 @@ function Get-ContainerVersion
   (git describe) -replace '-.*', ''
 }
 
-# installs gems for build and test and grabs base images
-function Invoke-ContainerBuildSetup
+function Lint-Dockerfile($Path)
 {
-  Push-Location (Get-CurrentDirectory)
-  bundle install --path '.bundle/gems'
-  bundle exec puppet-docker update-base-images ubuntu:16.04
+  hadolint --ignore DL3008 --ignore DL3018 --ignore DL4000 --ignore DL4001 $Path
+}
+
+function Build-Container(
+  $Namespace = 'puppet',
+  $Version = (Get-ContainerVersion),
+  $Vcs_ref = $(git rev-parse HEAD))
+{
+  Push-Location (Join-Path (Get-CurrentDirectory) '..')
+
+  $build_date = (Get-Date).ToUniversalTime().ToString('o')
+  $docker_args = @(
+    '--pull',
+    '--build-arg', "vcs_ref=$Vcs_ref",
+    '--build-arg', "build_date=$build_date",
+    '--build-arg', "version=$Version",
+    '--file', "r10k/Dockerfile",
+    '--tag', "$Namespace/r10k:$Version"
+  )
+
+  docker build $docker_args r10k
+
   Pop-Location
 }
 
-function Build-Container($Name, $Repository = '127.0.0.1', $Version = (Get-ContainerVersion))
+function Invoke-ContainerTest(
+  $Namespace = 'puppet',
+  $Version = (Get-ContainerVersion))
 {
   Push-Location (Join-Path (Get-CurrentDirectory) '..')
-  bundle exec puppet-docker local-lint $Name
-  bundle exec puppet-docker build $Name --no-cache --repository $Repository --version $Version --no-latest --build-arg namespace=$Repository
-  Pop-Location
-}
 
-function Invoke-ContainerTest($Name, $Repository = '127.0.0.1', $Version = (Get-ContainerVersion))
-{
-  Push-Location (Join-Path (Get-CurrentDirectory) '..')
-  bundle exec puppet-docker spec $Name --image "$Repository/${Name}:$Version"
+  bundle install --path .bundle/gems
+  $ENV:PUPPET_TEST_DOCKER_IMAGE = "$Namespace/r10k:$Version"
+  bundle exec rspec r10k/spec
+
   Pop-Location
 }
 


### PR DESCRIPTION
This is part 1 of the 2.6.x to 3.0.x mergeup that brings in older changes from the 2.5.x branch Docker content.

The next mergeup will be more complex as we must *keep* the Docker content in the 3.0.x branch rather than delete it, but must mergeup other content.

A separate PR for that will follow.