### PR TITLE
(OSOKR-23) Add GitHub Action to tag and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PUPPET_RELEASE_GH_TOKEN }}
           DEFAULT_BUMP: patch
           WITH_V: false
+          # Uncomment this if the tag and version file become out-of-sync and
+          # you need to tag at a specific version.
+          # CUSTOM_TAG:
       - name: Build gem
         uses: scarhand/actions-ruby@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Tag and release
+
+on:
+  push:
+    branches:
+      - master
+      - 2.6.x
+    paths:
+      - 'lib/r10k/version.rb'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.17.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUPPET_RELEASE_GH_TOKEN }}
+          DEFAULT_BUMP: patch
+          WITH_V: false
+      - name: Build gem
+        uses: scarhand/actions-ruby@master
+        with:
+          args: build *.gemspec
+      - name: Publish gem
+        uses: scarhand/actions-ruby@master
+        env:
+          RUBYGEMS_AUTH_TOKEN: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+        with:
+          args: push *.gem
+

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+2.6.7
+----
+
+### Changes
+
+(CDPE-1813) Add module deploy info to .r10k-deploy.json.
+(RK-351) Update minitar to ~> 0.9.0.
+
 2.6.6
 ----
 

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+2.6.8
+----
+
+### Changes
+
+(RK-357) Restrict gettext and fast_gettext versions for compatibility with Ruby 2.4.
+(RK-358) Update puppet_forge to ~> 2.3.0.
+
 2.6.7
 ----
 

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,7 @@ CHANGELOG
 2.6.6
 ----
 
-## Changes
+### Changes
 
  - Flag for overriding default branch configuration in Puppetfile
  - Plumbing for internationalization
@@ -13,25 +13,27 @@ CHANGELOG
 2.6.5
 ----
 
-## Bug Fix
+### Bug Fix
 
 (RK-324) Fix Ruby pipe bug affecting Ubuntu
 
 2.6.4
 ----
 
-## Changes
+### Changes
 
 Numerous test fixes.
 
 2.6.3
 ----
-## Changes
+
+### Changes
 
 Update specs with new error string.
 
 2.6.2
 -----
+
 ### Changes
 
 (RK-311) Yard dependency updated for security fix.

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '2.6.7'
+  VERSION = '2.6.8'
 end

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -1,3 +1,6 @@
 module R10K
+  # When updating to a new major (X) or minor (Y) version, include `#major` or
+  # `#minor` (respectively) in your commit message to trigger the appropriate
+  # release. Otherwise, a new patch (Z) version will be released.
   VERSION = '2.6.7'
 end


### PR DESCRIPTION
This commit adds a GitHub Action to tag the r10k repo, build the r10k gem, and
publish the gem to rubygems. This Action will be triggered whenever r10k's
version file gets updated. The commit message to update the version file must
include `#minor` or `#major` in order to bump the Y or X version. Otherwise,
the Z version will get bumped. For more info, see
https://github.com/marketplace/actions/github-tag-bump