### PR TITLE
(RK-360) Allow overriding the cachedir in `deploy module`

### DIFF
--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -72,7 +72,11 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(environment: true, 'no-force': :self, 'generate-types': :self, 'puppet-path': :self)
+          super.merge(environment: true,
+                      cachedir: :self,
+                      'no-force': :self,
+                      'generate-types': :self,
+                      'puppet-path': :self)
         end
       end
     end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -25,6 +25,10 @@ describe R10K::Action::Deploy::Module do
     it 'can accept a puppet-path option' do
       described_class.new({ 'puppet-path': '/nonexistent' }, [])
     end
+
+    it 'can accept a cachedir option' do
+      described_class.new({ cachedir: '/nonexistent' }, [])
+    end
   end
 
   describe "with no-force" do
@@ -121,6 +125,15 @@ describe R10K::Action::Deploy::Module do
 
     it 'sets puppet_path' do
       expect(subject.instance_variable_get(:@puppet_path)).to eq('/nonexistent')
+    end
+  end
+
+  describe 'with cachedir' do
+
+    subject { described_class.new({ config: '/some/nonexistent/path', cachedir: '/nonexistent' }, []) }
+
+    it 'sets puppet_path' do
+      expect(subject.instance_variable_get(:@cachedir)).to eq('/nonexistent')
     end
   end
 end


### PR DESCRIPTION
Previously, we added the ability to configure the cachedir from the CLI
for the `deploy environment` command, since Code Manager configures a
separate cachedir for each of its r10k workers. Now that we are also
using the `deploy module` command in Code Manager, it needs to respect
these special cachedirs the same way. The `--cachedir` flag can now be
used with the `deploy module` command.