### PR TITLE
(CDPE-1813) Add module deploy info to .r10k-deploy.json file

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -125,11 +125,22 @@ module R10K
         end
 
         def write_environment_info!(environment, started_at, success)
+          module_deploys = []
+          if environment.puppetfile && environment.puppetfile.modules
+            environment.puppetfile.modules.each do |mod|
+              name = mod.name
+              version = mod.version
+              sha = mod.repo.head rescue nil
+              module_deploys.push({:name => name, :version => version, :sha => sha})
+            end
+          end
+
           File.open("#{environment.path}/.r10k-deploy.json", 'w') do |f|
             deploy_info = environment.info.merge({
               :started_at => started_at,
               :finished_at => Time.new,
               :deploy_success => success,
+              :module_deploys => module_deploys,
             })
 
             f.puts(JSON.pretty_generate(deploy_info))

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -127,4 +127,58 @@ describe R10K::Action::Deploy::Environment do
       end
     end
   end
+
+  describe "write_environment_info!" do
+
+    class Fake_Environment
+      attr_accessor :path
+      attr_accessor :puppetfile
+      attr_accessor :info
+
+      def initialize(path, info)
+        @path = path
+        @info = info
+        @puppetfile = R10K::Puppetfile.new
+      end
+    end
+
+    let(:mock_stateful_repo) { instance_double("R10K::Git::StatefulRepository", :head => "123456") }
+    let(:mock_stateful_repo_2) { instance_double("R10K::Git::StatefulRepository", :head => "654321") }
+    let(:mock_module) { instance_double("R10K::Module::Git", :name => "my_cool_module", :version => "1.0", :repo => mock_stateful_repo) }
+    let(:mock_module_2) { instance_double("R10K::Module::Git", :name => "my_lame_module", :version => "0.0.1", :repo => mock_stateful_repo_2) }
+    let(:mock_puppetfile) { instance_double("R10K::Puppetfile", :modules => [mock_module, mock_module_2]) }
+
+    before(:all) do
+      @tmp_path = "./tmp-r10k-test-dir/"
+      Dir.mkdir(@tmp_path) unless File.exists?(@tmp_path)
+    end
+
+    after(:all) do
+      File.delete("#{@tmp_path}/.r10k-deploy.json")
+      Dir.delete(@tmp_path)
+    end
+
+    it "writes the .r10k-deploy file correctly" do
+      allow(R10K::Puppetfile).to receive(:new).and_return(mock_puppetfile)
+
+      fake_env = Fake_Environment.new(@tmp_path, {:name => "my_cool_environment", :signature => "pablo picasso"})
+      subject.send(:write_environment_info!, fake_env, "2019-01-01 23:23:22 +0000", true)
+
+      file_contents = File.read("#{@tmp_path}/.r10k-deploy.json")
+      r10k_deploy = JSON.parse(file_contents)
+
+      expect(r10k_deploy['name']).to eq("my_cool_environment")
+      expect(r10k_deploy['signature']).to eq("pablo picasso")
+      expect(r10k_deploy['started_at']).to eq("2019-01-01 23:23:22 +0000")
+      expect(r10k_deploy['deploy_success']).to eq(true)
+      expect(r10k_deploy['module_deploys'].length).to eq(2)
+      expect(r10k_deploy['module_deploys'][0]['name']).to eq("my_cool_module")
+      expect(r10k_deploy['module_deploys'][0]['version']).to eq("1.0")
+      expect(r10k_deploy['module_deploys'][0]['sha']).to eq("123456")
+      expect(r10k_deploy['module_deploys'][1]['name']).to eq("my_lame_module")
+      expect(r10k_deploy['module_deploys'][1]['version']).to eq("0.0.1")
+      expect(r10k_deploy['module_deploys'][1]['sha']).to eq("654321")
+
+    end
+  end
 end


### PR DESCRIPTION
With this change, module information will be added to the output file '.r10k-deploy.json' for external consumption (including the module name, version, and git sha associated with the commit used if pulling the module from a git repository.

In particular, we need the module deploy sha in order to detect changes to the module when running Impact Analysis. Currently, the only way to detect changes is it compare the module versions.