### PR TITLE
(RK-341) Pin back cri gem to maintain ruby 2.3 support

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,5 +1,11 @@
 CHANGELOG
 =========
+3.0.4
+----
+
+## Changes
+
+(RK-341)The cri gem version 2.15.4 dropped support for Ruby 2.3. In order to maintain Ruby 2.3 compatibility the cri gem dependency must be limited to versions between 2.15.1 and 2.15.3. 
 
 3.0.3
 ----

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_dependency 'colored',   '1.2'
-  s.add_dependency 'cri',       '~> 2.15.1'
+  # cri 2.15.4 added dependency on ruby >= 2.4. Unpin when r10k drops ruby 2.3 support.
+  s.add_dependency 'cri',       '>= 2.15.1', '< 2.15.4'
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
This commit limits the cri dependency versions to `2.15.{1,2,3}` as `2.15.4` is incompatible with `ruby 2.3` which is the common system ruby interpreter version for test infrastructure (for example `osx10.{13,14}`)