### PR TITLE
[#1106, #1109] Plumb git creds from CLI to rugged

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -32,8 +32,7 @@ module R10K
           @visit_ok = true
 
           expect_config!
-          credentials = extract_credentials!
-          deployment = R10K::Deployment.new(@settings, credentials)
+          deployment = R10K::Deployment.new(@settings)
           check_write_lock!(@settings)
 
           deployment.accept(self)
@@ -43,40 +42,6 @@ module R10K
         include R10K::Action::Visitor
 
         private
-
-        def extract_credentials!
-          if @sshkey_path && @token_path
-            raise R10K::Error, "Cannot specify both an SSH key and a token to use with this deploy."
-          end
-
-          if @sshkey_path
-            if File.exists?(@sshkey_path)
-              { sshkey_path: @sshkey_path }
-            else
-              raise R10K::Error, _("{%path} does not exist, cannot load SSH key") % { path: @sshkey_path }
-            end
-          elsif @token_path
-            if @token_path == '-'
-              token = $stdin.read
-            elsif File.exists?(@token_path)
-              token = File.read(@token_path).strip
-            else
-              raise R10K::Error, _("{%path} does not exist, cannot load OAuth token") % { path: @token_path }
-            end
-
-            unless valid_token?(token)
-              raise R10K::Error, _("Supplied token contains invalid characters.")
-            end
-
-            { token: token }
-          end
-        end
-
-        # This regex is the only real requirement for OAuth token format,
-        # per https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
-        def valid_token?(token)
-          return token =~ /^[\w\-\.~\+\/]+$/
-        end
 
         def visit_deployment(deployment)
           # Ensure that everything can be preloaded. If we cannot preload all
@@ -224,8 +189,8 @@ module R10K
                       'generate-types': :self,
                       'puppet-path': :self,
                       'puppet-conf': :self,
-                      'sshkey-path': :self,
-                      'token-path': :self,
+                      'private-key': :self,
+                      'oauth-token': :self,
                       'default-branch-override': :self)
         end
       end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -78,8 +78,8 @@ module R10K
                       'generate-types': :self,
                       'puppet-path': :self,
                       'puppet-conf': :self,
-                      'sshkey-path': :self,
-                      'token-path': :self)
+                      'private-key': :self,
+                      'oauth-token': :self)
         end
       end
     end

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -32,8 +32,8 @@ module R10K::CLI
           end
         end
         option nil, :'puppet-conf', 'Path to puppet.conf', argument: :required
-        option nil, :'sshkey-path', 'Path to SSH key to use when cloning. Only valid with rugged provider', argument: :required
-        option nil, :'token-path', 'Path to OAuth token to use when cloning. Only valid with rugged provider', argument: :required
+        option nil, :'private-key', 'Path to SSH key to use when cloning. Only valid with rugged provider', argument: :required
+        option nil, :'oauth-token', 'Path to OAuth token to use when cloning. Only valid with rugged provider', argument: :required
 
         run do |opts, args, cmd|
           puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -28,9 +28,8 @@ module R10K
     #   @return [R10K::Deployment::Config]
     attr_reader :config
 
-    def initialize(config, credentials = {})
+    def initialize(config)
       @config = config
-      @credentials = credentials
     end
 
     def preload!

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -134,6 +134,7 @@ module R10K
     extend R10K::Settings::Mixin::ClassMethods
 
     def_setting_attr :private_key
+    def_setting_attr :oauth_token
     def_setting_attr :proxy
     def_setting_attr :username
     def_setting_attr :repositories, {}

--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -55,6 +55,7 @@ module R10K
         with_setting(:private_key) { |value| R10K::Git.settings[:private_key] = value }
         with_setting(:proxy) { |value| R10K::Git.settings[:proxy] = value }
         with_setting(:repositories) { |value| R10K::Git.settings[:repositories] = value }
+        with_setting(:oauth_token) { |value| R10K::Git.settings[:oauth_token] = value }
       end
     end
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -37,6 +37,11 @@ module R10K
                     Only used by the 'rugged' Git provider.",
         }),
 
