### PR TITLE
(RK-340) Prefer SHA256 checksum for verifying modules

### DIFF
--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -111,6 +111,7 @@ module R10K
       # module release checksum given by the Puppet Forge. On mismatch, remove
       # the cached copy.
       #
+      # @raise [R10K::Error] when no SHA256 is available and FIPS mode is on
       # @return [void]
       def verify
         logger.debug1 "Verifying that #{@tarball_cache_path} matches checksum"
@@ -118,105 +119,71 @@ module R10K
         sha256_of_tarball = Digest::SHA256.file(@tarball_cache_path).hexdigest
 
         if @sha256_file_path.exist?
-          verify_from_sha256_file(sha256_of_tarball)
+          verify_from_file(sha256_of_tarball, @sha256_file_path)
         else
-          begin
-            verify_sha256_from_forge(sha256_of_tarball)
-          rescue R10K::Error
+          forge_256_checksum = @forge_release.file_sha256
+          if forge_256_checksum
+            verify_from_forge(sha256_of_tarball, forge_256_checksum, @sha256_file_path)
+          else
             if R10K::Util::Platform.fips?
               raise R10K::Error, "Could not verify module, no SHA256 checksum available, and MD5 checksums not allowed in FIPS mode"
             end
 
             logger.debug1 "No SHA256 checksum available, falling back to MD5"
-
             md5_of_tarball = Digest::MD5.file(@tarball_cache_path).hexdigest
-
             if @md5_file_path.exist?
-              verify_from_md5_file(md5_of_tarball)
+              verify_from_file(md5_of_tarball, @md5_file_path)
             else
-              verify_md5_from_forge(md5_of_tarball)
+              verify_from_forge(md5_of_tarball, @forge_release.file_md5, @md5_file_path)
             end
           end
         end
       end
 
-      # Verify the SHA256 of the cached tarball against the
+      # Verify the checksum of the cached tarball against the
       # module release checksum stored in the cache as well.
       # On mismatch, remove the cached copy of both files.
+      # @param tarball_checksum [String] the checksum (either md5 or SHA256)
+      #                         of the downloaded module tarball
+      # @param file [Pathname] the file containing the checksum as downloaded
+      #             previously from the forge
+      # @param digest_class [Digest::SHA256, Digest::MD5] which checksum type
+      #                     to verify with
       #
       # @raise [PuppetForge::V3::Release::ChecksumMismatch] The
       #   cached module release checksum doesn't match the cached checksum.
       #
       # @return [void]
-      def verify_from_sha256_file(sha256_of_tarball)
-        sha256_from_file = File.read(@sha256_file_path).strip
-        if sha256_of_tarball != sha256_from_file
-          logger.error "SHA256 of #{@tarball_cache_path} (#{sha256_of_tarball}) does not match checksum #{sha256_from_file} in #{@sha256_file_path}. Removing both files."
-          cleanup_cached_tarball_path
-          cleanup_sha256_file_path
+      def verify_from_file(tarball_checksum, checksum_file_path)
+        checksum_from_file = File.read(checksum_file_path).strip
+        if tarball_checksum != checksum_from_file
+          logger.error "Checksum of #{@tarball_cache_path} (#{tarball_checksum}) does not match checksum #{checksum_from_file} in #{checksum_file_path}. Removing both files."
+          @tarball_cache_path.delete
+          checksum_file_path.delete
           raise PuppetForge::V3::Release::ChecksumMismatch.new
         end
       end
 
-      # Verify the sha256 of the cached tarball against the
+      # Verify the checksum of the cached tarball against the
       # module release checksum from the forge.
       # On mismatch, remove the cached copy of the tarball.
+      # @param tarball_checksum [String] the checksum (either md5 or SHA256)
+      #                         of the downloaded module tarball
+      # @param forge_checksum [String] the checksum downloaded from the Forge
+      # @param checksum_file_path [Pathname] the path to write the verified
+      #                            checksum to
       #
       # @raise [PuppetForge::V3::Release::ChecksumMismatch] The
       #   cached module release checksum doesn't match the forge checksum.
       #
       # @return [void]
