### PR TITLE
Issue 1096: use Default-Branch

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- Fetch modules from the repo's default branch, rather than defaulting to 'master' [#1096](https://github.com/puppetlabs/r10k/issues/1096)
+
 3.7.0
 -----
 

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -103,7 +103,7 @@ class R10K::Module::Git < R10K::Module::Base
 
     @remote = options[:git]
 
-    @desired_ref = ref_opts.find { |key| break options[key] if options.has_key?(key) } || 'master'
+    @desired_ref = ref_opts.find { |key| break options[key] if options.has_key?(key) } || 'HEAD'
     @default_ref = options[:default_branch]
 
     if @desired_ref == :control_branch && @environment && @environment.respond_to?(:ref)

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -66,7 +66,7 @@ describe R10K::Module::Git do
     end
 
     before(:each) do
-      allow(mock_repo).to receive(:resolve).with('master').and_return('abc123')
+      allow(mock_repo).to receive(:resolve).with('HEAD').and_return('abc123')
       allow(mock_repo).to receive(:head).and_return('abc123')
     end
 
@@ -75,7 +75,7 @@ describe R10K::Module::Git do
     end
 
     it "sets the expected version" do
-      expect(subject.properties).to include(:expected => 'master')
+      expect(subject.properties).to include(:expected => 'HEAD')
     end
 
     it "sets the actual version to the revision when the revision is available" do
@@ -129,10 +129,10 @@ describe R10K::Module::Git do
 
     describe "desired ref" do
       context "when no desired ref is given" do
-        it "defaults to master" do
-          expect(mock_repo).to receive(:resolve).with('master').and_return('abc123')
+        it "defaults to HEAD" do
+          expect(mock_repo).to receive(:resolve).with('HEAD').and_return('abc123')
 
-          expect(test_module({}).properties).to include(expected: 'master')
+          expect(test_module({}).properties).to include(expected: 'HEAD')
         end
       end
 


### PR DESCRIPTION
Use Default-Branch defined by the Upstream-Repo, if no Reference is given.
This Fix is only successful, if the cached Repos are deleted beforehead.

Note: Nowadays the Default-Branch is not always 'master'.  Many Repos
use 'main' f.e.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- [Issue 1096](https://github.com/puppetlabs/r10k/issues/1096): use Default-Branch, if no Ref is given
```
