### PR TITLE
(maint) Update test regexes to work with Puppet 6 and 7

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,7 @@ CHANGELOG
 
 Unreleased
 ----------
+- Update test cases to account for error message changes in Puppet 7
 
 3.6.0
 -----

--- a/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
@@ -24,7 +24,7 @@ stage_env_notify_message = 'This is a different message'
 stage_env_notify_message_regex = /#{stage_env_notify_message}/
 
 #Verification for "test" Environment
-test_env_error_message_regex = /Error:.*Could not find environment 'test'/
+test_env_error_message_regex = /Error:.*Could not.*environment '?test'?/
 
 #Verification for "temp" Environment
 test_env_notify_message_regex = /I am in the temp environment/

--- a/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
@@ -15,7 +15,7 @@ initial_env_names = ['production', 'stage']
 
 #Verification
 notify_message_regex = /I am in the production environment/
-stage_env_error_message_regex = /Error:.*Could not find environment 'stage'/
+stage_env_error_message_regex = /Error:.*Could not.*environment '?stage'?/
 
 #Manifest
 site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')

--- a/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
@@ -22,7 +22,7 @@ site_pp = create_site_pp(master_certname, '  include helloworld')
 notify_message_prod_env_regex = /I am in the production environment/
 notify_message_test_env_regex = /I am in the test environment/
 removal_message_test_env_regex = /Removing unmanaged path.*test/
-error_message_regex = /Could not retrieve catalog from remote server/
+error_message_regex = /Could not retrieve (catalog from remote server|information from environment test)/
 
 #Teardown
 teardown do


### PR DESCRIPTION
Puppet 7 stopped squashing errors from pluginsync while doing an agent
run. So the runs in these tests that error because of a missing
environment now error in a different spot with a different but related
message. This commit updates the test regexes to work in both cases.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
