### PR TITLE
(maint) Refactor Docker specs for internally hosted Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,15 @@ steps:
     #
     # Azure
     #
-    Write-Host "`n`n$line`nAzure`n$line`n"
-    Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
-      ConvertTo-Json -Depth 10 |
-      Write-Host
+    $assetTag = Get-WmiObject -class Win32_SystemEnclosure -namespace root\CIMV2 |
+      Select -ExpandProperty SMBIOSAssetTag
+    if ($assetTag -eq '7783-7084-3265-9085-8269-3286-77')
+    {
+      Write-Host "`n`n$line`nAzure`n$line`n"
+      Invoke-RestMethod -Headers @{'Metadata'='true'} -URI http://169.254.169.254/metadata/instance?api-version=2017-12-01 -Method Get |
+        ConvertTo-Json -Depth 10 |
+        Write-Host
+    }
     #
     # Docker
     #

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,7 @@ steps:
     Write-Host "`n`n$line`nRuby`n$line`n"
     ruby --version
     gem --version
+    gem env
     bundle --version
     #
     # Environment

--- a/docker/ci/build.ps1
+++ b/docker/ci/build.ps1
@@ -54,6 +54,8 @@ function Invoke-ContainerTest(
 
   bundle install --path .bundle/gems
   $ENV:PUPPET_TEST_DOCKER_IMAGE = "$Namespace/r10k:$Version"
+  Write-Host "Testing against image: ${ENV:PUPPET_TEST_DOCKER_IMAGE}"
+  bundle exec rspec --version
   bundle exec rspec r10k/spec
 
   Pop-Location

--- a/docker/r10k/spec/dockerfile_spec.rb
+++ b/docker/r10k/spec/dockerfile_spec.rb
@@ -1,9 +1,26 @@
 require 'rspec/core'
 require 'fileutils'
+require 'open3'
 
 SPEC_DIRECTORY = File.dirname(__FILE__)
 
 describe 'r10k container' do
+
+  def run_command(command)
+    status = nil
+    STDOUT.puts "Executing #{command}"
+    Open3.popen2e(command) do |stdin, stdout_stderr, wait_thread|
+      Thread.new do
+        stdout_stderr.each { |l| STDOUT.puts l }
+      end
+
+      stdin.close
+      status = wait_thread.value
+    end
+
+    status
+  end
+
   before(:all) do
     @image = ENV['PUPPET_TEST_DOCKER_IMAGE']
     if @image.nil?
@@ -22,24 +39,24 @@ describe 'r10k container' do
                --volume #{File.join(SPEC_DIRECTORY, 'fixtures')}:/test \
                #{@image}).chomp
 
-    %x(docker exec #{@container} cp test/Puppetfile /)
+    run_command("docker exec #{@container} cp test/Puppetfile /")
   end
 
   after(:all) do
-    %x(docker container kill #{@container})
+    run_command("docker container kill #{@container}")
     FileUtils.rm_rf(File.join(SPEC_DIRECTORY, 'fixtures', 'modules'))
   end
 
   it 'should validate the Puppetfile' do
-    %x(docker exec #{@container} r10k puppetfile check)
-    status = $?
-    expect(status).to eq(0)
+    cmd = "docker exec #{@container} r10k puppetfile check"
+    status = run_command(cmd)
+    expect(status.exitstatus).to eq(0)
   end
 
   it 'should install the Puppetfile' do
-    %x(docker exec #{@container} r10k puppetfile install)
-    status = $?
-    expect(status).to eq(0)
+    cmd = "docker exec #{@container} r10k puppetfile install"
+    status = run_command(cmd)
+    expect(status.exitstatus).to eq(0)
     expect(Dir.exist?(File.join(SPEC_DIRECTORY, 'fixtures', 'modules', 'ntp'))).to eq(true)
   end
 end


### PR DESCRIPTION
* Emit rspec version when running specs
* Output the gem env
* Rewrite Docker spec invocation so that stdout / stderr are emitted (for the sake of debugging). This also fixes a problem with running `%x` in environments other than Azure.
* Only emit Azure info when running in an Azure VM
