### PR TITLE
Fix leaky env module deploys

### DIFF
--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -46,12 +46,12 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   #     - The r10k environment object
   #     - A Puppetfile in the environment's content
   def modules
-    return @modules if @puppetfile.nil?
+    return @modules if puppetfile.nil?
 
-    @puppetfile.load unless @puppetfile.loaded?
+    puppetfile.load unless puppetfile.loaded?
 
     env_mod_names = @modules.map(&:name)
-    @modules + @puppetfile.modules.select { |mod| !env_mod_names.include?(mod.name) }
+    @modules + puppetfile.modules.select { |mod| !env_mod_names.include?(mod.name) }
   end
 
   def accept(visitor)
@@ -98,8 +98,8 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   end
 
   def validate_no_module_conflicts
-    @puppetfile.load unless @puppetfile.loaded?
-    conflicts = (@modules + @puppetfile.modules)
+    puppetfile.load unless puppetfile.loaded?
+    conflicts = (@modules + puppetfile.modules)
                 .group_by { |mod| mod.name }
                 .select { |_, v| v.size > 1 }
     unless conflicts.empty?
@@ -110,10 +110,10 @@ class R10K::Environment::WithModules < R10K::Environment::Base
       case conflict_opt = @options[:module_conflicts]
       when 'override_puppetfile_and_warn', nil
         logger.warn log_msg
-        conflicting_mods.each { |mod| @puppetfile.remove_module(mod) }
+        conflicting_mods.each { |mod| puppetfile.remove_module(mod) }
       when 'override_puppetfile'
         logger.debug log_msg
