### PR TITLE
Implemented default_branch_override flag to override Puppetfile :default_branch entry during environment deployments

### DIFF
--- a/doc/dynamic-environments/usage.mkd
+++ b/doc/dynamic-environments/usage.mkd
@@ -60,6 +60,18 @@ Update a single environment and force an update of modules:
 This will update the given environment and update all contained modules. This is
 useful if you want to make sure that a given environment is fully up to date.
 
+- - -
+
+Update a single environment and specify a default branch override:
+
+    r10k deploy environment my_working_environment --puppetfile --default-branch-override default_branch_override
+
+This will update the given environment and update all contained modules, overrideing 
+the :default_branch entry in the Puppetfile of each module. This is used primarily to allow
+automated r10k solutions using the control_branch pattern with a temporary branch deployment to 
+ensure the deployment is pushed to the correct module repository branch. Note that the :default_branch
+is only ever utilized if the desired ref cannot be located.
+
 ### Deploying modules
 
 Update a single module across all environments:

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -109,7 +109,7 @@ module R10K
         end
 
         def visit_puppetfile(puppetfile)
-          puppetfile.load
+          puppetfile.load(@opts[:'default-branch-override'])
 
           yield
 
@@ -146,7 +146,7 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, cachedir: :self, :'no-force' => :self)
+          super.merge(puppetfile: :self, cachedir: :self, :'no-force' => :self, :'default-branch-override' => :self)
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -53,6 +53,7 @@ scheduled. On subsequent deployments, Puppetfile deployment will default to off.
           DESCRIPTION
 
           flag :p, :puppetfile, 'Deploy modules from a puppetfile'
+          required nil, :'default-branch-override', 'Specify a branchname to override the default branch in the puppetfile'
 
           runner R10K::Action::CriRunner.wrap(R10K::Action::Deploy::Environment)
         end

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -23,6 +23,11 @@ class R10K::Module::Git < R10K::Module::Base
   #   @return [String]
   attr_reader :desired_ref
 
+  # @!attribute [r] default_ref
+  #   @api private
+  #   @return [String]
+  attr_reader :default_ref
+
   def initialize(title, dirname, args, environment=nil)
     super
 

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -55,17 +55,20 @@ class Puppetfile
     @loaded = false
   end
 
-  def load
+  def load(default_branch_override = nil)
     if File.readable? @puppetfile_path
-      self.load!
+      self.load!(default_branch_override)
     else
       logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile_path.inspect}
     end
   end
 
-  def load!
+  def load!(default_branch_override = nil)
+    @default_branch_override = default_branch_override
+
     dsl = R10K::Puppetfile::DSL.new(self)
     dsl.instance_eval(puppetfile_contents, @puppetfile_path)
+    
     validate_no_duplicate_names(@modules)
     @loaded = true
   rescue SyntaxError, LoadError, ArgumentError => e
@@ -105,6 +108,10 @@ class Puppetfile
       validate_install_path(install_path, name)
     else
       install_path = @moduledir
+    end
+
+    if args.is_a?(Hash) && @default_branch_override != nil
+      args[:default_branch] = @default_branch_override
     end
 
     # Keep track of all the content this Puppetfile is managing to enable purging.

--- a/spec/fixtures/unit/puppetfile/default-branch-override/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/default-branch-override/Puppetfile
@@ -1,0 +1,5 @@
+mod 'cd4pe',
+  :git => 'test@randomurl.com:something/some_module.git',
+  :ref => 'expected_ref',
+  :default_branch => 'here_lies_the_default_branch'
+

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -19,6 +19,10 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({puppetfile: true}, [])
     end
 
+    it "can accept a default_branch_override option" do
+      described_class.new({:'default-branch-override' => 'default_branch_override_name'}, [])
+    end
+
     it "can accept a no-force option" do
       described_class.new({:'no-force' => true}, [])
     end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -181,6 +181,25 @@ describe R10K::Puppetfile do
       subject = described_class.new(path)
       expect { subject.load! }.not_to raise_error
     end
+
+    it "creates a git module and applies the default branch sepcified in the Puppetfile" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'default-branch-override')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect { subject.load! }.not_to raise_error
+      git_module = subject.modules[0]
+      expect(git_module.default_ref).to eq 'here_lies_the_default_branch'
+    end
+
+    it "creates a git module and applies the provided default_branch_override" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'default-branch-override')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      default_branch_override = 'default_branch_override_name'
+      expect { subject.load!(default_branch_override) }.not_to raise_error
+      git_module = subject.modules[0]
+      expect(git_module.default_ref).to eq default_branch_override
+    end
   end
 
   describe "accepting a visitor" do


### PR DESCRIPTION
### Description
With this change, a user can specify a default branch override using the `--default-branch-override` flag. This value will be passed through to the deployment and used in place of the Puppetfile's `:default_branch` entry. If no `:default_branch` was previously specified in the Puppetfile, the supplied default branch override will be used anyways.

### How this feature is to be used
When running r10k, specify a default_branch_override using the `--default-branch-override` flag. 
> `r10k deploy environment -p production --default-branch-override temporary_branch_237292`
 
### How important is this feature to our environment?
The impetus behind this feature is to address a bug in **Continuous Delivery for Puppet Enterprise**, where deployments utilizing a combination of the Control Branch AND [Temporary Branch pattern](https://puppet.com/docs/continuous-delivery/2.x/deployment_policies.html#concept-5197) for module deployments would cause modules to be deployed to the wrong branch, or fail completely.

(Because the control_branch pattern requires that both the control repo and module repo have branches with matching names, and the temporary branch pattern creates a brand new branch by definition, there is no way for the control branch pattern to succeed, _unless_ a default_branch is specified in the module's Puppetfile specifying same name as the new temporary branch). The only way to be sure the `default_branch` entry in the Puppetfile matches the temporary branch name is to supply is as an override.

Note: This bug also causes Impact Analysis runs to fail, as they use the Temporary Branch pattern as well.

### How useful this feature would be for other users?
I can't imagine another use case that makes overriding the default_branch via r10k simpler than just updating your Puppetfile, but its always possible.

### Potential caveats?
When a `default_branch_override` is specified for a deployment, the `default_branch` param will be set on _every module_ in the Puppetfile during deployment. Generally speaking, this will have no effect on the deployments of those modules, as the desired ref will generally always exist (ie. modules pulled from the forge), **and** the name of the `default_branch_override` will likely not exist in that repo.