### PR TITLE
[#1106, #1109] Add CLI flags for sshkey and token paths

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -189,6 +189,8 @@ module R10K
                       'generate-types': :self,
                       'puppet-path': :self,
                       'puppet-conf': :self,
+                      'sshkey-path': :self,
+                      'token-path': :self,
                       'default-branch-override': :self)
         end
       end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -77,7 +77,9 @@ module R10K
                       'no-force': :self,
                       'generate-types': :self,
                       'puppet-path': :self,
-                      'puppet-conf': :self)
+                      'puppet-conf': :self,
+                      'sshkey-path': :self,
+                      'token-path': :self)
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -32,6 +32,8 @@ module R10K::CLI
           end
         end
         option nil, :'puppet-conf', 'Path to puppet.conf', argument: :required
+        option nil, :'sshkey-path', 'Path to SSH key to use when cloning. Only valid with rugged provider', argument: :required
+        option nil, :'token-path', 'Path to OAuth token to use when cloning. Only valid with rugged provider', argument: :required
 
         run do |opts, args, cmd|
           puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -21,7 +21,7 @@ module R10K::CLI
 (https://puppet.com/docs/puppet/latest/environments_about.html).
         DESCRIPTION
 
-        required nil, :cachedir, 'Specify a cachedir, overriding the value in config'
+        option nil, :cachedir, 'Specify a cachedir, overriding the value in config', argument: :required
         flag nil, :'no-force', 'Prevent the overwriting of local module modifications'
         flag nil, :'generate-types', 'Run `puppet generate types` after updating an environment'
         option nil, :'puppet-path', 'Path to puppet executable', argument: :required do |value, cmd|
@@ -62,7 +62,8 @@ scheduled. On subsequent deployments, Puppetfile deployment will default to off.
           DESCRIPTION
 
           flag :p, :puppetfile, 'Deploy modules from a puppetfile'
-          required nil, :'default-branch-override', 'Specify a branchname to override the default branch in the puppetfile'
+          option nil, :'default-branch-override', 'Specify a branchname to override the default branch in the puppetfile',
+                 argument: :required
 
           runner R10K::Action::CriRunner.wrap(R10K::Action::Deploy::Environment)
         end
@@ -82,7 +83,7 @@ It will load the Puppetfile configurations out of all environments, and will
 try to deploy the given module names in all environments.
           DESCRIPTION
 
-          required :e, :environment, 'Update the modules in the given environment'
+          option :e, :environment, 'Update the modules in the given environment', argument: :required
 
           runner R10K::Action::CriRunner.wrap(R10K::Action::Deploy::Module)
         end
@@ -100,7 +101,8 @@ try to deploy the given module names in all environments.
           flag :p, :puppetfile, 'Display Puppetfile modules'
           flag nil, :detail, 'Display detailed information'
           flag nil, :fetch, 'Update available environment lists from all remote sources'
-          required nil, :format, 'Display output in a specific format. Valid values: json, yaml. Default: yaml'
+          option nil, :format, 'Display output in a specific format. Valid values: json, yaml. Default: yaml',
+                 argument: :required
 
           runner R10K::Action::CriRunner.wrap(R10K::Action::Deploy::Display)
         end

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -30,8 +30,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           name    'install'
           usage   'install'
           summary 'Install all modules from a Puppetfile'
-          required nil, :moduledir, 'Path to install modules to'
-          required nil, :puppetfile, 'Path to puppetfile'
+          option nil, :moduledir, 'Path to install modules to', argument: :required
+          option nil, :puppetfile, 'Path to puppetfile', argument: :required
           flag     nil, :force, 'Force locally changed files to be overwritten'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end
@@ -45,7 +45,7 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'check'
           summary 'Try and load the Puppetfile to verify the syntax is correct.'
 
-          required nil, :puppetfile, 'Path to Puppetfile'
+          option nil, :puppetfile, 'Path to Puppetfile', argument: :required
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Check)
         end
       end
@@ -58,8 +58,8 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           usage 'purge'
           summary 'Purge unmanaged modules from a Puppetfile managed directory'
 