+        Definition.new(:oauth_token, {
+          :desc => "The path to a token file for Git OAuth remotes.
+                    Only used by the 'rugged' Git provider."
+        }),
+
         URIDefinition.new(:proxy, {
           :desc => "An optional proxy server to use when interacting with Git sources via HTTP(S).",
           :default => :inherit,
@@ -54,11 +59,17 @@ module R10K
               :default => :inherit,
             }),
 
+            Definition.new(:oauth_token, {
+              :desc => "The path to a token file for Git OAuth remotes.
+                        Only used by the 'rugged' Git provider.",
+              :default => :inherit
+            }),
+
             URIDefinition.new(:proxy, {
               :desc => "An optional proxy server to use when interacting with Git sources via HTTP(S).",
               :default => :inherit,
             }),
-            
+
             Definition.new(:ignore_branch_prefixes, {
               :desc => "Array of strings used to prefix branch names that will not be deployed as environments.",
             }),

--- a/spec/fixtures/unit/action/r10k_creds.yaml
+++ b/spec/fixtures/unit/action/r10k_creds.yaml
@@ -1,0 +1,9 @@
+---
+  git:
+    private_key: '/global/config/private/key'
+    oauth_token: '/global/config/oauth/token'
+    repositories:
+      - remote: 'git@myfakegitserver.com:user/repo.git'
+        private_key: '/config/private/key'
+      - remote: 'https://myfakegitserver.com/user/repo.git'
+        oauth_token: '/config/oauth/token'

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -27,8 +27,6 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({:'no-force' => true}, [])
     end
 
-    it "normalizes environment names in the arg vector"
-
     it 'can accept a generate-types option' do
       described_class.new({ 'generate-types': true }, [])
     end
@@ -37,12 +35,12 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({ 'puppet-path': '/nonexistent' }, [])
     end
 
-    it 'can accept an sshkey-path option' do
-      described_class.new({ 'sshkey-path': '/nonexistent' }, [])
+    it 'can accept a private-key option' do
+      described_class.new({ 'private-key': '/nonexistent' }, [])
     end
 
     it 'can accept a token option' do
-      described_class.new({ 'token-path': '/nonexistent' }, [])
+      described_class.new({ 'oauth-token': '/nonexistent' }, [])
     end
   end
 
@@ -175,67 +173,6 @@ describe R10K::Action::Deploy::Environment do
         R10K::Deployment.new(mock_config)
       end
 
-      it 'errors if both token and key paths are passed' do
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                      'token-path': '/nonexistent',
-                                      'sshkey-path': '/also/fake' }, [])
-        expect{ action.call }.to raise_error(R10K::Error, /Cannot specify both/)
-      end
-
-      it 'errors if sshkey file does not exist' do
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                      'sshkey-path': '/also/fake' }, [])
-        expect{ action.call }.to raise_error(R10K::Error, /cannot load SSH key/)
-
-      end
-
-      it 'errors if token file does not exist' do
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                      'token-path': '/also/fake' }, [])
-        expect{ action.call }.to raise_error(R10K::Error, /cannot load OAuth token/)
-      end
-
-      it 'passes token to deployment from file' do
-        token_file = Tempfile.new('token')
-        token_file.write('my_token')
-        token_file.close
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                       'token-path': token_file.path }, [])
-        expect(R10K::Deployment).to receive(:new).with({}, { token: "my_token" }).and_return(deployment)
-        action.call
-      end
-
-      it 'passes token to deployment from stdin' do
-        allow($stdin).to receive(:read).and_return("my_token")
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                       'token-path': '-' }, [])
-        expect(R10K::Deployment).to receive(:new).with({}, { token: 'my_token' }).and_return(deployment)
-        action.call
-      end
-
-      it 'errors if the token on stdin is not a valid OAuth token' do
-        allow($stdin).to receive(:read).and_return("<bad>token")
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                       'token-path': '-' }, [])
-        expect{ action.call }.to raise_error(R10K::Error, /Supplied token contains invalid characters/)
-      end
-
-      it 'errors if the token in the file is not a valid OAuth token' do
-        token_file = Tempfile.new('token')
-        token_file.write('my bad \ntoken')
-        token_file.close
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                       'token-path': token_file.path }, [])
-        expect{ action.call }.to raise_error(R10K::Error, /Supplied token contains invalid characters/)
-      end
-
-      it 'passes sshkey path to deployment' do
-        sshkey_file = Tempfile.new('sshkey')
-        action = described_class.new({ config: '/some/nonexistent/path',
-                                       'sshkey-path': sshkey_file.path }, [])
-        expect(R10K::Deployment).to receive(:new).with({}, { sshkey_path: sshkey_file.path }).and_return(deployment)
-        action.call
-      end
     end
 
     describe "purge_levels" do
