### PR TITLE
(maint) Switch Travis to Ubuntu 20.04 builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,14 @@ matrix:
         - docker
       rvm: 2.6.6
       env:
+        - DOCKER_COMPOSE_VERSION=1.25.5
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
+      before_install:
+        - sudo rm /usr/local/bin/docker-compose
+        - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
+        - chmod +x docker-compose
+        - sudo mv docker-compose /usr/local/bin
       script:
         - set -e
         - cd docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   email: false
 sudo: false
 jdk:
-  - openjdk8
+  - openjdk11
 before_install: gem install bundler -v '< 2' --no-document
 matrix:
   include:
@@ -23,20 +23,16 @@ matrix:
     - stage: r10k tests
       rvm: jruby
     - stage: r10k container tests
-      dist: bionic
+      dist: focal
       language: ruby
       services:
-        # bionic uses 18.06 but need 19.03+ for buildkit so upgrade later in relevant cell
         - docker
-      rvm: 2.6.5
+      rvm: 2.6.6
       env:
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
       script:
         - set -e
-        - sudo apt update -y && sudo apt install -y docker.io
-        - sudo systemctl unmask docker.service
-        - sudo systemctl start docker
         - cd docker
         - make lint
         - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,11 @@ matrix:
         # necessary to prevent overwhelming TravisCI build output limits
         - DOCKER_BUILD_FLAGS="--progress plain"
       script:
-        - |
-          set -ex
-          sudo apt update -y && sudo apt install -y docker.io
-          sudo systemctl unmask docker.service
-          sudo systemctl start docker
-          cd docker && make lint build test
-          set +x
+        - set -e
+        - sudo apt update -y && sudo apt install -y docker.io
+        - sudo systemctl unmask docker.service
+        - sudo systemctl start docker
+        - cd docker
+        - make lint
+        - make build
+        - make test


### PR DESCRIPTION
 - Focal fossa time!
 - No need to upgrade Docker for buildkit as image has 19.03 already,
   so this should remove ~30s of setup time
 - Switch to Ruby 2.6.6 for specs, which is known good and installed
 - docker-compose in the 19.03 release included here is 1.23.1, so
   continue to upgrade it on Travis to 1.25.5
 - Separate out Travis operations so that logs have timings for lint, build and test