-          required nil, :moduledir, 'Path to install modules to'
-          required nil, :puppetfile, 'Path to Puppetfile'
+          option nil, :moduledir, 'Path to install modules to', argument: :required
+          option nil, :puppetfile, 'Path to Puppetfile', argument: :required
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Purge)
         end
       end

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -28,8 +28,9 @@ module R10K
     #   @return [R10K::Deployment::Config]
     attr_reader :config
 
-    def initialize(config)
+    def initialize(config, credentials = {})
       @config = config
+      @credentials = credentials
     end
 
     def preload!

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -36,6 +36,14 @@ describe R10K::Action::Deploy::Environment do
     it 'can accept a puppet-path option' do
       described_class.new({ 'puppet-path': '/nonexistent' }, [])
     end
+
+    it 'can accept an sshkey-path option' do
+      described_class.new({ 'sshkey-path': '/nonexistent' }, [])
+    end
+
+    it 'can accept a token option' do
+      described_class.new({ 'token-path': '/nonexistent' }, [])
+    end
   end
 
   describe "when called" do
@@ -338,6 +346,24 @@ describe R10K::Action::Deploy::Environment do
 
       it 'sets puppet_conf' do
         expect(subject.instance_variable_get(:@puppet_conf)).to eq('/nonexistent')
+      end
+    end
+
+    describe 'with sshkey-path' do
+
+      subject { described_class.new({ config: '/some/nonexistent/path', 'sshkey-path': '/nonexistent' }, []) }
+
+      it 'sets puppet_path' do
+        expect(subject.instance_variable_get(:@sshkey_path)).to eq('/nonexistent')
+      end
+    end
+
+    describe 'with token-path' do
+
+      subject { described_class.new({ config: '/some/nonexistent/path', 'token-path': '/nonexistent' }, []) }
+
+      it 'sets puppet_path' do
+        expect(subject.instance_variable_get(:@token_path)).to eq('/nonexistent')
       end
     end
   end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -33,6 +33,14 @@ describe R10K::Action::Deploy::Module do
     it 'can accept a cachedir option' do
       described_class.new({ cachedir: '/nonexistent' }, [])
     end
+
+    it 'can accept an sshkey-path option' do
+      described_class.new({ 'sshkey-path': '/nonexistent' }, [])
+    end
+
+    it 'can accept a token option' do
+      described_class.new({ 'token-path': '/nonexistent' }, [])
+    end
   end
 
   describe "with no-force" do
@@ -147,6 +155,24 @@ describe R10K::Action::Deploy::Module do
 
     it 'sets puppet_path' do
       expect(subject.instance_variable_get(:@cachedir)).to eq('/nonexistent')
+    end
+  end
+
+  describe 'with sshkey-path' do
+
+    subject { described_class.new({ config: '/some/nonexistent/path', 'sshkey-path': '/nonexistent' }, []) }
+
+    it 'sets puppet_path' do
+      expect(subject.instance_variable_get(:@sshkey_path)).to eq('/nonexistent')
+    end
+  end
+
+  describe 'with token-path' do
+
+    subject { described_class.new({ config: '/some/nonexistent/path', 'token-path': '/nonexistent' }, []) }
+
+    it 'sets token_path' do
+      expect(subject.instance_variable_get(:@token_path)).to eq('/nonexistent')
     end
   end
 end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -153,7 +153,7 @@ describe R10K::Action::Deploy::Module do
 
     subject { described_class.new({ config: '/some/nonexistent/path', cachedir: '/nonexistent' }, []) }
 
-    it 'sets puppet_path' do
+    it 'sets cachedir' do
       expect(subject.instance_variable_get(:@cachedir)).to eq('/nonexistent')
     end
   end
@@ -162,7 +162,7 @@ describe R10K::Action::Deploy::Module do
 
     subject { described_class.new({ config: '/some/nonexistent/path', 'sshkey-path': '/nonexistent' }, []) }
 
-    it 'sets puppet_path' do
+    it 'sets sshkey_path' do
       expect(subject.instance_variable_get(:@sshkey_path)).to eq('/nonexistent')
     end
   end


### PR DESCRIPTION
This PR adds two CLI flags to the deploy command, `sshkey-path`
and `token-path`. These will be used to pass credentials to the git
provider for use when cloning the repo, overriding values from the
config for the source.


