### PR TITLE
(maint) Update Docker shared helper usage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ steps:
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -Context .
+    Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -PathOrUri .
   displayName: Build $(CONTAINER_NAME) Container
   name: build_container
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,6 @@ steps:
     testRunTitle: r10k Test Results
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Clear-ContainerBuilds -Name r10k -Namespace $ENV:NAMESPACE
+    Clear-BuildState -Name r10k -Namespace $ENV:NAMESPACE
   displayName: Container Cleanup
   condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ variables:
 steps:
 - checkout: self
   clean: true
+
 - powershell: |
     $gemfile = Join-Path -Path (Get-Location) -ChildPath 'docker/Gemfile'
     $gempath = Join-Path -Path (Get-Location) -ChildPath 'docker/.bundle/gems'
@@ -28,32 +29,38 @@ steps:
     bundle install
   displayName: Fetch Dependencies
   name: fetch_deps
+
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Write-HostDiagnostics
   displayName: Diagnostic Host Information
   name: hostinfo
+
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Lint-Dockerfile -Name $ENV:CONTAINER_NAME -Ignore @('DL3028')
   displayName: Lint $(CONTAINER_NAME) Dockerfile
   name: lint_dockerfile
+
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -Context .
   displayName: Build $(CONTAINER_NAME) Container
   name: build_container
+
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Invoke-ContainerTest -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE
   displayName: Test $(CONTAINER_NAME)
   name: test_container
+
 - task: PublishTestResults@2
   displayName: Publish $(CONTAINER_NAME) test results
   inputs:
     testResultsFormat: 'JUnit'
     testResultsFiles: 'docker/TEST-*.xml'
     testRunTitle: $(CONTAINER_NAME) Test Results
+
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
     Clear-BuildState -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ pool:
 
 variables:
   NAMESPACE: puppet
+  CONTAINER_NAME: r10k
 
 steps:
 - checkout: self
@@ -34,27 +35,27 @@ steps:
   name: hostinfo
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Lint-Dockerfile -Name r10k -Ignore @('DL3028')
-  displayName: Lint r10k Dockerfile
+    Lint-Dockerfile -Name $ENV:CONTAINER_NAME -Ignore @('DL3028')
+  displayName: Lint $(CONTAINER_NAME) Dockerfile
   name: lint_dockerfile
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Build-Container -Name r10k -Namespace $ENV:NAMESPACE -Context .
-  displayName: Build r10k Container
-  name: build_r10k_container
+    Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -Context .
+  displayName: Build $(CONTAINER_NAME) Container
+  name: build_container
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Invoke-ContainerTest -Name r10k -Namespace $ENV:NAMESPACE
-  displayName: Test r10k
-  name: test_r10k
+    Invoke-ContainerTest -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE
+  displayName: Test $(CONTAINER_NAME)
+  name: test_container
 - task: PublishTestResults@2
-  displayName: Publish r10k test results
+  displayName: Publish $(CONTAINER_NAME) test results
   inputs:
     testResultsFormat: 'JUnit'
     testResultsFiles: 'docker/TEST-*.xml'
-    testRunTitle: r10k Test Results
+    testRunTitle: $(CONTAINER_NAME) Test Results
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Clear-BuildState -Name r10k -Namespace $ENV:NAMESPACE
+    Clear-BuildState -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE
   displayName: Container Cleanup
   condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,9 @@ pr:
     - '*'
 
 pool:
-  # self-hosted agent on Windows 10 1709 environment
+  # self-hosted agent on Windows 10 1903 environment
   # includes newer Docker engine with LCOW enabled, new build of LCOW image
-  # includes Ruby 2.5, Go 1.10, Node.js 10.10, hadolint
+  # includes Ruby 2.5, Go 1.10, Node.js 10.10
   name: Default
 
 variables:
@@ -18,8 +18,8 @@ variables:
   CONTAINER_NAME: r10k
 
 steps:
-- checkout: self
-  clean: true
+- checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+  clean: true  # whether to fetch clean each time
 
 - powershell: |
     $gemfile = Join-Path -Path (Get-Location) -ChildPath 'docker/Gemfile'
@@ -47,6 +47,12 @@ steps:
     Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -Context .
   displayName: Build $(CONTAINER_NAME) Container
   name: build_container
+
+- powershell: |
+    . "$(bundle show pupperware)/ci/build.ps1"
+    Initialize-TestEnv
+  displayName: Prepare Test Environment
+  name: test_prepare
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"


### PR DESCRIPTION
(maint) Use Clear-BuildState Azure pipeline helper

 - This is a refactored / updated version of Clear-ContainerBuilds
 
(maint) Parameterize Azure YML with CONTAINER_NAME

 - Make azure-pipelines.yml easier to copy / paste
 
(maint) Azure pipelines YML whitespace

 - Minor updates for readability
 
(maint) Make azure-pipelines.yml consistent

 - With the universal definition
 
(maint) Use updated Build-Container parameter name

  - This aligns with the Docker param naming