### PR TITLE
(maint) Update the Forge API base url for PE LTS version

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -157,7 +157,7 @@ interactions. See the global proxy setting documentation for more information an
 #### baseurl
 
 The 'baseurl' setting indicates where Forge modules should be installed from.
-This defaults to 'https://forgeapi.puppetlabs.com'
+This defaults to 'https://forgeapi.puppet.com'
 
 ```yaml
 forge:

--- a/integration/tests/basic_functionality/proxy_specified_in_configuration.rb
+++ b/integration/tests/basic_functionality/proxy_specified_in_configuration.rb
@@ -50,7 +50,7 @@ forge:
 CONF
 
 #Verification
-squid_log_regex = /CONNECT forgeapi.puppetlabs.com:443/
+squid_log_regex = /CONNECT forgeapi.puppet.com:443/
 
 #Teardown
 teardown do

--- a/integration/tests/basic_functionality/proxy_with_pe_only_module.rb
+++ b/integration/tests/basic_functionality/proxy_with_pe_only_module.rb
@@ -55,7 +55,7 @@ site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
 site_pp = create_site_pp(master_certname, '  include peonly')
 
 #Verification
-squid_log_regex = /CONNECT forgeapi.puppetlabs.com:443/
+squid_log_regex = /CONNECT forgeapi.puppet.com:443/
 notify_message_regex = /I am in the production environment, this is a PE only module/
 
 #Teardown

--- a/integration/tests/basic_functionality/proxy_with_puppetfile.rb
+++ b/integration/tests/basic_functionality/proxy_with_puppetfile.rb
@@ -21,7 +21,7 @@ remove_squid = "#{pkg_manager} remove -y squid"
 squid_log = "/var/log/squid/access.log"
 
 #Verification
-squid_log_regex = /CONNECT forgeapi.puppetlabs.com:443/
+squid_log_regex = /CONNECT forgeapi.puppet.com:443/
 
 #Teardown
 teardown do

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_inaccessible_forge.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_inaccessible_forge.rb
@@ -19,7 +19,7 @@ PUPPETFILE
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')
 
 #Verification
-error_message_regex = /Error: Could not connect via HTTPS to https:\/\/forgeapi.puppetlabs.com/
+error_message_regex = /Error: Could not connect via HTTPS to https:\/\/forgeapi.puppet.com/
 
 #Teardown
 teardown do
@@ -34,7 +34,7 @@ step 'Backup "/etc/hosts" File on Master'
 on(master, "mv #{hosts_file_path} #{hosts_file_path}.bak")
 
 step 'Point Forge Hostname to Localhost'
-on(master, "echo '127.0.0.1  forgeapi.puppetlabs.com' > #{hosts_file_path}")
+on(master, "echo '127.0.0.1  forgeapi.puppet.com' > #{hosts_file_path}")
 
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -50,7 +50,7 @@ class Puppetfile
 
     @modules = []
     @managed_content = {}
-    @forge   = 'forgeapi.puppetlabs.com'
+    @forge   = 'forgeapi.puppet.com'
 
     @loaded = false
   end

--- a/r10k.yaml.example
+++ b/r10k.yaml.example
@@ -102,5 +102,5 @@ forge:
   #proxy: 'https://proxy.example.com:8888'
 
   # The 'baseurl' setting indicates where Forge modules should be installed
-  # from. This defaults to 'https://forgeapi.puppetlabs.com'
+  # from. This defaults to 'https://forgeapi.puppet.com'
   #baseurl: 'https://forgemirror.example.com'


### PR DESCRIPTION
The Forge API is now primarily served from the `puppet.com` domain. DNS
still resolves from the old domain, but the legacy `*.puppetlabs.com`
certificate [has been removed](https://headwayapp.co/puppet-forge-updates/removed-legacy-*-puppetlabs-com-ssl-certificate-143941).
For most users, this will have no effect because the main `puppet.com`
certificate includes `puppetlabs.com` as a SAN, but in some outdated or
otherwise broken SSL stacks, this might prevent SSL validation.

To remove that edge case, this PR updates the baseurl to the current
domain name.
