### PR TITLE
(maint) Consistently compare values to nil

### DIFF
--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -44,7 +44,7 @@ module R10K
 
         overrides = {}
         overrides[:cachedir] = @opts[:cachedir] unless @opts[:cachedir].nil?
-        overrides[:deploy] = {} if @opts[:'puppet-path'] || @opts[:'generate-types']
+        overrides[:deploy] = {} if !@opts[:'puppet-path'].nil? || !@opts[:'generate-types'].nil?
         overrides[:deploy][:puppet_path] = @opts[:'puppet-path'] unless @opts[:'puppet-path'].nil?
         overrides[:deploy][:generate_types] = @opts[:'generate-types'] unless @opts[:'generate-types'].nil?
 


### PR DESCRIPTION
`overrides[:deploy]` is initialized as an empty Hash if any of _puppet-path_ and _generate-types_ is set.

`overrides[:deploy][:puppet_path]` and `overrides[:deploy][:generate_types]` are respectively set when _puppet-path_ and _generate-types_ are non-nil.

`false` being not nil, when _generate-types_ is set to `false`, `overrides[:deploy]` will not be initialized and an excpetion will be raised when setting `overrides[:deploy][:generate_types]` to false.

Always compare values to nil to avoid such a situation.