### PR TITLE
Ensure that 'git clone' does not use hardlinks

### DIFF
--- a/lib/r10k/git/shellgit/bare_repository.rb
+++ b/lib/r10k/git/shellgit/bare_repository.rb
@@ -24,7 +24,7 @@ class R10K::Git::ShellGit::BareRepository < R10K::Git::ShellGit::BaseRepository
     proxy = R10K::Git.get_proxy_for_remote(remote)
 
     R10K::Git.with_proxy(proxy) do
-      git ['clone', '--mirror', remote, git_dir.to_s]
+      git ['clone', '--no-hardlinks', '--mirror', remote, git_dir.to_s]
     end
   end
 

--- a/lib/r10k/git/shellgit/working_repository.rb
+++ b/lib/r10k/git/shellgit/working_repository.rb
@@ -28,7 +28,7 @@ class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseReposito
   #
   # @return [void]
   def clone(remote, opts = {})
-    argv = ['clone', '--no-hardinks', remote, @path.to_s]
+    argv = ['clone', '--no-hardlinks', remote, @path.to_s]
     if opts[:reference]
       argv += ['--reference', opts[:reference]]
     end

--- a/lib/r10k/git/shellgit/working_repository.rb
+++ b/lib/r10k/git/shellgit/working_repository.rb
@@ -28,7 +28,7 @@ class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseReposito
   #
   # @return [void]
   def clone(remote, opts = {})
-    argv = ['clone', remote, @path.to_s]
+    argv = ['clone', '--no-hardinks', remote, @path.to_s]
     if opts[:reference]
       argv += ['--reference', opts[:reference]]
     end


### PR DESCRIPTION
Shell git uses hardlinks by default for local repo clones. This causes
issues with the r10k cache and SELinux contexts since the source and
destination will, quite often, be a home directory and some other
location on the system.

To prevent this (and other inadvertent issues with hardlinks in the r10k
cache), this patch adds the `--no-hardlinks` option to each call of `git
clone` when using shellgit.

Closes #931