### PR TITLE
(maint) Clear Azure source directory on builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,9 @@ variables:
   CONTAINER_BUILD_PATH: .
   LINT_IGNORES: DL3008 DL3018 DL4000 DL4001 DL3028
 
+workspace:
+  clean: resources
+
 steps:
 - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
   clean: true  # whether to fetch clean each time


### PR DESCRIPTION
 - Occasionally files intended to live in containers get written on
   Windows with the wrong line endings. Linux containers need LF line
   endings for executable scripts and config files (for instance), but
   the default checkout on Windows is CRLF, unless explicitly configured
   to be different.

   Unfortunately a subsequent pull of the code will not reset local
   line endings on Windows, even when .gitattributes is set properly.

   This typically results in RDPing into an Azure DevOps builder and
   manually trashing the source code, so that when the code is next
   checked out, the appropriate LF line endings will be set.

   Instead of doing that, have the `s` (source) subdirectory purged
   on each build.

   https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#job