### PR TITLE
(maint) Merge up 3.2.x & update changelog for new work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 ---
 language: ruby
-services:
-  - docker
 bundler_args: "--without system"
 script: "bundle exec rspec --color --format documentation spec/unit"
 notifications:
@@ -20,7 +18,3 @@ matrix:
       rvm: 2.3.0
     - stage: r10k tests
       rvm: jruby
-    - stage: r10k container tests
-      language: generic
-      script:
-        - cd docker && make lint && make build && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   email: false
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install: gem install bundler -v '< 2' --no-document
 matrix:
   include:

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,38 +1,46 @@
 CHANGELOG
 =========
 
+3.2.1
+----
+
+### Changes
+ - Flag for overriding default branch configuration in Puppetfile
+ - Plumbing for internationalization
+ - Numerous test fixes and legacy docker work
+
 3.2.0
 -----
 
-## New Feature
+### Changes
 
-Add support for running `puppet generate types`
+  - Add support for running `puppet generate types`
 
 3.1.1
 -----
 
-## Bug Fixes
+### Changes
 
-(RK-335) Postrun `modifiedenvs` doesn't include environment prefixes
+  - (RK-335) Postrun `modifiedenvs` doesn't include environment prefixes
 
 3.1.0
 -----
 
-## New Feature
+### Changes
 
-Substitute environments acted on in postrun command.
+  - Substitute environments acted on in postrun command.
 
-Now post run commands that contain the string "$modifiedenvs"
-(eg. ["/usr/local/bin/my-postrun-cmd", "--verbose", "$modifiedenvs"])
-will have the string substituted with a space separated list
-of environments acted upon (either a single environment if
-specified on the command line or all environments).
+    Now post run commands that contain the string "$modifiedenvs"
+    (eg. ["/usr/local/bin/my-postrun-cmd", "--verbose", "$modifiedenvs"])
+    will have the string substituted with a space separated list
+    of environments acted upon (either a single environment if
+    specified on the command line or all environments).
 
-Specifically this should allow users to easily wrap
-`puppet generate types` and matches the terminology used
-in g10k.
+    Specifically this should allow users to easily wrap
+    `puppet generate types` and matches the terminology used
+    in g10k.
 
-Many thanks to @raphink for the contribution.
+    Many thanks to @raphink for the contribution.
 
 3.0.4
 ----

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+3.0.4
+----
+
+## Changes
+ - Flag for overriding default branch configuration in Puppetfile
+ - Plumbing for internationalization
+ - Numerous test fixes and legacy docker work
+
 3.0.3
 ----
 

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,7 @@ CHANGELOG
 3.0.4
 ----
 
-## Changes
+### Changes
  - Flag for overriding default branch configuration in Puppetfile
  - Plumbing for internationalization
  - Numerous test fixes and legacy docker work
@@ -12,49 +12,49 @@ CHANGELOG
 3.0.3
 ----
 
-## Bug Fixes
+### Changes
 
-(RK-324) Fix Ruby pipe bug affecting Ubuntu
+  - (RK-324) Fix Ruby pipe bug affecting Ubuntu
 
 3.0.2
 ----
 
-## Changes
+### Changes
 
-Minor test fixes.
+  - Minor test fixes.
 
 3.0.1
-=======
+----
 
-## Changes
+### Changes
 
 Because of dependency issues R10K 3.0.0 required Ruby >= 2.3
 rather than the reported 2.0. This release makes the requirement of
 Ruby >= 2.3 official and documented.
 
-(#853) ([RK-327](https://tickets.puppetlabs.com/browse/RK-327) Uninitialized Constant Cri::Error
-  When resolving the Cri dependency >= 2.13 R10K would fail with an
-  uninitialized constant error. Thanks to @ostavnaas for the bug report,
-  @ddfreyne for the fix, and @baurmatt for the review.
+  - (#853) ([RK-327](https://tickets.puppetlabs.com/browse/RK-327) Uninitialized Constant Cri::Error
+    When resolving the Cri dependency >= 2.13 R10K would fail with an
+    uninitialized constant error. Thanks to @ostavnaas for the bug report,
+    @ddfreyne for the fix, and @baurmatt for the review.
 
 
 3.0.0
 ----
 
-## Changes
+### Changes
 
-### Known issues
+#### Known issues
   - Child processes may die unexpectedly when deploying many environments
     on Ubuntu Bionic. See
     [RK-324](https://tickets.puppetlabs.com/browse/RK-324).
 
-### Backwards breaking changes
+#### Backwards breaking changes
   - Drop support for Ruby < 2.0
   - Remove support for PUPPETFILE and PUPPETFILE_DIR environment variables
     when running the `puppetfile` action, please use flags instead.
   - Fail when duplicate module definitions in Puppetfile
 
-### Bug fixes
+#### Bug fixes
   - More reliable pruning of refs on fetch
   - Improved error messaging when:
     - Unable to connect to a proxy
@@ -65,28 +65,29 @@ Ruby >= 2.3 official and documented.
 2.6.6
 ----
 
-## Changes
- - Flag for overriding default branch configuration in Puppetfile
- - Plumbing for internationalization
- - Numerous test fixes and legacy docker work
+### Changes
+  - Flag for overriding default branch configuration in Puppetfile
+  - Plumbing for internationalization
+  - Numerous test fixes and legacy docker work
 
 2.6.5
 ----
 
-## Bug Fix
+### Bug Fix
 
 (RK-324) Fix Ruby pipe bug affecting Ubuntu
 
 2.6.4
 ----
 
-## Changes
+### Changes
 
 Numerous test fixes.
 
 2.6.3
 ----
-## Changes
+
+### Changes
 
 Update specs with new error string.
 
@@ -95,6 +96,7 @@ when a release is made on that branch.
 
 2.6.2
 -----
+
 ### Changes
 
 (RK-311) Yard dependency updated for security fix.

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,5 +1,15 @@
 CHANGELOG
 =========
+
+2.6.6
+----
+
+## Changes
+
+ - Flag for overriding default branch configuration in Puppetfile
+ - Plumbing for internationalization
+ - Numerous test fixes and legacy docker work
+
 2.6.5
 ----
 

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,17 +1,27 @@
 CHANGELOG
 =========
 
+3.3.1
+----
+
+### Changes
+ - Assorted threadpool fixes
+ - Flag for overriding default branch configuration in Puppetfile
+ - Plumbing for internationalization
+ - Numerous test fixes and legacy docker work
+
 3.3.0
 -----
 
-## New Feature
+### Changes
+#### New Feature
 
-Adds support for installing modules concurrently
+  - Adds support for installing modules concurrently
 
-## Bug Fixes
+#### Bug Fixes
 
-(RK-343) Pins CRI dependency to 2.15.6 to resolve regression in options
-parsing.
+  - (RK-343) Pins CRI dependency to 2.15.6 to resolve regression in options
+    parsing.
 
 3.2.1
 ----

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -1,3 +1,3 @@
 module R10K
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -1,3 +1,3 @@
 module R10K
-  VERSION = '2.6.5'
+  VERSION = '2.6.6'
 end

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -1,3 +1,3 @@
 module R10K
-  VERSION = '3.0.3'
+  VERSION = '3.0.4'
 end


### PR DESCRIPTION
From the merge up:
```
Conflicts:
  - .travis.yml
  - CHANGELOG.mkd
  - lib/r10k/version.rb
```