### PR TITLE
RFC: Add `--environment` option to `puppetfile install`

### DIFF
--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -10,7 +10,7 @@ module R10K
 
         def call
           @visit_ok = true
-          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil , @force)
+          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil , @force, @environment)
           pf.accept(self)
           @visit_ok
         end
@@ -30,14 +30,18 @@ module R10K
           logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
 
           if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
-            logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})
+            if @environment.nil?
+              logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available, (or use --environment)." % {name: mod.name})
+            else
+              logger.info _("Attempting to use branch '%{branch}' for module '%{name}'." % {branch: @environment, name: mod.name})
+            end
           end
 
           mod.sync(force: @force)
         end
 
         def allowed_initialize_opts
-          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :self )
+          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :self, environment: :self )
         end
       end
     end

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -32,6 +32,7 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           summary 'Install all modules from a Puppetfile'
           required nil, :moduledir, 'Path to install modules to'
           required nil, :puppetfile, 'Path to puppetfile'
+          required nil, :environment, 'The environment your Puppetfile is in'
           flag     nil, :force, 'Force locally changed files to be overwritten'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -108,6 +108,8 @@ class R10K::Module::Git < R10K::Module::Base
 
     if @desired_ref == :control_branch && @environment && @environment.respond_to?(:ref)
       @desired_ref = @environment.ref
+    elsif @desired_ref == :control_branch && @environment.is_a?(String)
+      @desired_ref = @environment
     end
   end
 end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -52,12 +52,14 @@ class Puppetfile
   # @param [String] puppetfile_path The path to the Puppetfile, default to #{basedir}/Puppetfile
   # @param [String] puppetfile_name The name of the Puppetfile, default to 'Puppetfile'
   # @param [Boolean] force Shall we overwrite locally made changes?
-  def initialize(basedir, moduledir = nil, puppetfile_path = nil, puppetfile_name = nil, force = nil )
+  # @param [String] The environment the Puppetfile is in.
+  def initialize(basedir, moduledir = nil, puppetfile_path = nil, puppetfile_name = nil, force = nil, environment = nil )
     @basedir         = basedir
     @force           = force || false
     @moduledir       = moduledir  || File.join(basedir, 'modules')
     @puppetfile_name = puppetfile_name || 'Puppetfile'
     @puppetfile_path = puppetfile_path || File.join(basedir, @puppetfile_name)
+    @environment     = environment
 
     logger.info _("Using Puppetfile '%{puppetfile}'") % {puppetfile: @puppetfile_path}
 


### PR DESCRIPTION
I use Onceover and it uses R10k via `r10k puppetfile install`.
Unfortunately, this is a problem if modules in your Puppetfile use `:branch => :control_branch`.
See https://github.com/puppetlabs/r10k/blob/master/doc/puppetfile.mkd#control-repo-branch-tracking

```
Cannot track control repo branch for content some_module when not part of a 'deploy' action, will use default if available.
```

This change adds a `--environment` option to the `r10k puppetfile install` command.
Not sure I'm going about it the right way, or perhaps someone can suggest a better solution.

Feedback appreciated.