### PR TITLE
(maint) Prep 3.0.4 release

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+3.0.4
+----
+
+## Changes
+ - Flag for overriding default branch configuration in Puppetfile
+ - Plumbing for internationalization
+ - Numerous test fixes and legacy docker work
+
 3.0.3
 ----
 

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,7 @@ CHANGELOG
 3.0.4
 ----
 
-## Changes
+### Changes
  - Flag for overriding default branch configuration in Puppetfile
  - Plumbing for internationalization
  - Numerous test fixes and legacy docker work
@@ -12,49 +12,49 @@ CHANGELOG
 3.0.3
 ----
 
-## Bug Fixes
+### Changes
 
-(RK-324) Fix Ruby pipe bug affecting Ubuntu
+  - (RK-324) Fix Ruby pipe bug affecting Ubuntu
 
 3.0.2
 ----
 
-## Changes
+### Changes
 
-Minor test fixes.
+  - Minor test fixes.
 
 3.0.1
-=======
+----
 
-## Changes
+### Changes
 
 Because of dependency issues R10K 3.0.0 required Ruby >= 2.3
 rather than the reported 2.0. This release makes the requirement of
 Ruby >= 2.3 official and documented.
 
-(#853) ([RK-327](https://tickets.puppetlabs.com/browse/RK-327) Uninitialized Constant Cri::Error
-  When resolving the Cri dependency >= 2.13 R10K would fail with an
-  uninitialized constant error. Thanks to @ostavnaas for the bug report,
-  @ddfreyne for the fix, and @baurmatt for the review.
+  - (#853) ([RK-327](https://tickets.puppetlabs.com/browse/RK-327) Uninitialized Constant Cri::Error
+    When resolving the Cri dependency >= 2.13 R10K would fail with an
+    uninitialized constant error. Thanks to @ostavnaas for the bug report,
+    @ddfreyne for the fix, and @baurmatt for the review.
 
 
 3.0.0
 ----
 
-## Changes
+### Changes
 
-### Known issues
+#### Known issues
   - Child processes may die unexpectedly when deploying many environments
     on Ubuntu Bionic. See
     [RK-324](https://tickets.puppetlabs.com/browse/RK-324).
 
-### Backwards breaking changes
+#### Backwards breaking changes
   - Drop support for Ruby < 2.0
   - Remove support for PUPPETFILE and PUPPETFILE_DIR environment variables
     when running the `puppetfile` action, please use flags instead.
   - Fail when duplicate module definitions in Puppetfile
 
-### Bug fixes
+#### Bug fixes
   - More reliable pruning of refs on fetch
   - Improved error messaging when:
     - Unable to connect to a proxy
@@ -65,28 +65,29 @@ Ruby >= 2.3 official and documented.
 2.6.6
 ----
 
-## Changes
- - Flag for overriding default branch configuration in Puppetfile
- - Plumbing for internationalization
- - Numerous test fixes and legacy docker work
+### Changes
+  - Flag for overriding default branch configuration in Puppetfile
+  - Plumbing for internationalization
+  - Numerous test fixes and legacy docker work
 
 2.6.5
 ----
 
-## Bug Fix
+### Bug Fix
 
 (RK-324) Fix Ruby pipe bug affecting Ubuntu
 
 2.6.4
 ----
 
-## Changes
+### Changes
 
 Numerous test fixes.
 
 2.6.3
 ----
-## Changes
+
+### Changes
 
 Update specs with new error string.
 
@@ -95,6 +96,7 @@ when a release is made on that branch.
 
 2.6.2
 -----
+
 ### Changes
 
 (RK-311) Yard dependency updated for security fix.

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,5 +1,15 @@
 CHANGELOG
 =========
+
+2.6.6
+----
+
+## Changes
+
+ - Flag for overriding default branch configuration in Puppetfile
+ - Plumbing for internationalization
+ - Numerous test fixes and legacy docker work
+
 2.6.5
 ----
 

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -1,3 +1,3 @@
 module R10K
-  VERSION = '2.6.5'
+  VERSION = '2.6.6'
 end


### PR DESCRIPTION
Includes:

```
(maint) Merge branch '2.6.x' into '3.0.x'

Conflicts:
  - .travis.yml
  - CHANGELOG.mkd
  - integration/Gemfile
  - integration/pre-suite/00_pe_install.rb
  - lib/r10k/version.rb
```