-        conflicting_mods.each { |mod| @puppetfile.remove_module(mod) }
+        conflicting_mods.each { |mod| puppetfile.remove_module(mod) }
       when 'error'
         raise R10K::Error, _('Puppetfile cannot contain module names defined by environment ' \
                              '%{env}; Remove the conflicting definitions of the following modules: ' \

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -140,6 +140,15 @@ class Puppetfile
     @modules << mod
   end
 
+  # Removes a loaded module from the set of content being managed
+  # @param [R10K::Module::Base] mod
+  def remove_module(mod)
+    return unless @modules.include?(mod)
+    @modules -= [mod]
+    @managed_content[mod.dirname] -= [mod.name]
+    @managed_content.delete(mod.dirname) if @managed_content[mod.dirname].empty?
+  end
+
   include R10K::Util::Purgeable
 
   def managed_directories

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -42,11 +42,6 @@ class Puppetfile
   #   @return [Boolean] Overwrite any locally made changes
   attr_accessor :force
 
-  # @!attribute [r] modules_by_vcs_cachedir
-  #   @api private Only exposed for testing purposes
-  #   @return [Hash{:none, String => Array<R10K::Module>}]
-  attr_reader :modules_by_vcs_cachedir
-
   # @param [String] basedir
   # @param [String] moduledir The directory to install the modules, default to #{basedir}/modules
   # @param [String] puppetfile_path The path to the Puppetfile, default to #{basedir}/Puppetfile
@@ -63,7 +58,6 @@ class Puppetfile
 
     @modules = []
     @managed_content = {}
-    @modules_by_vcs_cachedir = {}
     @forge   = 'forgeapi.puppetlabs.com'
 
     @loaded = false
@@ -83,7 +77,7 @@ class Puppetfile
 
     dsl = R10K::Puppetfile::DSL.new(self)
     dsl.instance_eval(puppetfile_contents, @puppetfile_path)
-    
+
     validate_no_duplicate_names(@modules)
     @loaded = true
   rescue SyntaxError, LoadError, ArgumentError, NameError => e
@@ -140,12 +134,9 @@ class Puppetfile
     @managed_content[install_path] = Array.new unless @managed_content.has_key?(install_path)
 
     mod = R10K::Module.new(name, install_path, args, @environment)
-    mod.origin = 'Puppetfile'
+    mod.origin = :puppetfile
 
     @managed_content[install_path] << mod.name
-    cachedir = mod.cachedir
-    @modules_by_vcs_cachedir[cachedir] ||= []
-    @modules_by_vcs_cachedir[cachedir] << mod
     @modules << mod
   end
 
@@ -223,7 +214,7 @@ class Puppetfile
   def modules_queue(visitor)
     Queue.new.tap do |queue|
       visitor.visit(:puppetfile, self) do
-        modules_by_cachedir = modules_by_vcs_cachedir.clone
+        modules_by_cachedir = modules.group_by { |mod| mod.cachedir }
         modules_without_vcs_cachedir = modules_by_cachedir.delete(:none) || []
 
         modules_without_vcs_cachedir.each {|mod| queue << Array(mod) }

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -82,8 +82,8 @@ describe R10K::Action::Deploy::Module do
 
       before do
         allow(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
-          expect(environment.puppetfile).to receive(:modules_by_vcs_cachedir).and_return(
-            {none: [R10K::Module::Local.new(environment.name, '/fakedir', [], environment)]}
+          expect(environment.puppetfile).to receive(:modules).and_return(
+            [R10K::Module::Local.new(environment.name, '/fakedir', [], environment)]
           )
           original.call(environment, &block)
         end

--- a/spec/unit/environment/with_modules_spec.rb
+++ b/spec/unit/environment/with_modules_spec.rb
@@ -10,9 +10,9 @@ describe R10K::Environment::WithModules do
       {
         :type             => 'bare',
         :modules          => {
-          'puppetlabs-stdlib' => '6.0.0',
-          'puppetlabs-concat' => '6.1.0',
-          'puppetlabs-exec'   => '0.5.0',
+          'puppetlabs-stdlib' => { local: true },
+          'puppetlabs-concat' => { local: true },
+          'puppetlabs-exec'   => { local: true },
         }
       }.merge(subject_params)
     )
@@ -24,7 +24,7 @@ describe R10K::Environment::WithModules do
   describe "dealing with Puppetfile module conflicts" do
     context "with no module conflicts" do
       it "validates when there are no conflicts" do
-        mod = double('module', :name => 'nonconflict')
+        mod = instance_double('R10K::Module::Base', :name => 'nonconflict')
         expect(subject.puppetfile).to receive(:load)
         expect(subject.puppetfile).to receive(:modules).and_return [mod]
         expect { subject.validate_no_module_conflicts }.not_to raise_error
@@ -33,16 +33,16 @@ describe R10K::Environment::WithModules do
 
     context "with module conflicts and default behavior" do
       it "does not raise an error" do
-        mod = double('duplicate-stdlib', :name => 'stdlib')
+        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
         expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).and_return [mod]
+        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
         expect(subject.logger).to receive(:warn).with(/Puppetfile.*both define.*ignored/i)
         expect { subject.validate_no_module_conflicts }.not_to raise_error
       end
 
       it "does not visit puppetfile modules overridden by environment modules" do
-        mod1 = double('puppet-nondup', name: 'nondup', dirname: '/dev/null', cachedir: :none)
-        mod2 = double('puppet-stdlib', name: 'stdlib', dirname: '/dev/null', cachedir: :none)
+        mod1 = instance_double('R10K::Module::Base', name: 'nondup', dirname: '/dev/null', cachedir: :none)
+        mod2 = instance_double('R10K::Module::Base', name: 'stdlib', dirname: '/dev/null', cachedir: :none)
 
         pf = R10K::Puppetfile.new('/some/nonexistent/path', nil, nil)
         pf.instance_variable_set(:@managed_content, {'/dev/null' => []})
@@ -65,9 +65,9 @@ describe R10K::Environment::WithModules do
     context "with module conflicts and 'error' behavior" do
       let(:subject_params) {{ :module_conflicts => 'error' }}
       it "raises an error" do
-        mod = double('duplicate-stdlib', :name => 'stdlib')
+        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
         expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).and_return [mod]
+        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
         expect { subject.validate_no_module_conflicts }.to raise_error(R10K::Error, /Puppetfile.*defined.*conflict/i)
       end
     end
@@ -75,9 +75,9 @@ describe R10K::Environment::WithModules do
     context "with module conflicts and 'override_puppetfile' behavior" do
       let(:subject_params) {{ :module_conflicts => 'override_puppetfile' }}
       it "does not raise an error" do
