### PR TITLE
(maint) Upgrade Rugged gem to ~> 1.0

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,7 @@ CHANGELOG
 
 Unreleased
 ----
+- Upgrade Rugged Gemfile dependency for local development to ~> 1.0
 
 
 3.5.0
@@ -394,7 +395,7 @@ Puppetfile should be installed to. See the [Puppetfile documentation](https://gi
 
 You can now configure how r10k purges unmanaged content after a deployment. The
 default behavior should be unchanged but there is a new "purge\_levels" configuration
-option that can be used to enable new behavior or de-activate certain existing 
+option that can be used to enable new behavior or de-activate certain existing
 behaviors. See the relevant [configuration documentation](https://github.com/puppetlabs/r10k/blob/master/doc/dynamic-environments/configuration.mkd#purge_levels) for more details.
 
 (RK-223) Ability to track control repo branch from content declarations.
@@ -441,7 +442,7 @@ fix.)
 Previously, r10k only supported the use of HTTP proxies for connecting to the Puppet
 Forge. With these changes, r10k can now be configured to use an HTTP proxy for both
 Forge and Git operations. Configuration can be specified globally, for Forge or Git
-only, or on a per-Git repository basis. See [configuration documentation](https://github.com/puppetlabs/r10k/blob/master/doc/dynamic-environments/configuration.mkd) 
+only, or on a per-Git repository basis. See [configuration documentation](https://github.com/puppetlabs/r10k/blob/master/doc/dynamic-environments/configuration.mkd)
 for more details.
 
 ### Bug Fixes
@@ -462,9 +463,9 @@ for SSH.
 (RK-241) "deploy display" action does not properly format wrapped exceptions
 
 The "deploy display" action was not capturing and logging exceptions in the same way as
-other related actions. This meant that in many cases, when an error occurred, the 
+other related actions. This meant that in many cases, when an error occurred, the
 underlying cause was not being shown. Specifically, the "deploy display" action was
-not benefitting from the improved error messaging for unreadable SSH keys which was 
+not benefitting from the improved error messaging for unreadable SSH keys which was
 added in r10k 2.2.0 as part of RK-220.
 
 2.2.1

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemspec
 
 group :extra do
-  gem 'rugged', '>= 0.24.0', '< 0.24.6', :platforms => :ruby
+  gem 'rugged', '~> 1.0', :platforms => :ruby
 end
 
 group :development do


### PR DESCRIPTION
This is a blocker for using Ubuntu 20.04 builders in Travis as part of #1063


 - The old version was pinned to a max of 0.24.5 in 2017 due to some
   build-time errors in 6c55978d7b5e2c4c57732f3bb4967aa6a31a9a69

   0.24.5 was published Jan 6, 2017 and has been updated regularly,
   receiving 350+ commits since:

   https://github.com/libgit2/rugged/compare/v0.24.5...v1.0.0

 - The gemspec doesn't specify a hard dependency on rugged, so updating
   the Gemfile only impacts local development and CI systems.

   Rugged 1.0 specifies compatibility back to Ruby 1.9.3:
	 rubygems.org/gems/rugged/versions/1.0.0

 - In reality, the Alpine "edge" (nightly) container and the latest
   tagged "release" (3.3.3) have been installing the Alpine 3.9
   precompiled binary to avoid compiling rugged. That vesion is actually
   0.27.5:

   docker run -it --rm --entrypoint /usr/bin/ruby puppet/r10k:edge -e "require 'rugged'; puts Rugged::VERSION"
   0.27.5

   docker run -it --rm --entrypoint /usr/bin/ruby puppet/r10k:3.3.3 -e "require 'rugged'; puts Rugged::VERSION"
   0.27.5

 - The shipped container won't pick up a new version of Rugged until
   we either:

   * compile it in a multi-stage build
   * update Alpine version to 3.11 or similar - 3.11 ships 0.28.4.1

 - In PE scenarios, the vanagon project specifies a dependency on rugged
   0.27.7, and this PR doesn't change that:

   puppetlabs/pe-r10k-vanagon:configs/components/rubygem-rugged.rb@master#L3

 - Also note that a newer version of Rugged is required to be able to
   build on Ubuntu 20.04 LTS Focal Fossa (and a PR is in progress to
   switch the Travis jobs over to this builder for the sake of a newer
   pre-installed Docker version)
