### PR TITLE
Pin gettext as they have decided to make a breaking change

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet_forge', '~> 2.3.0'
 
   s.add_dependency 'gettext-setup', '~>0.24'
+  s.add_dependency 'gettext',       '~>3.2.0'
 
   s.add_development_dependency 'rspec', '~> 3.1'
 


### PR DESCRIPTION
- gettext 3.3.0 has made a breaking change of suddenly requiring ruby >= 2.5.0
  this breaks anybody on ruby 2.4.9 with Puppet 5 series supported versions