### PR TITLE
Revert "Issue 1096: use Default-Branch"

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,6 @@ CHANGELOG
 Unreleased
 ----------
 
-- Fetch modules from the repo's default branch, rather than defaulting to 'master' [#1096](https://github.com/puppetlabs/r10k/issues/1096)
 - Experimental feature change: conflicts between environment-defined modules and Puppetfile-defined modules now default to logging a warning and deploying the environment module version, overriding the Puppetfile. Previously, conflicts would result in an error. The behavior is now configurable via the `module_conflicts` environment setting [#1107](https://github.com/puppetlabs/r10k/pull/1107)
 
 3.7.0

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -103,7 +103,7 @@ class R10K::Module::Git < R10K::Module::Base
 
     @remote = options[:git]
 
-    @desired_ref = ref_opts.find { |key| break options[key] if options.has_key?(key) } || 'HEAD'
+    @desired_ref = ref_opts.find { |key| break options[key] if options.has_key?(key) } || 'master'
     @default_ref = options[:default_branch]
 
     if @desired_ref == :control_branch && @environment && @environment.respond_to?(:ref)

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -66,7 +66,7 @@ describe R10K::Module::Git do
     end
 
     before(:each) do
-      allow(mock_repo).to receive(:resolve).with('HEAD').and_return('abc123')
+      allow(mock_repo).to receive(:resolve).with('master').and_return('abc123')
       allow(mock_repo).to receive(:head).and_return('abc123')
     end
 
@@ -75,7 +75,7 @@ describe R10K::Module::Git do
     end
 
     it "sets the expected version" do
-      expect(subject.properties).to include(:expected => 'HEAD')
+      expect(subject.properties).to include(:expected => 'master')
     end
 
     it "sets the actual version to the revision when the revision is available" do
@@ -129,10 +129,10 @@ describe R10K::Module::Git do
 
     describe "desired ref" do
       context "when no desired ref is given" do
-        it "defaults to HEAD" do
-          expect(mock_repo).to receive(:resolve).with('HEAD').and_return('abc123')
+        it "defaults to master" do
+          expect(mock_repo).to receive(:resolve).with('master').and_return('abc123')
 
-          expect(test_module({}).properties).to include(expected: 'HEAD')
+          expect(test_module({}).properties).to include(expected: 'master')
         end
       end
 


### PR DESCRIPTION
This reverts commit 57329b6.
This constituted a breaking change, which we are not prepared to make right now.
In the future, when we are ready for a new major version, we hope to require
users to specify a ref in their Puppetfile, rather than defaulting to something.
See #1110 for more info.