### PR TITLE
(maint) Run r10k as the `puppet` user

### DIFF
--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -31,6 +31,11 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
+# Add a puppet user to run r10k as for consistency with puppetserver
+COPY docker/r10k/adduser.sh /
+RUN chmod a+x /adduser.sh && \
+    /adduser.sh
+
 RUN apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev
 COPY --from=build /workspace/r10k.gem /
 RUN gem install --no-doc r10k.gem json etc && \
@@ -39,7 +44,10 @@ RUN gem install --no-doc r10k.gem json etc && \
 COPY docker/r10k/docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 COPY docker/r10k/docker-entrypoint.d /docker-entrypoint.d
+RUN chown -R puppet: /docker-entrypoint.d /docker-entrypoint.sh
 
+USER puppet
+WORKDIR /home/puppet
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]
 

--- a/docker/r10k/adduser.sh
+++ b/docker/r10k/adduser.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+getent_string="$(getent group | grep -e ':999$')"
+exit_code=$?
+
+if [ "$exit_code" = '0' ]; then
+  group="$(echo $getent_string | cut -d ':' -f1)"
+else
+  addgroup -g 999 puppet
+  group='puppet'
+fi
+
+adduser -G $group -D -u 999 puppet

--- a/docker/spec/dockerfile_spec.rb
+++ b/docker/spec/dockerfile_spec.rb
@@ -8,9 +8,11 @@ describe 'r10k container' do
   include Pupperware::SpecHelpers
   def run_r10k(command)
     run_command("docker run --detach \
-                   --volume #{File.join(SPEC_DIRECTORY, 'fixtures')}:/test \
+                   --volume #{File.join(SPEC_DIRECTORY, 'fixtures')}:/home/puppet/test \
                    #{@image} #{command} \
-                   --puppetfile /test/Puppetfile")
+                   --verbose \
+                   --trace \
+                   --puppetfile test/Puppetfile")
   end
 
   before(:all) do
@@ -35,7 +37,6 @@ describe 'r10k container' do
     container = result[:stdout].chomp
     wait_on_container_exit(container)
     expect(get_container_exit_code(container)).to eq(0)
-    expect(Dir.exist?(File.join(SPEC_DIRECTORY, 'fixtures', 'modules', 'ntp'))).to eq(true)
     emit_log(container)
     teardown_container(container)
   end

--- a/docker/spec/fixtures/Puppetfile
+++ b/docker/spec/fixtures/Puppetfile
@@ -1,2 +1,2 @@
-moduledir 'test/modules'
+moduledir '/test/modules'
 mod 'puppetlabs/ntp'

--- a/docker/spec/fixtures/Puppetfile
+++ b/docker/spec/fixtures/Puppetfile
@@ -1,2 +1,2 @@
-moduledir '/test/modules'
+moduledir '/tmp/modules'
 mod 'puppetlabs/ntp'


### PR DESCRIPTION
This way permissions won't get weird when r10k and puppetserver are
mounting a shared code volume