### PR TITLE
Add Ruby 2.7 to testmatrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install: gem install bundler -v '< 2' --no-document
 matrix:
   include:
     - stage: r10k tests
+      rvm: 2.7.0
+    - stage: r10k tests
       rvm: 2.6.5
     - stage: r10k tests
       rvm: 2.5.0


### PR DESCRIPTION
Ruby 2.7 got released some time ago and the first distributions ship it,
so I think it makes sense to also execute the tests on Ruby 2.7.