### PR TITLE
(maint) Prep for 3.5.0 release #minor

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,10 +3,20 @@ CHANGELOG
 
 Unreleased
 ----
-- Add exec environment source type. The exec source type allows for the implementation of external environment sources [#1042](https://github.com/puppetlabs/r10k/pull/1042)
+
+
+3.5.0
+-----
+
+- Add exec environment source type. The exec source type allows for the
+  implementation of external environment sources
+  [#1042](https://github.com/puppetlabs/r10k/pull/1042).
+- Improve atomicity of .r10k-deploy.json writes. Fixes
+  [#813](https://github.com/puppetlabs/r10k/issues/813)
 
 3.4.1
 ----
+
 - Add support for Ruby 2.7
 - (RK-357) Restrict gettext and fast_gettext versions for compatibility with Ruby 2.4
 - Bump cri to 2.15.10

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '3.4.1'
+  VERSION = '3.5.0'
 end


### PR DESCRIPTION
Updates CHANGELOG with missing entries and for formatting. Updates
VERSION constant to 3.5.0.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