-        mod = double('duplicate-stdlib', :name => 'stdlib')
+        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
         expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).and_return [mod]
+        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
         expect(subject.logger).to receive(:debug).with(/Puppetfile.*both define.*ignored/i)
         expect { subject.validate_no_module_conflicts }.not_to raise_error
       end
@@ -86,9 +86,9 @@ describe R10K::Environment::WithModules do
     context "with module conflicts and invalid configuration" do
       let(:subject_params) {{ :module_conflicts => 'batman' }}
       it "raises an error" do
-        mod = double('duplicate-stdlib', :name => 'stdlib')
+        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
         expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).and_return [mod]
+        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
         expect { subject.validate_no_module_conflicts }.to raise_error(R10K::Error, /Unexpected value.*module_conflicts/i)
       end
     end
@@ -96,15 +96,15 @@ describe R10K::Environment::WithModules do
 
   describe "modules method" do
     it "overrides duplicates, choosing the environment version" do
-      mod = double('duplicate-stdlib', :name => 'stdlib', :giveaway => :'i-am-a-double')
+      puppetfile_mod = instance_double('R10K::Module::Base', name: 'stdlib')
       expect(subject.puppetfile).to receive(:load)
-      expect(subject.puppetfile).to receive(:modules).and_return [mod]
-      returned = subject.modules
-      expect(returned.map(&:name).sort).to eq(%w[concat exec stdlib])
+      expect(subject.puppetfile).to receive(:modules).and_return [puppetfile_mod]
+      returned_modules = subject.modules
+      expect(returned_modules.map(&:name).sort).to eq(%w[concat exec stdlib])
 
       # Make sure the module that was picked was the environment one, not the Puppetfile one
-      stdlib = returned.find { |m| m.name == 'stdlib' }
-      expect(stdlib.respond_to?(:giveaway)).to eq(false)
+      selected_stdlib = returned_modules.find { |m| m.name == 'stdlib' }
+      expect(selected_stdlib).not_to eq(puppetfile_mod)
     end
   end
 end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -127,25 +127,6 @@ describe R10K::Puppetfile do
 
       expect { subject.add_module('puppet/test_module', module_opts) }.to raise_error(R10K::Error, /cannot manage content.*is not within/i).and not_change { subject.modules }
     end
-
-    it "groups modules by vcs cache location" do
-      module_opts = { install_path: File.join(subject.basedir, 'vendor') }
-      opts1 = module_opts.merge(git: 'git@example.com:puppet/test_module.git')
-      opts2 = module_opts.merge(git: 'git@example.com:puppet/test_module_c.git')
-      sanitized_name1 = "git@example.com-puppet-test_module.git"
-      sanitized_name2 = "git@example.com-puppet-test_module_c.git"
-
-      subject.add_module('puppet/test_module_a', opts1)
-      subject.add_module('puppet/test_module_b', opts1)
-      subject.add_module('puppet/test_module_c', opts2)
-      subject.add_module('puppet/test_module_d', '1.2.3')
-
-      mods_by_cachedir = subject.modules_by_vcs_cachedir
-
-      expect(mods_by_cachedir[:none].length).to be 1
-      expect(mods_by_cachedir[sanitized_name1].length).to be 2
-      expect(mods_by_cachedir[sanitized_name2].length).to be 1
-    end
   end
 
   describe "#purge_exclusions" do
@@ -302,12 +283,12 @@ describe R10K::Puppetfile do
         block.call
       end
 
-      mod1 = spy('module')
+      mod1 = double('module', :cachedir => :none)
+      mod2 = double('module', :cachedir => :none)
       expect(mod1).to receive(:accept).with(visitor)
-      mod2 = spy('module')
       expect(mod2).to receive(:accept).with(visitor)
+      expect(subject).to receive(:modules).and_return([mod1, mod2])
 
-      expect(subject).to receive(:modules_by_vcs_cachedir).and_return({none: [mod1, mod2]})
       subject.accept(visitor)
     end
 
@@ -323,12 +304,11 @@ describe R10K::Puppetfile do
         block.call
       end
 
-      mod1 = spy('module')
+      mod1 = double('module1', :cachedir => :none)
+      mod2 = double('module2', :cachedir => :none)
       expect(mod1).to receive(:accept).with(visitor)
