### PR TITLE
(RK-319) Ensure r10k cleans up tmp directories

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----
 - Upgrade Rugged Gemfile dependency for local development to ~> 1.0
+- Clean up tmp directories used for downloading modules
 
 
 3.5.0

--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -212,14 +212,14 @@ module R10K
 
       # Remove the temporary directory used for unpacking the module.
       def cleanup_unpack_path
-        if unpack_path.exist?
+        if unpack_path.parent.exist?
           unpack_path.parent.rmtree
         end
       end
 
       # Remove the downloaded module release.
       def cleanup_download_path
-        if download_path.exist?
+        if download_path.parent.exist?
           download_path.parent.rmtree
         end
       end

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -166,33 +166,37 @@ describe R10K::Forge::ModuleRelease do
   end
 
   describe "#cleanup_unpack_path" do
-    it "ignores the unpack_path if it doesn't exist" do
-      expect(unpack_path).to receive(:exist?).and_return false
-      expect(unpack_path).to_not receive(:parent)
+    it "ignores the unpack_path if the parent doesn't exist" do
+      parent = instance_double('Pathname')
+      expect(parent).to receive(:exist?).and_return false
+      expect(parent).to_not receive(:rmtree)
+      expect(unpack_path).to receive(:parent).and_return(parent)
       subject.cleanup_unpack_path
     end
 
     it "removes the containing directory of unpack_path if it exists" do
       parent = instance_double('Pathname')
       expect(parent).to receive(:rmtree)
-      expect(unpack_path).to receive(:exist?).and_return true
-      expect(unpack_path).to receive(:parent).and_return(parent)
+      expect(parent).to receive(:exist?).and_return true
+      expect(unpack_path).to receive(:parent).and_return(parent).exactly(2).times
       subject.cleanup_unpack_path
     end
   end
 
   describe "#cleanup_download_path" do
-    it "ignores the download_path if it doesn't exist" do
-      expect(download_path).to receive(:exist?).and_return false
-      expect(download_path).to_not receive(:parent)
+    it "ignores the download_path if the parent doesn't exist" do
+      parent = instance_double('Pathname')
+      expect(parent).to receive(:exist?).and_return false
+      expect(parent).to_not receive(:rmtree)
+      expect(download_path).to receive(:parent).and_return(parent)
       subject.cleanup_download_path
     end
 
     it "removes the containing directory of download_path if it exists" do
       parent = instance_double('Pathname')
       expect(parent).to receive(:rmtree)
-      expect(download_path).to receive(:exist?).and_return true
-      expect(download_path).to receive(:parent).and_return(parent)
+      expect(parent).to receive(:exist?).and_return true
+      expect(download_path).to receive(:parent).and_return(parent).exactly(2).times
       subject.cleanup_download_path
     end
   end


### PR DESCRIPTION
Prior to this PR, deploying modules from the forge would leave
behind tmp directories. The conditional check looked for the existence
of the download and extract paths, but not for the tmp directory
containing them. This commit cleans up the tmp directory instead of the
specific download or cache path.

Before this PR we would have tmp directories after an `r10k` deploy environment.

```
# ls -ld d20*
drwx------ 2 pe-puppet pe-puppet 6 Jun  1 17:10 d20200601-16891-1uiz7s
drwx------ 2 pe-puppet pe-puppet 6 Jun  1 17:10 d20200601-16891-ltl2km
```