### PR TITLE
Run spec tests on Ruby 2.6 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install: gem install bundler -v '< 2' --no-document
 matrix:
   include:
     - stage: r10k tests
+      rvm: 2.6.5
+    - stage: r10k tests
       rvm: 2.5.0
     - stage: r10k tests
       rvm: 2.4.0

--- a/README.mkd
+++ b/README.mkd
@@ -17,7 +17,8 @@ implementation of Puppet [dynamic environments][workflow].
 Requirements
 ------------
 
-R10k supports the Ruby versions `>= 2.3.0`.
+R10k supports the Ruby versions `>= 2.3.0`. It's tested on Ruby 2.3.0 up to
+Ruby 2.6.0 + Jruby.
 
 R10k requires additional components, depending on how you plan on managing
 environments and modules.


### PR DESCRIPTION
As more and more distributions support Ruby 2.6 is makes sense to also
run our test on it.