### PR TITLE
remove test symlink #833 [RK-338]

### DIFF
--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-integration


### PR DESCRIPTION
This PR removes the `test` symlink that points to the `integration` directory. This fixes #833. 

I've also raised a PR against Puppet internal CI jobs repo which has the pipeline also look for the `integration` directory if `test` is not found. 