### PR TITLE
(MAINT) Disable metrics by default

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,6 @@
 
 The following environment variables are supported:
 
-- `PUPPERWARE_DISABLE_ANALYTICS`
+- `PUPPERWARE_ANALYTICS_ENABLED`
 
-  Set to `true` to disable Google Analytics metrics.
+  Set to `true` to enable Google Analytics metrics.

--- a/docker/r10k/docker-entrypoint.d/10-analytics.sh
+++ b/docker/r10k/docker-entrypoint.d/10-analytics.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ "${PUPPERWARE_DISABLE_ANALYTICS}" = "true" ]; then
-    echo "($0) Pupperware analytics disabled; skipping metric submission"
+if [ "${PUPPERWARE_ANALYTICS_ENABLED}" != "true" ]; then
+    echo "($0) Pupperware analytics not enabled; skipping metric submission"
     exit 0
 fi
 

--- a/docker/r10k/spec/dockerfile_spec.rb
+++ b/docker/r10k/spec/dockerfile_spec.rb
@@ -37,7 +37,6 @@ describe 'r10k container' do
       fail error_message
     end
     result = run_command("docker run --rm --detach \
-               --env PUPPERWARE_DISABLE_ANALYTICS=true \
                --entrypoint /bin/ash \
                --interactive \
                --volume #{File.join(SPEC_DIRECTORY, 'fixtures')}:/test \


### PR DESCRIPTION
Make them opt-in instead of opt-out.

Also rename the variable so all the analytics-related variables follow
the naming pattern PUPPERWARE_ANALYTICS_*, since we also have
PUPPERWARE_ANALYTICS_STREAM (not user-facing though).