### PR TITLE
Add Supercronic - to be used in K8s

### DIFF
--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -19,7 +19,7 @@ ARG pupperware_analytics_stream="dev"
 ARG supercronic_version="0.1.9"
 ARG supercronic_sha1sum="5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85"
 ARG supercronic="supercronic-linux-amd64"
-ARG supercronic_url="https://github.com/aptible/supercronic/releases/download/v$supercronic_version/supercronic-linux-amd64"
+ARG supercronic_url="https://github.com/aptible/supercronic/releases/download/v$supercronic_version/$supercronic"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -44,6 +44,7 @@ LABEL org.label-schema.version="$version" \
       org.label-schema.build-date="$build_date"
 
 COPY --from=build /workspace/r10k.gem /
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN chmod a+x /adduser.sh && \
 # Add a puppet user to run r10k as for consistency with puppetserver
     /adduser.sh && \
@@ -52,7 +53,7 @@ RUN chmod a+x /adduser.sh && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
     gem install --no-doc /r10k.gem json etc && \
     rm -f /r10k.gem && \
-    curl -fsSLO "$supercronic_url" && \
+    curl --fail --silent --show-error --location --remote-name "$supercronic_url" && \
     echo "${supercronic_sha1sum}  ${supercronic}" | sha1sum -c - && \
     chmod +x "$supercronic" && \
     mv "$supercronic" "/usr/local/bin/${supercronic}" && \

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -15,6 +15,11 @@ ARG version="3.1.0"
 # Used by entrypoint to submit metrics to Google Analytics.
 # Published images should use "production" for this build_arg.
 ARG pupperware_analytics_stream="dev"
+# required to schedule runs of "r10k" in K8s
+ARG supercronic_version="0.1.9"
+ARG supercronic_sha1sum="5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85"
+ARG supercronic="supercronic-linux-amd64"
+ARG supercronic_url="https://github.com/aptible/supercronic/releases/download/v$supercronic_version/supercronic-linux-amd64"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -31,7 +36,7 @@ COPY docker/r10k/docker-entrypoint.d /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]
 
-# dyanmic LABELs and ENV vars placed lower for the sake of Docker layer caching
+# dynamic LABELs and ENV vars placed lower for the sake of Docker layer caching
 ENV PUPPERWARE_ANALYTICS_STREAM="$pupperware_analytics_stream"
 
 LABEL org.label-schema.version="$version" \
@@ -46,7 +51,12 @@ RUN chmod a+x /adduser.sh && \
     chown -R puppet: /docker-entrypoint.d /docker-entrypoint.sh && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
     gem install --no-doc /r10k.gem json etc && \
-    rm -f /r10k.gem
+    rm -f /r10k.gem && \
+    curl -fsSLO "$supercronic_url" && \
+    echo "${supercronic_sha1sum}  ${supercronic}" | sha1sum -c - && \
+    chmod +x "$supercronic" && \
+    mv "$supercronic" "/usr/local/bin/${supercronic}" && \
+    ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
 
 USER puppet
 WORKDIR /home/puppet

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -45,10 +45,9 @@ LABEL org.label-schema.version="$version" \
 
 COPY --from=build /workspace/r10k.gem /
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN chmod a+x /adduser.sh && \
+RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
 # Add a puppet user to run r10k as for consistency with puppetserver
     /adduser.sh && \
-    chmod +x /docker-entrypoint.sh && \
     chown -R puppet: /docker-entrypoint.d /docker-entrypoint.sh && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
     gem install --no-doc /r10k.gem json etc && \

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -21,7 +21,7 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.dockerfile="/release.Dockerfile"
 
-COPY docker-entrypoint.sh /
+COPY adduser.sh docker-entrypoint.sh /
 COPY docker-entrypoint.d /docker-entrypoint.d
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
@@ -35,7 +35,9 @@ LABEL org.label-schema.version="$version" \
       org.label-schema.build-date="$build_date"
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
-RUN chmod +x /docker-entrypoint.sh && \
+RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
+    /adduser.sh && \
+    chown -R puppet: /docker-entrypoint.d /docker-entrypoint.sh && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
     gem install --no-doc r10k:"$version" json etc && \
     curl --fail --silent --show-error --location --remote-name "$supercronic_url" && \
@@ -43,5 +45,8 @@ RUN chmod +x /docker-entrypoint.sh && \
     chmod +x "$supercronic" && \
     mv "$supercronic" "/usr/local/bin/${supercronic}" && \
     ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
+
+USER puppet
+WORKDIR /home/puppet
 
 COPY release.Dockerfile /

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -6,6 +6,11 @@ ARG version="3.1.0"
 # Used by entrypoint to submit metrics to Google Analytics.
 # Published images should use "production" for this build_arg.
 ARG pupperware_analytics_stream="dev"
+# required to schedule runs of "r10k" in K8s
+ARG supercronic_version="0.1.9"
+ARG supercronic_sha1sum="5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85"
+ARG supercronic="supercronic-linux-amd64"
+ARG supercronic_url="https://github.com/aptible/supercronic/releases/download/v$supercronic_version/$supercronic"
 
 LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -29,8 +34,14 @@ LABEL org.label-schema.version="$version" \
       org.label-schema.vcs-ref="$vcs_ref" \
       org.label-schema.build-date="$build_date"
 
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN chmod +x /docker-entrypoint.sh && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
-    gem install --no-doc r10k:"$version" json etc
+    gem install --no-doc r10k:"$version" json etc && \
+    curl --fail --silent --show-error --location --remote-name "$supercronic_url" && \
+    echo "${supercronic_sha1sum}  ${supercronic}" | sha1sum -c - && \
+    chmod +x "$supercronic" && \
+    mv "$supercronic" "/usr/local/bin/${supercronic}" && \
+    ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
 
 COPY release.Dockerfile /


### PR DESCRIPTION
`supercronic` is needed - so r10k can be scheduled in a sidecar container in K8s. 

That will allow Puppet Server, deployed through the Helm chart, to run on different K8s nodes (even distributed in different cloud zones).