### PR TITLE
Allow `>= 2.15.10` versions of cri

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_dependency 'colored2',   '3.1.2'
-  s.add_dependency 'cri',       '2.15.6'
+  s.add_dependency 'cri', ['>= 2.15.10', '< 3.0.0']
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
cri 2.15.10 is the latest version and people already use it with r10k so
I think we should also test against it / allow it. It claims it's
compatible with Ruby 2.3.