-      mod2 = spy('module')
       expect(mod2).to receive(:accept).with(visitor)
-
-      expect(subject).to receive(:modules_by_vcs_cachedir).and_return({none: [mod1, mod2]})
+      expect(subject).to receive(:modules).and_return([mod1, mod2])
 
       expect(Thread).to receive(:new).exactly(pool_size).and_call_original
       expect(Queue).to receive(:new).and_call_original
@@ -344,22 +324,19 @@ describe R10K::Puppetfile do
         block.call
       end
 
-      mod1 = spy('module1')
-      mod2 = spy('module2')
-      mod3 = spy('module3')
-      mod4 = spy('module4')
-      mod5 = spy('module5')
-      mod6 = spy('module6')
+      m1 = double('module1', :cachedir => '/dev/null/A')
+      m2 = double('module2', :cachedir => '/dev/null/B')
+      m3 = double('module3', :cachedir => '/dev/null/C')
+      m4 = double('module4', :cachedir => '/dev/null/C')
+      m5 = double('module5', :cachedir => '/dev/null/D')
+      m6 = double('module6', :cachedir => '/dev/null/D')
 
-      expect(subject).to receive(:modules_by_vcs_cachedir)
-        .and_return({:none => [mod1, mod2],
-                     "foo-cachedir" => [mod3, mod4],
-                     "bar-cachedir" => [mod5, mod6]})
+      expect(subject).to receive(:modules).and_return([m1, m2, m3, m4, m5, m6])
 
       queue = subject.modules_queue(visitor)
       expect(queue.length).to be 4
       queue_array = 4.times.map { queue.pop }
-      expect(queue_array).to match_array([[mod1], [mod2], [mod3, mod4], [mod5, mod6]])
+      expect(queue_array).to match_array([[m1], [m2], [m3, m4], [m5, m6]])
     end
   end
 end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -283,8 +283,8 @@ describe R10K::Puppetfile do
         block.call
       end
 
-      mod1 = double('module', :cachedir => :none)
-      mod2 = double('module', :cachedir => :none)
+      mod1 = instance_double('R10K::Module::Base', :cachedir => :none)
+      mod2 = instance_double('R10K::Module::Base', :cachedir => :none)
       expect(mod1).to receive(:accept).with(visitor)
       expect(mod2).to receive(:accept).with(visitor)
       expect(subject).to receive(:modules).and_return([mod1, mod2])
@@ -304,8 +304,8 @@ describe R10K::Puppetfile do
         block.call
       end
 
-      mod1 = double('module1', :cachedir => :none)
-      mod2 = double('module2', :cachedir => :none)
+      mod1 = instance_double('R10K::Module::Base', :cachedir => :none)
+      mod2 = instance_double('R10K::Module::Base', :cachedir => :none)
       expect(mod1).to receive(:accept).with(visitor)
       expect(mod2).to receive(:accept).with(visitor)
       expect(subject).to receive(:modules).and_return([mod1, mod2])
@@ -324,12 +324,12 @@ describe R10K::Puppetfile do
         block.call
       end
 
-      m1 = double('module1', :cachedir => '/dev/null/A')
-      m2 = double('module2', :cachedir => '/dev/null/B')
-      m3 = double('module3', :cachedir => '/dev/null/C')
-      m4 = double('module4', :cachedir => '/dev/null/C')
-      m5 = double('module5', :cachedir => '/dev/null/D')
-      m6 = double('module6', :cachedir => '/dev/null/D')
+      m1 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/A')
+      m2 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/B')
+      m3 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/C')
+      m4 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/C')
+      m5 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/D')
+      m6 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/D')
 
       expect(subject).to receive(:modules).and_return([m1, m2, m3, m4, m5, m6])
 


### PR DESCRIPTION
This fixes a problem with "Implement less restrictive env module merge", merged at e6831cbfcf813a583cbbb1cfe6df76027eb97896.

Previously, when an environment should have overridden a Puppetfile-defined module, it did not. This is because the Puppetfile still contained a copy of the module, and when visited, it deployed that copy, overwriting the environment's version of the module.