@@ -418,21 +355,21 @@ describe R10K::Action::Deploy::Environment do
       end
     end
 
-    describe 'with sshkey-path' do
+    describe 'with private-key' do
 
-      subject { described_class.new({ config: '/some/nonexistent/path', 'sshkey-path': '/nonexistent' }, []) }
+      subject { described_class.new({ config: '/some/nonexistent/path', 'private-key': '/nonexistent' }, []) }
 
-      it 'sets sshkey_path' do
-        expect(subject.instance_variable_get(:@sshkey_path)).to eq('/nonexistent')
+      it 'sets private_key' do
+        expect(subject.instance_variable_get(:@private_key)).to eq('/nonexistent')
       end
     end
 
-    describe 'with token-path' do
+    describe 'with oauth-token' do
 
-      subject { described_class.new({ config: '/some/nonexistent/path', 'token-path': '/nonexistent' }, []) }
+      subject { described_class.new({ config: '/some/nonexistent/path', 'oauth-token': '/nonexistent' }, []) }
 
-      it 'sets token_path' do
-        expect(subject.instance_variable_get(:@token_path)).to eq('/nonexistent')
+      it 'sets oauth_token' do
+        expect(subject.instance_variable_get(:@oauth_token)).to eq('/nonexistent')
       end
     end
   end

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -34,12 +34,12 @@ describe R10K::Action::Deploy::Module do
       described_class.new({ cachedir: '/nonexistent' }, [])
     end
 
-    it 'can accept an sshkey-path option' do
-      described_class.new({ 'sshkey-path': '/nonexistent' }, [])
+    it 'can accept a private-key option' do
+      described_class.new({ 'private-key': '/nonexistent' }, [])
     end
 
     it 'can accept a token option' do
-      described_class.new({ 'token-path': '/nonexistent' }, [])
+      described_class.new({ 'oauth-token': '/nonexistent' }, [])
     end
   end
 
@@ -158,21 +158,21 @@ describe R10K::Action::Deploy::Module do
     end
   end
 
-  describe 'with sshkey-path' do
+  describe 'with private-key' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path', 'sshkey-path': '/nonexistent' }, []) }
+    subject { described_class.new({ config: '/some/nonexistent/path', 'private-key': '/nonexistent' }, []) }
 
-    it 'sets sshkey_path' do
-      expect(subject.instance_variable_get(:@sshkey_path)).to eq('/nonexistent')
+    it 'sets private_key' do
+      expect(subject.instance_variable_get(:@private_key)).to eq('/nonexistent')
     end
   end
 
-  describe 'with token-path' do
+  describe 'with oauth-token' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path', 'token-path': '/nonexistent' }, []) }
+    subject { described_class.new({ config: '/some/nonexistent/path', 'oauth-token': '/nonexistent' }, []) }
 
     it 'sets token_path' do
-      expect(subject.instance_variable_get(:@token_path)).to eq('/nonexistent')
+      expect(subject.instance_variable_get(:@oauth_token)).to eq('/nonexistent')
     end
   end
 end


### PR DESCRIPTION
This is an alternative approach to https://github.com/puppetlabs/r10k/pull/1115 that avoids changing method signatures throughout the project. 

In this implementation, the `oauth_token_file` setting is available both on the CLI and and as a global config option, with the CLI version taking precedence. If we want to add a per-repo token setting to the config, we will have the same question as for SSH keys, described below.

When writing this, I assumed we wanted the CLI flag for the private key to take precedence over both the global and per-repo settings, but that made the precedence weird and I ended up having to add a new setting for the private key from the CLI. Does that assumption make sense? Or should we have it just override the global value, and let the per-repo still be the highest precedence? If so, we can do away with the weird extra setting. In this scenario, someone wanting to specify an SSH key file on the CLI should not configure it in the per-repo settings.