### PR TITLE
Increase default pool_size to 4

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 Unreleased
+ - Increase pool_size default to 4 from 1 [#1044](https://github.com/puppetlabs/r10k/pull/1044)
 ----
 
 3.4.1

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -10,7 +10,7 @@ class Puppetfile
 
   include R10K::Settings::Mixin
 
-  def_setting_attr :pool_size, 1
+  def_setting_attr :pool_size, 4
 
   include R10K::Logging
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -159,8 +159,8 @@ module R10K
         }),
 
         Definition.new(:pool_size, {
-          :desc => "The amount of threads used to concurrently install modules. The default value is 1: install one module at a time.",
-          :default => 1,
+          :desc => "The amount of threads used to concurrently install modules. The default value is 4: install four modules at a time.",
+          :default => 4,
           :validate => lambda do |value|
             if !value.is_a?(Integer)
               raise ArgumentError, "The pool_size setting should be an integer, not a #{value.class}"

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -19,7 +19,9 @@ describe R10K::Action::Puppetfile::Install do
 
   describe "installing modules" do
     let(:modules) do
-      Array.new(4, R10K::Module::Base.new('author/modname', "/some/nonexistent/path/modname", nil))
+      (1..4).map do |idx|
+        R10K::Module::Base.new("author/modname#{idx}", "/some/nonexistent/path/modname#{idx}", nil)
+      end
     end
 
     before do


### PR DESCRIPTION
Solves #1038.  pool_size was added as an optional setting
a while ago and people have been using it successfully
in the wild.  This commit increases the default to 4
which seems like a generally useful improvement.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
