### PR TITLE
(maint) Emit docker build command line

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -27,7 +27,7 @@ else
 endif
 
 build: prep
-	@docker build \
+	docker build \
 		--pull \
 		--build-arg vcs_ref=$(vcs_ref) \
 		--build-arg build_date=$(build_date) \


### PR DESCRIPTION
Verified Travis

> docker build \
>	--pull \
>	--build-arg vcs_ref=fd59ee1ad9867e5e0a8dfbcb7c81e7849abec9a0 \
>	--build-arg build_date=2019-10-27T03:47:30 \
>	--build-arg version=3.3.3 \
>	--build-arg pupperware_analytics_stream=dev \
>	--file r10k/Dockerfile \
>	--tag puppet/r10k:3.3.3 /home/travis/build/puppetlabs/r10k/docker/..

And Azure

> docker build --build-arg version=3.3.3 --build-arg vcs_ref=fd59ee1ad9867e5e0a8dfbcb7c81e7849abec9a0 --build-arg build_date=--file docker/r10k/Dockerfile --tag puppet/r10k:3.3.3 --pull .
