### PR TITLE
(RK-342) Update for behavior change in Cri options hash

### DIFF
--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -24,6 +24,7 @@ module R10K
         {
           :config => true,
           :trace  => true,
+          :help => true,
         }
       end
     end


### PR DESCRIPTION
With the release of cri 2.15.7 flags are now always included in the options hash with the value set to `false`. This was causing errors in the `R10k::Util::Setops` setops method when executing puppetfile or deploy actions. This commit adds `help` to the `allowed_initialize_opts` in the `R10k::Action::Base` class