### PR TITLE
(maint) Reduce 28 Dockerfile build steps to 22

### DIFF
--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.9 as build
 
-RUN apk add --no-cache ruby git
-RUN mkdir /workspace
+RUN apk add --no-cache ruby git && \
+    mkdir /workspace
 WORKDIR /workspace
 COPY . /workspace
 RUN gem build r10k.gemspec && \
@@ -15,38 +15,40 @@ ARG version="3.1.0"
 # Used by entrypoint to submit metrics to Google Analytics.
 # Published images should use "production" for this build_arg.
 ARG pupperware_analytics_stream="dev"
-ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/r10k" \
       org.label-schema.name="r10k" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$version" \
       org.label-schema.vcs-url="https://github.com/puppetlabs/r10k" \
-      org.label-schema.vcs-ref="$vcs_ref" \
-      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/Dockerfile"
 
-# Add a puppet user to run r10k as for consistency with puppetserver
-COPY docker/r10k/adduser.sh /
-RUN chmod a+x /adduser.sh && \
-    /adduser.sh
-
-RUN apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev
-COPY --from=build /workspace/r10k.gem /
-RUN gem install --no-doc r10k.gem json etc && \
-    rm -f r10k.gem
-
-COPY docker/r10k/docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
+COPY docker/r10k/adduser.sh docker/r10k/docker-entrypoint.sh /
 COPY docker/r10k/docker-entrypoint.d /docker-entrypoint.d
-RUN chown -R puppet: /docker-entrypoint.d /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["help"]
+
+# dyanmic LABELs and ENV vars placed lower for the sake of Docker layer caching
+ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
+
+LABEL org.label-schema.version="$version" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date"
+
+COPY --from=build /workspace/r10k.gem /
+RUN chmod a+x /adduser.sh && \
+# Add a puppet user to run r10k as for consistency with puppetserver
+    /adduser.sh && \
+    chmod +x /docker-entrypoint.sh && \
+    chown -R puppet: /docker-entrypoint.d /docker-entrypoint.sh && \
+    apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
+    gem install --no-doc /r10k.gem json etc && \
+    rm -f /r10k.gem
 
 USER puppet
 WORKDIR /home/puppet
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["help"]
 
 COPY docker/r10k/Dockerfile /

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -17,14 +17,12 @@ ARG version="3.1.0"
 ARG pupperware_analytics_stream="dev"
 ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
 
-ENV R10K_VERSION="$version"
-
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/r10k" \
       org.label-schema.name="r10k" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$R10K_VERSION" \
+      org.label-schema.version="$version" \
       org.label-schema.vcs-url="https://github.com/puppetlabs/r10k" \
       org.label-schema.vcs-ref="$vcs_ref" \
       org.label-schema.build-date="$build_date" \

--- a/docker/r10k/docker-entrypoint.d/10-analytics.sh
+++ b/docker/r10k/docker-entrypoint.d/10-analytics.sh
@@ -11,7 +11,7 @@ tid=UA-132486246-5
 # Application Name
 an=r10k
 # Application Version
-av=$R10K_VERSION
+av=$(r10k version | cut -d ' ' -f 2)
 # Anonymous Client ID
 _file=/var/tmp/pwclientid
 cid=$(cat $_file 2>/dev/null || (cat /proc/sys/kernel/random/uuid | tee $_file))

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -8,14 +8,12 @@ ARG version="3.1.0"
 ARG pupperware_analytics_stream="dev"
 ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
 
-ENV R10K_VERSION="$version"
-
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/r10k" \
       org.label-schema.name="r10k" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$R10K_VERSION" \
+      org.label-schema.version="$version" \
       org.label-schema.vcs-url="https://github.com/puppetlabs/r10k" \
       org.label-schema.vcs-ref="$vcs_ref" \
       org.label-schema.build-date="$build_date" \

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -6,28 +6,31 @@ ARG version="3.1.0"
 # Used by entrypoint to submit metrics to Google Analytics.
 # Published images should use "production" for this build_arg.
 ARG pupperware_analytics_stream="dev"
-ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/r10k" \
       org.label-schema.name="r10k" \
       org.label-schema.license="Apache-2.0" \
-      org.label-schema.version="$version" \
       org.label-schema.vcs-url="https://github.com/puppetlabs/r10k" \
-      org.label-schema.vcs-ref="$vcs_ref" \
-      org.label-schema.build-date="$build_date" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/release.Dockerfile"
 
-RUN apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev
-RUN gem install --no-doc r10k:"$version" json etc
-
 COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
 COPY docker-entrypoint.d /docker-entrypoint.d
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]
+
+# dyanmic LABELs and ENV vars placed lower for the sake of Docker layer caching
+ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
+
+LABEL org.label-schema.version="$version" \
+      org.label-schema.vcs-ref="$vcs_ref" \
+      org.label-schema.build-date="$build_date"
+
+RUN chmod +x /docker-entrypoint.sh && \
+    apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
+    gem install --no-doc r10k:"$version" json etc
 
 COPY release.Dockerfile /


### PR DESCRIPTION
 - Collapse Dockerfile commands where applicable. This helps out LCOW,
   which has problems when there are two many virtual hard disks in
   play. It also speeds up the builds by reducing layers.

 - Improve caching, making 16 layers cacheable for subsequent builds.