### PR TITLE
(RK-343) Update option handling for new CRI

### DIFF
--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -43,10 +43,10 @@ module R10K
         config_settings = settings_from_config(@opts[:config])
 
         overrides = {}
-        overrides[:cachedir] = @opts[:cachedir] unless @opts[:cachedir].nil?
-        overrides[:deploy] = {} if !@opts[:'puppet-path'].nil? || !@opts[:'generate-types'].nil?
-        overrides[:deploy][:puppet_path] = @opts[:'puppet-path'] unless @opts[:'puppet-path'].nil?
-        overrides[:deploy][:generate_types] = @opts[:'generate-types'] unless @opts[:'generate-types'].nil?
+        overrides[:cachedir] = @opts[:cachedir] if @opts.key?(:cachedir)
+        overrides[:deploy] = {} if @opts.key?(:'puppet-path') || @opts.key?(:'generate-types')
+        overrides[:deploy][:puppet_path] = @opts[:'puppet-path'] if @opts.key?(:'puppet-path')
+        overrides[:deploy][:generate_types] = @opts[:'generate-types'] if @opts.key?(:'generate-types')
 
         with_overrides = config_settings.merge(overrides) do |key, oldval, newval|
           newval = oldval.merge(newval) if oldval.is_a? Hash

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -94,7 +94,7 @@ describe R10K::Action::Runner do
                         else
                           { "#{conf_path}": override }
                         end
-            expect(global_settings).to receive(:evaluate).with(overrides).and_call_original
+            expect(global_settings).to receive(:evaluate).with(hash_including(overrides)).and_call_original
             runner.call
           end
         end
@@ -109,7 +109,7 @@ describe R10K::Action::Runner do
                         else
                           { "#{conf_path}": override }
                         end
-            expect(global_settings).to receive(:evaluate).with(overrides).and_call_original
+            expect(global_settings).to receive(:evaluate).with(hash_including(overrides)).and_call_original
             runner.call
           end
         end


### PR DESCRIPTION
CRI now uses defaulting hashes for options, so we need to check whether
the key is present to tell if an option was passed explicitly.