### PR TITLE
(OSOKR-23) Add GitHub Action for releasing r10k gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Gem release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build gem
+        uses: scarhand/actions-ruby@master
+        with:
+          args: build *.gemspec
+      - name: Publish gem
+        uses: scarhand/actions-ruby@master
+        env:
+          RUBYGEMS_AUTH_TOKEN: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+        with:
+          args: push *.gem
+


### PR DESCRIPTION
This commit adds a GitHub Action that will release the r10k gem whenever the
repository is tagged. This will enable community members to release as-needed.