-      def verify_sha256_from_forge(sha256_of_tarball)
-        if !@forge_release.file_sha256.nil?
-          sha256_from_forge = @forge_release.file_sha256
-        else
-          raise R10K::Error, "No SHA256 checksum available"
-        end
-
-        if sha256_of_tarball != sha256_from_forge
-          logger.debug1 "SHA256 of #{@tarball_cache_path} (#{sha256_of_tarball}) does not match checksum #{sha256_from_forge} found on the forge. Removing tarball."
-          cleanup_cached_tarball_path
+      def verify_from_forge(tarball_checksum, forge_checksum, checksum_file_path)
+        if tarball_checksum != forge_checksum
+          logger.debug1 "Checksum of #{@tarball_cache_path} (#{tarball_checksum}) does not match checksum #{forge_checksum} found on the forge. Removing tarball."
+          @tarball_cache_path.delete
           raise PuppetForge::V3::Release::ChecksumMismatch.new
         else
-          File.write(@sha256_file_path, sha256_from_forge)
-        end
-      end
-
-      # Verify the md5 of the cached tarball against the
-      # module release checksum stored in the cache as well.
-      # On mismatch, remove the cached copy of both files.
-      #
-      # @raise [PuppetForge::V3::Release::ChecksumMismatch] The
-      #   cached module release checksum doesn't match the cached checksum.
-      #
-      # @return [void]
-      def verify_from_md5_file(md5_of_tarball)
-        md5_from_file = File.read(@md5_file_path).strip
-        if md5_of_tarball != md5_from_file
-          logger.error "MD5 of #{@tarball_cache_path} (#{md5_of_tarball}) does not match checksum #{md5_from_file} in #{@md5_file_path}. Removing both files."
-          cleanup_cached_tarball_path
-          cleanup_md5_file_path
-          raise PuppetForge::V3::Release::ChecksumMismatch.new
-        end
-      end
-
-      # Verify the md5 of the cached tarball against the
-      # module release checksum from the forge.
-      # On mismatch, remove the cached copy of the tarball.
-      #
-      # @raise [PuppetForge::V3::Release::ChecksumMismatch] The
-      #   cached module release checksum doesn't match the forge checksum.
-      #
-      # @return [void]
-      def verify_md5_from_forge(md5_of_tarball)
-        md5_from_forge = @forge_release.file_md5
-        #compare file_md5 to md5_of_tarball
-        if md5_of_tarball != md5_from_forge
-          logger.debug1 "MD5 of #{@tarball_cache_path} (#{md5_of_tarball}) does not match checksum #{md5_from_forge} found on the forge. Removing tarball."
-          cleanup_cached_tarball_path
-          raise PuppetForge::V3::Release::ChecksumMismatch.new
-        else
-          File.write(@md5_file_path, md5_from_forge)
+          File.write(checksum_file_path, forge_checksum)
         end
       end
 
@@ -254,27 +221,6 @@ module R10K
       def cleanup_download_path
         if download_path.exist?
           download_path.parent.rmtree
-        end
-      end
-
-      # Remove the cached module release.
-      def cleanup_cached_tarball_path
-        if tarball_cache_path.exist?
-          tarball_cache_path.delete
-        end
-      end
-
-      # Remove the module release md5.
-      def cleanup_md5_file_path
-        if md5_file_path.exist?
-          md5_file_path.delete
-        end
-      end
-
-      # Remove the module release sha256.
-      def cleanup_sha256_file_path
-        if sha256_file_path.exist?
-          sha256_file_path.delete
         end
       end
     end

--- a/lib/r10k/util/platform.rb
+++ b/lib/r10k/util/platform.rb
@@ -3,6 +3,8 @@ require 'rbconfig'
 module R10K
   module Util
     module Platform
+      FIPS_FILE = "/proc/sys/crypto/fips_enabled"
+
       def self.platform
         # Test JRuby first to handle JRuby on Windows as well.
         if self.jruby?
@@ -11,6 +13,16 @@ module R10K
           :windows
         else
           :posix
