### PR TITLE
(MAINT) Don't print container messages to CLI

### DIFF
--- a/docker/r10k/docker-entrypoint.d/10-analytics.sh
+++ b/docker/r10k/docker-entrypoint.d/10-analytics.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "${PUPPERWARE_ANALYTICS_ENABLED}" != "true" ]; then
-    echo "($0) Pupperware analytics not enabled; skipping metric submission"
+    # Don't print out any messages here since this is a CLI container
     exit 0
 fi
 
@@ -23,6 +23,6 @@ ea=start
 _params="v=1&t=event&tid=${tid}&an=${an}&av=${av}&cid=${cid}&ec=${ec}&ea=${ea}"
 _url="http://www.google-analytics.com/collect?${_params}"
 
-echo "($0) Sending metrics ${_url}"
+# Don't print out any messages here since this is a CLI container
 curl --fail --silent --show-error --output /dev/null \
     -X POST -H "Content-Length: 0" $_url

--- a/docker/r10k/docker-entrypoint.sh
+++ b/docker/r10k/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 for f in /docker-entrypoint.d/*.sh; do
-  echo "Running $f"
+  # Don't print out any messages here since this is a CLI container
   chmod +x "$f"
   "$f"
 done


### PR DESCRIPTION
Silence the container entrypoint echo statements. Since this is a CLI
container and not a service container, it should not have these verbose
logging style statements being printed out. They just get in the way of
the user trying to run the CLI and see the output of their command.

Since this is breaking consistency with our other containers (which all
happen to be service containers and not CLI containers) I left comments
in place saying why we're not printing out any messages.

----

Before this change:

```
$ docker run -ti --rm local/r10k:3.1.1 --help
Running /docker-entrypoint.d/10-analytics.sh
(/docker-entrypoint.d/10-analytics.sh) Pupperware analytics not enabled; skipping metric submission
NAME
    r10k - Killer robot powered Puppet environment deployment

USAGE
    r10k <subcommand> [options]

DESCRIPTION
    r10k is a suite of commands to help deploy and manage puppet code for
    complex environments.

COMMANDS
    deploy         Puppet dynamic environment deployment
    help           show help
    puppetfile     Perform operations on a Puppetfile
    version        Print the version of r10k

OPTIONS
    -c --config=<value>         Specify a global configuration file
       --color                  Enable colored log messages
    -h --help                   Show help for this command
    -t --trace                  Display stack traces on application crash
    -v --verbose[=<value>]      Set log verbosity. Valid values: fatal,
                                error, warn, notice, info, debug, debug1,
                                debug2
```

After:
```
$ docker run -ti --rm local/r10k:3.1.1 --help
NAME
    r10k - Killer robot powered Puppet environment deployment

USAGE
    r10k <subcommand> [options]

DESCRIPTION
    r10k is a suite of commands to help deploy and manage puppet code for
    complex environments.

COMMANDS
    deploy         Puppet dynamic environment deployment
    help           show help
    puppetfile     Perform operations on a Puppetfile
    version        Print the version of r10k

OPTIONS
    -c --config=<value>         Specify a global configuration file
       --color                  Enable colored log messages
    -h --help                   Show help for this command
    -t --trace                  Display stack traces on application crash
    -v --verbose[=<value>]      Set log verbosity. Valid values: fatal,
                                error, warn, notice, info, debug, debug1,
                                debug2
```