### PR TITLE
Revert "(maint) Update the Forge API base url"

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,8 +3,6 @@ CHANGELOG
 
 Unreleased
 ----
-- Change default API base url to forgeapi.puppet.com
-  [#1067](https://github.com/puppetlabs/r10k/pull/1067)
 
 2.6.8
 ----

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -157,7 +157,7 @@ interactions. See the global proxy setting documentation for more information an
 #### baseurl
 
 The 'baseurl' setting indicates where Forge modules should be installed from.
-This defaults to 'https://forgeapi.puppet.com'
+This defaults to 'https://forgeapi.puppetlabs.com'
 
 ```yaml
 forge:

--- a/integration/tests/basic_functionality/proxy_specified_in_configuration.rb
+++ b/integration/tests/basic_functionality/proxy_specified_in_configuration.rb
@@ -50,7 +50,7 @@ forge:
 CONF
 
 #Verification
-squid_log_regex = /CONNECT forgeapi.puppet.com:443/
+squid_log_regex = /CONNECT forgeapi.puppetlabs.com:443/
 
 #Teardown
 teardown do

--- a/integration/tests/basic_functionality/proxy_with_pe_only_module.rb
+++ b/integration/tests/basic_functionality/proxy_with_pe_only_module.rb
@@ -55,7 +55,7 @@ site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
 site_pp = create_site_pp(master_certname, '  include peonly')
 
 #Verification
-squid_log_regex = /CONNECT forgeapi.puppet.com:443/
+squid_log_regex = /CONNECT forgeapi.puppetlabs.com:443/
 notify_message_regex = /I am in the production environment, this is a PE only module/
 
 #Teardown

--- a/integration/tests/basic_functionality/proxy_with_puppetfile.rb
+++ b/integration/tests/basic_functionality/proxy_with_puppetfile.rb
@@ -21,7 +21,7 @@ remove_squid = "#{pkg_manager} remove -y squid"
 squid_log = "/var/log/squid/access.log"
 
 #Verification
-squid_log_regex = /CONNECT forgeapi.puppet.com:443/
+squid_log_regex = /CONNECT forgeapi.puppetlabs.com:443/
 
 #Teardown
 teardown do

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_inaccessible_forge.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_inaccessible_forge.rb
@@ -19,7 +19,7 @@ PUPPETFILE
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')
 
 #Verification
-error_message_regex = /Error: Could not connect via HTTPS to https:\/\/forgeapi.puppet.com/
+error_message_regex = /Error: Could not connect via HTTPS to https:\/\/forgeapi.puppetlabs.com/
 
 #Teardown
 teardown do
@@ -34,7 +34,7 @@ step 'Backup "/etc/hosts" File on Master'
 on(master, "mv #{hosts_file_path} #{hosts_file_path}.bak")
 
 step 'Point Forge Hostname to Localhost'
-on(master, "echo '127.0.0.1  forgeapi.puppet.com' > #{hosts_file_path}")
+on(master, "echo '127.0.0.1  forgeapi.puppetlabs.com' > #{hosts_file_path}")
 
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -50,7 +50,7 @@ class Puppetfile
 
     @modules = []
     @managed_content = {}
-    @forge   = 'forgeapi.puppet.com'
+    @forge   = 'forgeapi.puppetlabs.com'
 
     @loaded = false
   end

--- a/r10k.yaml.example
+++ b/r10k.yaml.example
@@ -102,5 +102,5 @@ forge:
   #proxy: 'https://proxy.example.com:8888'
 
   # The 'baseurl' setting indicates where Forge modules should be installed
-  # from. This defaults to 'https://forgeapi.puppet.com'
+  # from. This defaults to 'https://forgeapi.puppetlabs.com'
   #baseurl: 'https://forgemirror.example.com'


### PR DESCRIPTION
This reverts commit 34b60787c96af0939e96841418ce901d3592bc36.
This change ended up causing failures in the pe-r10k pipelines. We have not
gotten a chance to investiage why these failures are occurring and we have a
PE 2018.1.x release coming up, so let's revert this for now.

Revert "update changelog"

This reverts commit b6a11a9bb4720e43af7aa6283598a39a2854b8c4.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.
