### PR TITLE
(maint) Update gettext-setup gem to 1.0

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'puppet_forge', '~> 2.3.0'
 
-  s.add_dependency 'gettext-setup', '~>0.24'
+  s.add_dependency 'gettext-setup', '~>1.0'
 
   s.add_development_dependency 'rspec', '~> 3.1'
 


### PR DESCRIPTION
The gettext-setup gem now pins gettext to < 3.3.0. The latest release
of gettext-setup is 1.0, so is not captured by the current version
constraint for the gem.