### PR TITLE
[#1058] Avoid concurrent cache updates when downloading modules on multiple threads

### DIFF
--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -99,10 +99,8 @@ class R10K::Git::Cache
 
   alias cached? exist?
 
-  private
-
   # Reformat the remote name into something that can be used as a directory
   def sanitized_dirname
-    @remote.gsub(/[^@\w\.-]/, '-')
+    @sanitized_dirname ||= @remote.gsub(/[^@\w\.-]/, '-')
   end
 end

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -12,6 +12,10 @@ class R10K::Git::StatefulRepository
   #   @api private
   attr_reader :repo
 
+  # @!attribute [r] cache
+  #   @api private
+  attr_reader :cache
+
   extend Forwardable
   def_delegators :@repo, :head, :tracked_paths
 

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -99,6 +99,14 @@ class R10K::Module::Base
     raise NotImplementedError
   end
 
+  # Return the module's cachedir. Subclasses that implement a cache
+  # will override this to return a real directory location.
+  #
+  # @return [String, :none]
+  def cachedir
+    :none
+  end
+
   private
 
   def parse_title(title)

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -57,6 +57,10 @@ class R10K::Module::Git < R10K::Module::Base
     @repo.status(version)
   end
 
+  def cachedir
+    @repo.cache.sanitized_dirname
+  end
+
   private
 
   def validate_ref(desired, default)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -143,7 +143,7 @@ class Puppetfile
     mod.origin = 'Puppetfile'
 
     @managed_content[install_path] << mod.name
-    cachedir = module_vcs_cachedir(mod)
+    cachedir = mod.cachedir
     @modules_by_vcs_cachedir[cachedir] ||= []
     @modules_by_vcs_cachedir[cachedir] << mod
     @modules << mod
@@ -188,19 +188,6 @@ class Puppetfile
   end
 
   private
-
-  def module_vcs_cachedir(mod)
-    if mod.respond_to? :repo
-      repo = mod.repo
-      if repo.respond_to? :cache
-        cache = repo.cache
-        if cache.respond_to? :sanitized_dirname
-          return cache.sanitized_dirname
-        end
-      end
-    end
-    :none
-  end
 
   def serial_accept(visitor)
     visitor.visit(:puppetfile, self) do

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -42,6 +42,11 @@ class Puppetfile
   #   @return [Boolean] Overwrite any locally made changes
   attr_accessor :force
 
+  # @!attribute [r] modules_by_vcs_cachedir
+  #   @api private Only exposed for testing purposes
+  #   @return [Hash{:none, String => Array<R10K::Module>}]
+  attr_reader :modules_by_vcs_cachedir
+
   # @param [String] basedir
   # @param [String] moduledir The directory to install the modules, default to #{basedir}/modules
   # @param [String] puppetfile_path The path to the Puppetfile, default to #{basedir}/Puppetfile
@@ -58,6 +63,7 @@ class Puppetfile
 
     @modules = []
     @managed_content = {}
+    @modules_by_vcs_cachedir = {}
     @forge   = 'forgeapi.puppetlabs.com'
 
     @loaded = false
@@ -137,6 +143,9 @@ class Puppetfile
     mod.origin = 'Puppetfile'
 
     @managed_content[install_path] << mod.name
+    cachedir = module_vcs_cachedir(mod)
+    @modules_by_vcs_cachedir[cachedir] ||= []
+    @modules_by_vcs_cachedir[cachedir] << mod
     @modules << mod
   end
 
@@ -180,6 +189,19 @@ class Puppetfile
 
   private
 
+  def module_vcs_cachedir(mod)
+    if mod.respond_to? :repo
+      repo = mod.repo
+      if repo.respond_to? :cache
+        cache = repo.cache
+        if cache.respond_to? :sanitized_dirname
+          return cache.sanitized_dirname
+        end
+      end
+    end
+    :none
+  end
+
   def serial_accept(visitor)
     visitor.visit(:puppetfile, self) do
       modules.each do |mod|
@@ -212,15 +234,22 @@ class Puppetfile
   def modules_queue(visitor)
     Queue.new.tap do |queue|
       visitor.visit(:puppetfile, self) do
-        modules.each { |mod| queue << mod }
+        modules_by_cachedir = modules_by_vcs_cachedir.clone
+        modules_without_vcs_cachedir = modules_by_cachedir.delete(:none) || []
+
+        modules_without_vcs_cachedir.each {|mod| queue << Array(mod) }
+        modules_by_cachedir.values.each {|mods| queue << mods }
       end
     end
   end
+  public :modules_queue
 
   def visitor_thread(visitor, mods_queue)
     Thread.new do
       begin
-        while mod = mods_queue.pop(true) do mod.accept(visitor) end
+        while mods = mods_queue.pop(true) do
+          mods.each {|mod| mod.accept(visitor) }
+        end
       rescue ThreadError => e
         logger.debug _("Module thread %{id} exiting: %{message}") % {message: e.message, id: Thread.current.object_id}
         Thread.exit

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -70,8 +70,8 @@ describe R10K::Action::Deploy::Module do
 
       before do
         allow(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
-          expect(environment.puppetfile).to receive(:modules).and_return(
-            [R10K::Module::Local.new(environment.name, '/fakedir', [], environment)]
+          expect(environment.puppetfile).to receive(:modules_by_vcs_cachedir).and_return(
+            {none: [R10K::Module::Local.new(environment.name, '/fakedir', [], environment)]}
           )
           original.call(environment, &block)
         end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -27,6 +27,7 @@ describe R10K::Action::Puppetfile::Install do
     before do
       allow(puppetfile).to receive(:purge!)
       allow(puppetfile).to receive(:modules).and_return(modules)
+      allow(puppetfile).to receive(:modules_by_vcs_cachedir).and_return({none: modules})
     end
 
     it "syncs each module in the Puppetfile" do


### PR DESCRIPTION
Moved from https://github.com/puppetlabs/r10k/pull/1059