### PR TITLE
Add Ruby 2.6 to the TravisCI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install: gem install bundler -v '< 2' --no-document
 matrix:
   include:
     - stage: r10k tests
+      rvm: 2.6.0
+    - stage: r10k tests
       rvm: 2.5.0
     - stage: r10k tests
       rvm: 2.4.0


### PR DESCRIPTION
Related: #927 

:tipping_hand_woman: This PR adds Ruby 2.6 to the versions of Ruby tested on Travis. 

In #927, we use `RubyVM::AbstractSyntaxTree.parse` to parse `Puppetfile` instead of `instance_eval`. I had some tests that failed locally on Ruby 2.6, but oddly the TravisCI build was fine!

This "fixes" that :)