### PR TITLE
Users should be able to include external Puppetfiles in their own.

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -298,7 +298,7 @@ class Puppetfile
 
             parse(File.read(path))
           else
-            # Should we log unexpected Ruby code?
+            raise LoadError, _("unrecognized declaration '%{method}'") % {method: args.shift}
           end
         end
         

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -72,8 +72,19 @@ class Puppetfile
   end
 
   def load!
-    dsl = R10K::Puppetfile::DSL.new(self)
-    dsl.instance_eval(puppetfile_contents, @puppetfile_path)
+    begin
+      logger.debug "Attempting to parse the AST directly"
+
+      parser = R10K::Puppetfile::Parser.new(self)
+      parser.parse(puppetfile_contents)
+
+    rescue R10K::Error => e
+      logger.debug "Falling back to eval'ing the Puppetfile"
+
+      dsl = R10K::Puppetfile::DSL.new(self)
+      dsl.instance_eval(puppetfile_contents, @puppetfile_path)
+    end
+    
     validate_no_duplicate_names(@modules)
     @loaded = true
   rescue SyntaxError, LoadError, ArgumentError, NameError => e
@@ -226,6 +237,65 @@ class Puppetfile
     end
 
     true
+  end
+
+  class Parser
+    # A Puppetfile parser that does not require eval'ing Ruby code
+    # 
+    # @api private
+
+    def initialize(librarian)
+      @librarian = librarian
+    end
+
+    def parse(puppetfile)
+      root = nil
+      begin
+        root = RubyVM::AbstractSyntaxTree.parse(puppetfile)
+      rescue NameError => e
+        # When run on Ruby 2.6 or greater, this will parse the Puppefile directly.
+        # See https://docs.ruby-lang.org/en/trunk/RubyVM/AbstractSyntaxTree.html for more information.
+        raise R10K::Error.new("Cannot parse Puppetfile directly on Ruby version #{RUBY_VERSION}")
+      end
+      traverse(root)
+    end
+
+    def traverse(node)
+      begin
+        if node.type == :FCALL
+          name = node.children.first
+          args = node.children.last.children.map do |item|
+            next if item.nil?
+
+            case item.type
+            when :HASH
+              Hash[*item.children.first.children.compact.map {|n| n.children.first }]
+            else
+              item.children.first
+            end
+          end.compact
+
+          case name
+          when :mod
+            @librarian.add_module(args.shift, *args)
+          when :forge
+            @librarian.set_forge(args.shift)
+          when :moduledir
+            @librarian.set_moduledir(args.shift)
+          else
+            # Should we log unexpected Ruby code?
+          end
+
+          node.children.each do |n|
+            next unless n.is_a? RubyVM::AbstractSyntaxTree::Node
+
+            traverse(n)
+          end
+        end
+      rescue => e
+        puts e.message
+      end
+    end
   end
 
   class DSL

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -74,7 +74,7 @@ class Puppetfile
   def load!
     begin
       logger.debug "Attempting to parse the AST directly"
-
+      
       parser = R10K::Puppetfile::Parser.new(self)
       parser.parse(puppetfile_contents)
 
@@ -317,7 +317,7 @@ class Puppetfile
     # A barebones implementation of the Puppetfile DSL
     #
     # @api private
-
+    
     def initialize(librarian)
       @librarian = librarian
     end
@@ -332,6 +332,16 @@ class Puppetfile
 
     def moduledir(location)
       @librarian.set_moduledir(location)
+    end
+
+    def incl(librarian)
+      if Pathname.new(librarian).absolute?
+        path = arg
+      else
+        path = File.join(File.dirname(@librarian.puppetfile_path), librarian)
+      end
+
+      instance_eval(File.read(path), @librarian.puppetfile_path)
     end
 
     def method_missing(method, *args)

--- a/spec/fixtures/unit/puppetfile/include/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/include/Puppetfile
@@ -1,0 +1,7 @@
+incl 'Puppetfile.shared'
+
+mod 'puppetlabs/stdlib'
+
+mod 'puppetlabs-apache',
+  :git => 'git@github.com:puppetlabs/puppetlabs-apache.git',
+  :branch => 'master'

--- a/spec/fixtures/unit/puppetfile/include/Puppetfile.shared
+++ b/spec/fixtures/unit/puppetfile/include/Puppetfile.shared
@@ -1,0 +1,3 @@
+forge 'http://forge.puppetlabs.com'
+
+mod 'puppetlabs-apt', '7.0.0'


### PR DESCRIPTION
Related: #885 

Hello!

:tipping_hand_woman: This PR adds a new `incl` syntax to the `Puppetfile` spec for including an external Puppetfile as if it were part of the environments dependencies.

Sample Puppetfile:
```Puppetfile
forge 'http://forge.puppetlabs.com'

# Include shared modules.
incl '/usr/local/share/r10k/Puppetfile'

#
# Tenant-specific dependencies.
#
mod 'puppetlabs/stdlib'
mod 'puppetlabs-apache',
  :git => 'git@github.com:puppetlabs/puppetlabs-apache.git',
  :branch => 'master'
```

Sample External Puppetfile at `/usr/local/share/r10k/Puppetfile`:
```Puppetfile
#
# Shared dependencies.
#
mod 'puppetlabs/apt'
```

In our environment, we have multiple tenants separated into separate control repositories. Some of these tenants depend on shared modules (roles/profiles) we maintain as a community. This means that when we decide to update underlying component modules, we have to communicate those changes to individual tenants and it creates a release bottleneck.

One "hack" that we've been using in the last year was to have our r10k node write the "shared upstream `Puppetfile`" to disk and then in tenant `Puppetfile`, they do the following:

```
# "Include" shared Puppetfile
self.instance_eval(File.read('/usr/local/share/r10k/Puppetfile'))

# 
# Tenant-specific dependencies
#
mod 'camptocamp-kmod', '2.3.0'
mod 'crayfishx-firewalld', '3.4.0'
```

The fact that `Puppetfile` are `eval()-d` as Ruby currently allows us to solve the problem. I

In #885, an AST-based approach is proposed for hosts running Ruby 2.6+. If this were the standard behaviour, then our eval-based approach to sharing modules would break. My proposal is based on the implementation @binford2k provides in #885 and adds new syntax to officially support inclusion of an external `Puppetfile`.

**Implementation Details / Credits**

- I plucked the AST-based parser implementation from #885 and credited @binford2k as the author in e177d55. Very awesome work.
- Following, I implemented support for `incl`. The directive receives a single argument that can be a relative or absolute path. If a relative path is used, it is relative to the *calling* `Puppetfile`.
- I did not impose any limit on the depth of includes that can be used. Arguably, as a matter of best practice, one might say "limit to a single depth of includes". I'm amenable to enforcing this, but left it out for now.
- There is no cycle detection, but that seems like something someone would have to go out of their way to do here. This feature is intended to be a very simple include.
- Includes are expected to function as if the contents of the file were in-lined into the calling `Puppetfile`.

Please let me know if you have any questions. I will be adding additional unit tests to cover this code, but wanted to get this PR submitted. I appreciate your time and consideration!