### PR TITLE
Add yamldir environment source type

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -511,7 +511,7 @@ This will create the following directory structure:
 ```
 
 Experimental Features
---------
+---------------------
 
 ### YAML Environment Source
 
@@ -529,7 +529,6 @@ sources:
     type: yaml
     basedir: /etc/puppetlabs/code/environments
     config: /etc/puppetlabs/r10k/environments.yaml # default
-
 ```
 
 When using the YAML source type, every environment is enumerated in a single yaml file. Each environment specifies a type, source, and version (typically a Git ref) to deploy. In the following example, two environments are defined, which are identical to each other.
@@ -545,6 +544,38 @@ development:
   type: git
   remote: git@github.com:puppetlabs/control-repo.git
   ref: 8820892
+```
+
+### YAMLdir Environment Source
+
+Like the YAML environment source, but implemented as a conf.d pattern.
+
+```yaml
+# r10k.yaml
+---
+sources:
+  puppet:
+    type: yamldir
+    basedir: /etc/puppetlabs/code/environments
+    config: /etc/puppetlabs/r10k/environments.d # default
+```
+
+Each environment is defined in a yaml file placed in the configuration directory. The filename, without the .yaml extension, will be the name of the environment.
+
+```
+/etc/puppetlabs/r10k/environments.d
+├── production.yaml
+└── development.yaml
+```
+
+The contents of the file should be a hash specifying the enviornment type, and all other applicable environment options.
+
+```yaml
+# production.yaml
+---
+type: git
+remote: git@github.com:puppetlabs/control-repo.git
+ref: 8820892
 ```
 
 ### Environment Modules
@@ -578,6 +609,22 @@ development:
     reidmv-xampl:
       git: https://github.com/reidmv/reidmv-xampl.git
       ref: 62d07f2
+```
+
+An example of a single environment definition for the YAMLdir environment source type:
+
+```yaml
+# production.yaml
+---
+type: git
+remote: git@github.com:puppetlabs/control-repo.git
+ref: 8820892
+modules:
+  puppetlabs-stdlib: 6.0.0
+  puppetlabs-concat: 6.1.0
+  reidmv-xampl:
+    git: https://github.com/reidmv/reidmv-xampl.git
+    ref: 62d07f2
 ```
 
 ### Bare Environment Type

--- a/lib/r10k/source.rb
+++ b/lib/r10k/source.rb
@@ -36,5 +36,6 @@ module R10K
     require 'r10k/source/git'
     require 'r10k/source/svn'
     require 'r10k/source/yaml'
+    require 'r10k/source/yamldir'
   end
 end

--- a/lib/r10k/source/yamldir.rb
+++ b/lib/r10k/source/yamldir.rb
@@ -1,0 +1,32 @@
+class R10K::Source::Yamldir < R10K::Source::Hash
+  R10K::Source.register(:yamldir, self)
+
+  def initialize(name, basedir, options = {})
+    config = options[:config] || '/etc/puppetlabs/r10k/environments.d'
+
+    unless File.directory?(config)
+      raise R10K::Deployment::Config::ConfigError, _("Error opening %{dir}: config must be a directory") % {dir: config}
+    end
+
+    unless File.readable?(config)
+      raise R10K::Deployment::Config::ConfigError, _("Error opening %{dir}: permission denied") % {dir: config}
+    end
+
+    environment_data = Dir.glob(File.join(config, '*.yaml')).reduce({}) do |memo,path|
+      name = File.basename(path, '.yaml')
+      begin
+        contents = ::YAML.load_file(path)
+      rescue => e
+        raise R10K::Deployment::Config::ConfigError, _("Error loading %{path}: %{err}") % {path: path, err: e.message}
+      end
+      memo.merge({name => contents })
+    end
+
+    # Set the environments key for the parent class to consume
+    options[:environments] = environment_data
+
+    # All we need to do is supply options with the :environments hash.
+    # The R10K::Source::Hash parent class takes care of the rest.
+    super(name, basedir, options)
+  end
+end


### PR DESCRIPTION
This is an alternative UX to the yaml environment source type, but functionally similar. If it's proven to be a better UX we may abandon the yaml environment source type in favor of yamldir.

Credit to @ekohl for the idea!