+        end
+      end
+
+      # We currently only suport FIPS mode on redhat 7, where it is
+      # toggled via a file.
+      def self.fips?
+        if File.exist?(FIPS_FILE)
+          File.read(FIPS_FILE).chomp == "1"
+        else
+          false
         end
       end
 

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -7,6 +7,7 @@ describe R10K::Forge::ModuleRelease do
   subject { described_class.new('branan-eight_hundred', '8.0.0') }
 
   let(:forge_release_class) { PuppetForge::V3::Release }
+  let(:sha256_digest_class) { Digest::SHA256 }
   let(:md5_digest_class) { Digest::MD5 }
 
   let(:download_path) { instance_double('Pathname') }
@@ -14,14 +15,21 @@ describe R10K::Forge::ModuleRelease do
   let(:tarball_cache_root) { instance_double('Pathname') }
   let(:unpack_path) { instance_double('Pathname') }
   let(:target_dir) { instance_double('Pathname') }
+  let(:tarball_cache_path) { instance_double('Pathname') }
   let(:md5_file_path) { instance_double('Pathname') }
+  let(:sha256_file_path) { instance_double('Pathname') }
 
   let(:file_lists) { {:valid=>['valid_ex'], :invalid=>[], :symlinks=>['symlink_ex']} }
 
   let(:file_contents) { "skeletor's closet" }
-  let(:md5_of_tarball) { "something_hexy" }
+  let(:sha256_digest) { instance_double('Digest::SHA256') }
+  let(:sha256_of_tarball) { "sha256_hash" }
+  let(:md5_digest) { instance_double('Digest::MD5') }
+  let(:md5_of_tarball) { "md5_hash" }
   let(:good_md5) { md5_of_tarball }
-  let(:bad_md5) { "different_hexy_thing" }
+  let(:good_sha256) { sha256_of_tarball }
+  let(:bad_sha256) { "bad_sha256_hash" }
+  let(:bad_md5) { "bad_md5_hash" }
 
   before do
     subject.download_path = download_path
@@ -29,6 +37,7 @@ describe R10K::Forge::ModuleRelease do
     subject.tarball_cache_root = tarball_cache_root
     subject.unpack_path = unpack_path
     subject.md5_file_path = md5_file_path
+    subject.sha256_file_path = sha256_file_path
   end
 
   context "no cached tarball" do
@@ -55,20 +64,71 @@ describe R10K::Forge::ModuleRelease do
 
   describe '#verify' do
 
-    it "verifies using the file md5, if that exists" do
-      allow(File).to receive(:read).and_return(file_contents)
-      allow(md5_digest_class).to receive(:hexdigest).and_return(md5_of_tarball)
-      allow(md5_file_path).to receive(:exist?).and_return(true)
-      expect(subject).to receive(:verify_from_md5_file).with(md5_of_tarball)
+    it "verifies using the file SHA256, if that exists" do
+      allow(sha256_digest_class).to receive(:file).and_return(sha256_digest)
+      allow(sha256_digest).to receive(:hexdigest).and_return(sha256_of_tarball)
+      allow(sha256_file_path).to receive(:exist?).and_return(true)
+      expect(subject).to receive(:verify_from_sha256_file).with(sha256_of_tarball)
       subject.verify
     end
 
-    it "verifies using the forge file_md5, if no md5 file exists" do
-      allow(File).to receive(:read).and_return(file_contents)
-      allow(md5_digest_class).to receive(:hexdigest).and_return(md5_of_tarball)
-      allow(md5_file_path).to receive(:exist?).and_return(false)
-      expect(subject).to receive(:verify_from_forge).with(md5_of_tarball)
+    it "verifies using the forge file_sha256, if no sha256 file exists" do
+      allow(sha256_digest_class).to receive(:file).and_return(sha256_digest)
+      allow(sha256_digest).to receive(:hexdigest).and_return(sha256_of_tarball)
+      allow(sha256_file_path).to receive(:exist?).and_return(false)
+      expect(subject).to receive(:verify_sha256_from_forge).with(sha256_of_tarball)
       subject.verify
