### PR TITLE
(RK-351) Update minitar to at least 0.9.0

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
 
   s.add_development_dependency 'yard', '~> 0.9.11'
-  s.add_development_dependency 'minitar', '~> 0.6.1'
+  s.add_development_dependency 'minitar', '~> 0.9.0'
 
   s.files        = %x[git ls-files].split($/)
   s.require_path = 'lib'


### PR DESCRIPTION
Puppet recently updated its version of minitar to take advantage of a
new options hash. Although r10k does not need this feature directly,
updating here too resolves some packaging issues.