### PR TITLE
Docker: Added option to include your own scripts

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- Added the option to mount your on custom script into the r10k (Docker) container, just like you can with [the puppetserver container](https://github.com/puppetlabs/puppetserver/blob/3b6d9181bc79671220ad938a193d938e95f0a70e/docker/puppetserver/docker-entrypoint.sh#L13-L19) [#1091](https://github.com/puppetlabs/r10k/pull/1091)
 - Add 'strip\_component' environment source configuration setting, to allow deploying Git branches named like "env/production" as Puppet environments named like "production". [#1128](https://github.com/puppetlabs/r10k/pull/1128)
 - A warning will be emitted when the user supplies conflicting arguments to module definitions in a Puppetfile, such as when specifying both :commit and :branch [#1130](https://github.com/puppetlabs/r10k/pull/1130)
 - Add optional standard module and environment specification interface: name, type, source, version. These options can be used when specifying environments and/or modules in a yaml/exec source, as well as when specifying modules in a Puppetfile. Providing the standard interface simplifies integrations with external services [#1131](https://github.com/puppetlabs/r10k/pull/1131)

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
-- Added the option to mount your on custom script into the r10k (Docker) container, just like you can with [the puppetserver container](https://github.com/puppetlabs/puppetserver/blob/3b6d9181bc79671220ad938a193d938e95f0a70e/docker/puppetserver/docker-entrypoint.sh#L13-L19) [#1091](https://github.com/puppetlabs/r10k/pull/1091)
+- Added the option to mount your own custom script into the r10k (Docker) container, just like you can with [the puppetserver container](https://github.com/puppetlabs/puppetserver/blob/3b6d9181bc79671220ad938a193d938e95f0a70e/docker/puppetserver/docker-entrypoint.sh#L13-L19) [#1091](https://github.com/puppetlabs/r10k/pull/1091)
 - Add 'strip\_component' environment source configuration setting, to allow deploying Git branches named like "env/production" as Puppet environments named like "production". [#1128](https://github.com/puppetlabs/r10k/pull/1128)
 - A warning will be emitted when the user supplies conflicting arguments to module definitions in a Puppetfile, such as when specifying both :commit and :branch [#1130](https://github.com/puppetlabs/r10k/pull/1130)
 - Add optional standard module and environment specification interface: name, type, source, version. These options can be used when specifying environments and/or modules in a yaml/exec source, as well as when specifying modules in a Puppetfile. Providing the standard interface simplifies integrations with external services [#1131](https://github.com/puppetlabs/r10k/pull/1131)

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ The following environment variables are supported:
 
   Set to 'true' to enable Google Analytics metrics. Defaults to 'false'.
 
-If you want to use your own script to config the r10k container, you can mount your script to the directory `/docker-custom-entrypoint.d` in the container:
+If you want to use your own script to configure the r10k container, you can mount your script to the directory `/docker-custom-entrypoint.d` in the container:
 ```
 docker run --name r10k -v ./r10k-custom:/docker-custom-entrypoint.d puppet/r10k
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,6 +10,11 @@ The following environment variables are supported:
 
   Set to 'true' to enable Google Analytics metrics. Defaults to 'false'.
 
+If you want to use your own script to config the r10k container, you can mount your script to the directory `/docker-custom-entrypoint.d` in the container:
+```
+docker run --name r10k -v ./r10k-custom:/docker-custom-entrypoint.d puppet/r10k
+```
+
 ## Analytics Data Collection
 
 The r10k container collects usage data. This is disabled by default. You can enable it by passing `--env PUPPERWARE_ANALYTICS_ENABLED=true`

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -67,6 +67,7 @@ RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
     mv "$supercronic" "/usr/local/bin/${supercronic}" && \
     ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
 
+# hadolint ignore=DL3000
 WORKDIR "/home/${PP_USER}"
 
 COPY docker/r10k/Dockerfile /

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -52,11 +52,10 @@ COPY --from=build /workspace/r10k.gem /
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # ignore apk and gem pinning
 # hadolint ignore=DL3018,DL3028
-RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
+RUN chmod -R a+x /adduser.sh /docker-entrypoint.sh /docker-entrypoint.d && \
 # Add a puppet user to run r10k as for consistency with puppetserver
     /adduser.sh && \
     chown -R "${PP_USER}:" /docker-entrypoint.d /docker-entrypoint.sh && \
-    chmod -R +x            /docker-entrypoint.d /docker-entrypoint.sh && \
     mkdir -p /docker-custom-entrypoint.d && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-json ruby-etc && \
     gem install --no-doc /r10k.gem && \
@@ -67,6 +66,8 @@ RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
     mv "$supercronic" "/usr/local/bin/${supercronic}" && \
     ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
 
+# Ignore the check for absolute WORKDIR path, this is need when using environment variables in WORKDIR.
+# https://github.com/hadolint/hadolint/wiki/DL3000
 # hadolint ignore=DL3000
 WORKDIR "/home/${PP_USER}"
 

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -35,6 +35,9 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
 COPY docker/r10k/adduser.sh docker/r10k/docker-entrypoint.sh /
 COPY docker/r10k/docker-entrypoint.d /docker-entrypoint.d
 
+ARG PP_USER
+ENV PP_USER="${PP_USER:-puppet}"
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]
 
@@ -52,7 +55,9 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
 # Add a puppet user to run r10k as for consistency with puppetserver
     /adduser.sh && \
-    chown -R puppet: /docker-entrypoint.d /docker-entrypoint.sh && \
+    chown -R "${PP_USER}:" /docker-entrypoint.d /docker-entrypoint.sh && \
+    chmod -R +x            /docker-entrypoint.d /docker-entrypoint.sh && \
+    mkdir -p /docker-custom-entrypoint.d && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-json ruby-etc && \
     gem install --no-doc /r10k.gem && \
     rm -f /r10k.gem && \
@@ -62,7 +67,6 @@ RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
     mv "$supercronic" "/usr/local/bin/${supercronic}" && \
     ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
 
-USER puppet
-WORKDIR /home/puppet
+WORKDIR "/home/${PP_USER}"
 
 COPY docker/r10k/Dockerfile /

--- a/docker/r10k/Dockerfile
+++ b/docker/r10k/Dockerfile
@@ -35,8 +35,8 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
 COPY docker/r10k/adduser.sh docker/r10k/docker-entrypoint.sh /
 COPY docker/r10k/docker-entrypoint.d /docker-entrypoint.d
 
-ARG PP_USER
-ENV PP_USER="${PP_USER:-puppet}"
+ARG PP_USER=puppet
+ENV PP_USER="${PP_USER}"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]

--- a/docker/r10k/docker-entrypoint.sh
+++ b/docker/r10k/docker-entrypoint.sh
@@ -9,7 +9,7 @@ done
 
 for f in /docker-custom-entrypoint.d/*.sh; do
   # Don't print out any messages here since this is a CLI container
-  [ -x "${f}" ] && "${f}"
+  [ -f "${f}" ] && [ -x "${f}" ] && "${f}"
 done
 
 exec su "${PP_USER}" -c "/usr/bin/r10k $*"

--- a/docker/r10k/docker-entrypoint.sh
+++ b/docker/r10k/docker-entrypoint.sh
@@ -1,11 +1,15 @@
 #! /bin/sh
 
-set -e
+set -ue
 
 for f in /docker-entrypoint.d/*.sh; do
   # Don't print out any messages here since this is a CLI container
-  chmod +x "$f"
-  "$f"
+  su "${PP_USER}" -- "${f}"
 done
 
-exec /usr/bin/r10k "$@"
+for f in /docker-custom-entrypoint.d/*.sh; do
+  # Don't print out any messages here since this is a CLI container
+  [ -x "${f}" ] && "${f}"
+done
+
+exec su "${PP_USER}" -c "/usr/bin/r10k $*"

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -25,8 +25,8 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
 COPY adduser.sh docker-entrypoint.sh /
 COPY docker-entrypoint.d /docker-entrypoint.d
 
-ARG PP_USER
-ENV PP_USER="${PP_USER:-puppet}"
+ARG PP_USER=puppet
+ENV PP_USER="${PP_USER}"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -41,10 +41,10 @@ LABEL org.label-schema.version="$version" \
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # ignore apk and gem pinning
 # hadolint ignore=DL3018,DL3028
-RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
+RUN chmod -R a+x /adduser.sh /docker-entrypoint.sh /docker-entrypoint.d && \
+# Add a puppet user to run r10k as for consistency with puppetserver
     /adduser.sh && \
     chown -R "${PP_USER}:" /docker-entrypoint.d /docker-entrypoint.sh && \
-    chmod -R +x            /docker-entrypoint.d /docker-entrypoint.sh && \
     mkdir -p /docker-custom-entrypoint.d && \
     apk add --no-cache ruby openssh-client git ruby-rugged curl ruby-dev make gcc musl-dev && \
     gem install --no-doc r10k:"$version" json etc && \
@@ -54,6 +54,8 @@ RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
     mv "$supercronic" "/usr/local/bin/${supercronic}" && \
     ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
 
+# Ignore the check for absolute WORKDIR path, this is need when using environment variables in WORKDIR.
+# https://github.com/hadolint/hadolint/wiki/DL3000
 # hadolint ignore=DL3000
 WORKDIR "/home/${PP_USER}"
 

--- a/docker/r10k/release.Dockerfile
+++ b/docker/r10k/release.Dockerfile
@@ -54,6 +54,7 @@ RUN chmod a+x /adduser.sh /docker-entrypoint.sh && \
     mv "$supercronic" "/usr/local/bin/${supercronic}" && \
     ln -s "/usr/local/bin/${supercronic}" /usr/local/bin/supercronic
 
+# hadolint ignore=DL3000
 WORKDIR "/home/${PP_USER}"
 
 COPY release.Dockerfile /


### PR DESCRIPTION
In the [The Puppet Server container](https://github.com/puppetlabs/puppetserver/blob/3b6d9181bc79671220ad938a193d938e95f0a70e/docker/puppetserver/docker-entrypoint.sh#L13-L19) there is the option to mount your own script to config to do some specific configuration for Puppet Server.

It finds it very useful to have this feature for r10k, so I hope you will accept this pull request 😃 I also added the option to have ones own script executed as root.