+    end
+
+    it "falls back to md5 verification when not in FIPS mode and no sha256 available" do
+      expect(R10K::Util::Platform).to receive(:fips?).and_return(false)
+      # failed sha256 verification
+      allow(sha256_digest_class).to receive(:file).and_return(sha256_digest)
+      allow(sha256_digest).to receive(:hexdigest).and_return(sha256_of_tarball)
+      allow(sha256_file_path).to receive(:exist?).and_return(false)
+      allow(subject).to receive(:verify_sha256_from_forge).with(sha256_of_tarball).and_raise(R10K::Error.new("no sha256"))
+      # md5 verification
+      allow(md5_digest_class).to receive(:file).and_return(md5_digest)
+      allow(md5_digest).to receive(:hexdigest).and_return(md5_of_tarball)
+      allow(md5_file_path).to receive(:exist?).and_return(true)
+      expect(subject).to receive(:verify_from_md5_file)
+      subject.verify
+    end
+  end
+
+  describe '#verify_from_sha256_file' do
+
+    it "does nothing when the checksums match" do
+      expect(File).to receive(:read).with(sha256_file_path).and_return(good_sha256)
+      expect(subject).not_to receive(:cleanup_cached_tarball_path)
+      subject.verify_from_sha256_file(sha256_of_tarball)
+    end
+
+    it "raises an error and cleans up when the checksums do not match" do
+      expect(File).to receive(:read).with(sha256_file_path).and_return(bad_sha256)
+      expect(subject).to receive(:cleanup_cached_tarball_path)
+      expect(subject).to receive(:cleanup_sha256_file_path)
+      expect { subject.verify_from_sha256_file(sha256_of_tarball) }.to raise_error(PuppetForge::V3::Release::ChecksumMismatch)
+    end
+  end
+
+  describe '#verify_sha256_from_forge' do
+    it "write the sha256 to file when the checksums match" do
+      expect(subject.forge_release).to receive(:file_sha256).twice.and_return(good_sha256)
+      expect(subject).not_to receive(:cleanup_cached_tarball_path)
+      expect(File).to receive(:write).with(sha256_file_path, good_sha256)
+      subject.verify_sha256_from_forge(sha256_of_tarball)
+    end
+
+    it "raises an error and cleans up when the checksums do not match" do
+      expect(subject.forge_release).to receive(:file_sha256).twice.and_return(bad_sha256)
+      expect(subject).to receive(:cleanup_cached_tarball_path)
+      expect { subject.verify_sha256_from_forge(sha256_of_tarball) }.to raise_error(PuppetForge::V3::Release::ChecksumMismatch)
+    end
+
+    it "raises and error when the forge release does contain a SHA256 checksum" do
+      expect(subject.forge_release).to receive(:file_sha256).and_return(nil)
+      expect { subject.verify_sha256_from_forge(sha256_of_tarball) }.to raise_error(R10K::Error)
     end
   end
 
@@ -88,18 +148,18 @@ describe R10K::Forge::ModuleRelease do
     end
   end
 
-  describe '#verify_from_forge' do
+  describe '#verify_md5_from_forge' do
     it "write the md5 to file when the checksums match" do
       expect(subject.forge_release).to receive(:file_md5).and_return(good_md5)
       expect(subject).not_to receive(:cleanup_cached_tarball_path)
       expect(File).to receive(:write).with(md5_file_path, good_md5)
-      subject.verify_from_forge(md5_of_tarball)
+      subject.verify_md5_from_forge(md5_of_tarball)
     end
 
     it "raises an error and cleans up when the checksums do not match" do
       expect(subject.forge_release).to receive(:file_md5).and_return(bad_md5)
       expect(subject).to receive(:cleanup_cached_tarball_path)
-      expect { subject.verify_from_forge(md5_of_tarball) }.to raise_error(PuppetForge::V3::Release::ChecksumMismatch)
+      expect { subject.verify_md5_from_forge(md5_of_tarball) }.to raise_error(PuppetForge::V3::Release::ChecksumMismatch)
     end
   end
 


### PR DESCRIPTION
FIPS mode does not allow md5 to be used, to this updates r10k to always prefer using SHA256 when verifying modules. If the Forge does not have SHA256 data and FIPS mode is not enabled, it will fall back to verifying with md5. If FIPS mode is enabled, it will error.