### PR TITLE
(RK-340) Check that the forge_release object has SHA256 file

### DIFF
--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -121,8 +121,8 @@ module R10K
         if @sha256_file_path.exist?
           verify_from_file(sha256_of_tarball, @sha256_file_path)
         else
-          forge_256_checksum = @forge_release.file_sha256
-          if forge_256_checksum
+          if @forge_release.respond_to?(:file_sha256) && !@forge_release.file_sha256.nil? && !@forge_release.file_sha256.size.zero?
+            forge_256_checksum = @forge_release.file_sha256
             verify_from_forge(sha256_of_tarball, forge_256_checksum, @sha256_file_path)
           else
             if R10K::Util::Platform.fips?

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -76,6 +76,7 @@ describe R10K::Forge::ModuleRelease do
       allow(sha256_digest_class).to receive(:file).and_return(sha256_digest)
       allow(sha256_digest).to receive(:hexdigest).and_return(sha256_of_tarball)
       allow(sha256_file_path).to receive(:exist?).and_return(false)
+      allow(subject.forge_release).to receive(:respond_to?).and_return(true)
       allow(subject.forge_release).to receive(:sha256_file).and_return(sha256_of_tarball)
       expect(subject).to receive(:verify_from_forge)
       subject.verify
@@ -87,7 +88,7 @@ describe R10K::Forge::ModuleRelease do
       allow(sha256_digest_class).to receive(:file).and_return(sha256_digest)
       allow(sha256_digest).to receive(:hexdigest).and_return(sha256_of_tarball)
       allow(sha256_file_path).to receive(:exist?).and_return(false)
-      allow(subject.forge_release).to receive(:file_sha256).and_return(nil)
+      allow(subject.forge_release).to receive(:respond_to?).and_return(false)
       allow(subject).to receive(:verify_from_forge)
       # md5 verification
       allow(md5_digest_class).to receive(:file).and_return(md5_digest)
@@ -102,7 +103,7 @@ describe R10K::Forge::ModuleRelease do
       allow(sha256_digest_class).to receive(:file).and_return(sha256_digest)
       allow(sha256_digest).to receive(:hexdigest).and_return(sha256_of_tarball)
       allow(sha256_file_path).to receive(:exist?).and_return(false)
-      allow(subject.forge_release).to receive(:file_sha256).and_return(nil)
+      allow(subject.forge_release).to receive(:respond_to?).and_return(false)
       allow(subject).to receive(:verify_from_forge)
       expect { subject.verify }.to raise_error(R10K::Error)
     end


### PR DESCRIPTION
Previously, we were only verifying that the Forge Release object did not
return nil from its `file_sha256` method. But actually, this method is
not even defined if the module does not provide a SHA256 checksum. So this
commit updates the verify logic to also check that the `file_sha256`
method exists.