### PR TITLE
(maint) Updates for container versioning

### DIFF
--- a/docker/r10k/Dockerfile-release
+++ b/docker/r10k/Dockerfile-release
@@ -1,0 +1,35 @@
+FROM alpine:3.9
+
+ARG vcs_ref
+ARG build_date
+ARG version="3.1.0"
+# Used by entrypoint to submit metrics to Google Analytics.
+# Published images should use "production" for this build_arg.
+ARG pupperware_analytics_stream="dev"
+ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
+
+ENV R10K_VERSION="$version"
+
+LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
+      org.label-schema.url="https://github.com/puppetlabs/r10k" \
+      org.label-schema.name="r10k" \
+      org.label-schema.license="Apache-2.0" \
+      org.label-schema.version="$R10K_VERSION" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/r10k" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.dockerfile="/Dockerfile-release"
+
+RUN apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev
+RUN gem install --no-doc r10k:"$version" json etc
+
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["help"]
+
+COPY Dockerfile-release /


### PR DESCRIPTION
Containers built from source will now be tagged with `edge`, and
containers tagged with a version number will have the published gem
installed.