### PR TITLE
Update documentation links

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -48,7 +48,7 @@ cachedir: '/var/cache/r10k'
 
 
 The cachedir setting defaults to `~/.r10k`. If the HOME environment variable is
-unset r10k will assume that r10k is being run with the Puppet [`prerun_command`](http://docs.puppetlabs.com/references/latest/configuration.html#preruncommand)
+unset r10k will assume that r10k is being run with the Puppet [`prerun_command`](https://puppet.com/docs/puppet/latest/configuration.html#preruncommand)
 setting and will set the cachedir default to `/root/.r10k`.
 
 ### proxy

--- a/doc/dynamic-environments/git-environments.mkd
+++ b/doc/dynamic-environments/git-environments.mkd
@@ -29,7 +29,7 @@ seamlessly reflected in Puppet environments. This means that creating a new Git
 branch creates a new Puppet environment, updating a Git branch will update that
 environment, and deleting a Git branch will remove that environment.
 
-R10k supports both [directory and config file environments](https://docs.puppetlabs.com/puppet/latest/reference/environments.html).
+R10k supports both [directory and config file environments](https://puppet.com/docs/puppet/latest/env_environments.html).
 Ensure that the basedir for your sources and your puppet config align.
 
 How it works

--- a/doc/dynamic-environments/master-configuration.mkd
+++ b/doc/dynamic-environments/master-configuration.mkd
@@ -40,7 +40,7 @@ use. (But you can if you want.)
 
 ## Puppet >= 3.6.0
 
-[environmentconf]: http://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html
+[environmentconf]: https://puppet.com/docs/puppet/latest/environments_creating.html#the-environment.conf-file
 
 Puppet 3.6.0 adds more fine grained control over how directory environments are
 configured. Each directory based environment can have an


### PR DESCRIPTION
There are two more in `doc/dynamic-environments/master-configuration.mkd` but I could figure out where http://docs.puppetlabs.com/puppet/latest/reference/environments.html#enabling-directory-environments should point to now.