### PR TITLE
Revert increase in default pool size

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,7 +3,6 @@ CHANGELOG
 
 Unreleased
 ----
-- Increase `pool_size` default to 4 from 1 [#1044](https://github.com/puppetlabs/r10k/pull/1044)
 - Add exec environment source type. The exec source type allows for the implementation of external environment sources [#1042](https://github.com/puppetlabs/r10k/pull/1042)
 
 3.4.1

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -10,7 +10,7 @@ class Puppetfile
 
   include R10K::Settings::Mixin
 
-  def_setting_attr :pool_size, 4
+  def_setting_attr :pool_size, 1
 
   include R10K::Logging
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -159,8 +159,8 @@ module R10K
         }),
 
         Definition.new(:pool_size, {
-          :desc => "The amount of threads used to concurrently install modules. The default value is 4: install four modules at a time.",
-          :default => 4,
+          :desc => "The amount of threads used to concurrently install modules. The default value is 1: install one module at a time.",
+          :default => 1,
           :validate => lambda do |value|
             if !value.is_a?(Integer)
               raise ArgumentError, "The pool_size setting should be an integer, not a #{value.class}"


### PR DESCRIPTION
After updating the default pool_size, a race condition was
found when initializing our local git cache. See
#1058 for the issue in detail.

When attempting a fix we realized that there were multiple copies of the
code to iterate over modules to manage. See
#1059 for a first attempt at this
problem and discussion.

In order to meet our current timelines, the default will need to reverted
until we can fix this issue properly. Hence this commit and a55536c.

This commit was necessary because the CHANGELOG has been refactored since
the commit referencing the default was added.
