### PR TITLE
Don't purge root when using `puppetfile install`

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -7,6 +7,7 @@ Unreleased
 - Add filter_command configuration option for git repositories. (Thanks to [mhumpula](https://github.com/mhumpula) for the feature.) [#823](https://github.com/puppetlabs/r10k/pull/823)
 - Increase default pool_size to 4, allowing modules to be downloaded on 4 threads concurrently. [#1038](https://github.com/puppetlabs/r10k/issues/1038)
 - Ensure that modules that share a cachedir download serially, to avoid cache corruption. [#1058](https://github.com/puppetlabs/r10k/issues/1058)
+- Don't purge root when using `puppetfile install`. [#1084](https://github.com/puppetlabs/r10k/issues/1084)
 
 3.5.2
 -----

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ variables:
   CONTAINER_BUILD_PATH: .
   LINT_IGNORES:
   DOCKER_BUILDKIT: 1
+  BUILD_OPTIONS: --build-arg alpine_version=3.9
 
 workspace:
   clean: resources
@@ -53,7 +54,7 @@ steps:
 
 - powershell: |
     . "$(bundle show pupperware)/ci/build.ps1"
-    Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -PathOrUri $ENV:CONTAINER_BUILD_PATH
+    Build-Container -Name $ENV:CONTAINER_NAME -Namespace $ENV:NAMESPACE -PathOrUri $ENV:CONTAINER_BUILD_PATH -AdditionalOptions ($ENV:BUILD_OPTIONS -split ' ')
   displayName: Build $(CONTAINER_NAME) Container
   timeoutInMinutes: 5
   name: build_container

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,6 +6,7 @@ build_date := $(shell date -u +%FT%T)
 hadolint_available := $(shell hadolint --help > /dev/null 2>&1; echo $$?)
 hadolint_command := hadolint
 hadolint_container := hadolint/hadolint:latest
+alpine_version := 3.9
 export BUNDLE_PATH = $(PWD)/.bundle/gems
 export BUNDLE_BIN = $(PWD)/.bundle/bin
 export GEMFILE = $(PWD)/Gemfile
@@ -48,9 +49,10 @@ else
 endif
 
 build: prep
+	docker pull alpine:$(alpine_version)
 	docker build \
 		${DOCKER_BUILD_FLAGS} \
-		--pull \
+		--build-arg alpine_version=$(alpine_version) \
 		--build-arg vcs_ref=$(vcs_ref) \
 		--build-arg build_date=$(build_date) \
 		--build-arg version=$(VERSION) \

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.9 as build
+ARG alpine_version=3.9
+FROM alpine:${alpine_version} as build
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ruby git && \
@@ -8,7 +9,7 @@ COPY . /workspace
 RUN gem build r10k.gemspec && \
     mv r10k*.gem r10k.gem
 
-FROM alpine:3.9
+FROM alpine:${alpine_version}
 
 ARG vcs_ref
 ARG build_date

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.9
+ARG alpine_version=3.9
+FROM alpine:${alpine_version}
 
 ARG vcs_ref
 ARG build_date

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -154,7 +154,9 @@ class Puppetfile
   def managed_directories
     self.load unless @loaded
 
-    @managed_content.keys
+    dirs = @managed_content.keys
+    dirs.delete(real_basedir)
+    dirs
   end
 
   # Returns an array of the full paths to all the content being managed.
@@ -264,13 +266,15 @@ class Puppetfile
   end
 
   def validate_install_path(path, modname)
-    real_basedir = Pathname.new(basedir).cleanpath.to_s
-
     unless /^#{Regexp.escape(real_basedir)}.*/ =~ path
       raise R10K::Error.new("Puppetfile cannot manage content '#{modname}' outside of containing environment: #{path} is not within #{real_basedir}")
     end
 
     true
+  end
+
+  def real_basedir
+    Pathname.new(basedir).cleanpath.to_s
   end
 
   class DSL

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -173,6 +173,26 @@ describe R10K::Puppetfile do
     end
   end
 
+  describe '#managed_directories' do
+    it 'returns an array of paths that can be purged' do
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, '1.2.3', anything).and_call_original
+
+      subject.add_module('puppet/test_module', '1.2.3')
+      expect(subject.managed_directories).to match_array(["/some/nonexistent/basedir/modules"])
+    end
+
+    context 'with a module with install_path == \'\'' do
+      it 'basedir isn\'t in the list of paths to purge' do
+        module_opts = { install_path: '', git: 'git@example.com:puppet/test_module.git' }
+
+        allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.basedir, module_opts, anything).and_call_original
+
+        subject.add_module('puppet/test_module', module_opts)
+        expect(subject.managed_directories).to be_empty
+      end
+    end
+  end
+
   describe "evaluating a Puppetfile" do
     def expect_wrapped_error(orig, pf_path, wrapped_error)
       expect(orig).to be_a_kind_of(R10K::Error)


### PR DESCRIPTION
This commit removes the base_dir from the list of directories r10k
should purge after installing modules with r10k puppetfile install.

Fixes #1084
Closes #1085 