### PR TITLE
(maint) Make sure Docker test bundle is fresh

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -41,6 +41,7 @@ endif
 
 test: prep
 	@bundle install --path $$BUNDLE_PATH --gemfile $$GEMFILE
+	@bundle update
 	@PUPPET_TEST_DOCKER_IMAGE=$(NAMESPACE)/r10k:$(version) \
 		bundle exec --gemfile $$GEMFILE \
 		rspec spec


### PR DESCRIPTION
 - Need a bundle update to be able to pull the pupperware spec_helper
   (this primarily impacts local dev)