### PR TITLE
(maint) Put back old version so that release job can bump

### DIFF
--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '2.6.9'
+  VERSION = '2.6.8'
 end


### PR DESCRIPTION
This commit resets the r10k version to 2.6.8. I forgot that the 2.6.x release
job does the bumping for you and the current version needs to be older than the
desired version, so this should allow us to use our automation to release 2.6.9.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
