### PR TITLE
(RK-357) Restrict `gettext` and `fast_gettext` versions

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -30,7 +30,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'puppet_forge', '~> 2.2.8'
 
-  s.add_dependency 'gettext-setup', '~> 0.5'
+  s.add_dependency 'gettext-setup', '~>0.24'
+  # These two pins narrow what is allowed by gettext-setup,
+  # to preserver compatability with Ruby 2.4
+  s.add_dependency 'fast_gettext', '~> 1.1.0'
+  s.add_dependency 'gettext', ['>= 3.0.2', '< 3.3.0']
 
   s.add_development_dependency 'rspec', '~> 3.1'
 


### PR DESCRIPTION
This commit restricts the allowed versions of the `gettext` and
`fast_gettext` gems to preserve compatability with older versions of
Ruby. This became necessary because the `gettext-setup` gem loosened its
requirements to allow newer versions of those deps, as part of a
modernization effort. We can remove these pins once we only need to
support Ruby 2.5+.