### PR TITLE
(maint) Ensure puppet agent is stopped in integration tests

### DIFF
--- a/integration/pre-suite/00_pe_install.rb
+++ b/integration/pre-suite/00_pe_install.rb
@@ -4,3 +4,7 @@ test_name 'CODEMGMT-20 - C48 - Install Puppet Enterprise'
 
 step 'Install PE'
 install_pe
+
+hosts.each do |host|
+  stop_agent_on(host)
+end


### PR DESCRIPTION
I did not update the changelog because it is purely a test change.
