### PR TITLE
(CODEMGMT-1350) Fall back to default branch even when overridden

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- Module ref resolution will now fall back to the normal default branch if the default branch override cannot be resolved. [#1122](https://github.com/puppetlabs/r10k/pull/1122)
 - Experimental feature change: conflicts between environment-defined modules and Puppetfile-defined modules now default to logging a warning and deploying the environment module version, overriding the Puppetfile. Previously, conflicts would result in an error. The behavior is now configurable via the `module_conflicts` environment setting [#1107](https://github.com/puppetlabs/r10k/pull/1107)
 
 3.7.0

--- a/doc/dynamic-environments/usage.mkd
+++ b/doc/dynamic-environments/usage.mkd
@@ -66,11 +66,12 @@ Update a single environment and specify a default branch override:
 
     r10k deploy environment my_working_environment --puppetfile --default-branch-override default_branch_override
 
-This will update the given environment and update all contained modules, overrideing 
-the :default_branch entry in the Puppetfile of each module. This is used primarily to allow
+This will update the given environment and update all contained modules, overriding
+the :default_branch entry in the Puppetfile of each module. If the specified override branch is not
+found, it will fall back to the normal default branch and attempt to use that. This is used primarily to allow
 automated r10k solutions using the control_branch pattern with a temporary branch deployment to 
-ensure the deployment is pushed to the correct module repository branch. Note that the :default_branch
-is only ever utilized if the desired ref cannot be located.
+ensure the deployment is pushed to the correct module repository branch. Note that the :default_branch and its
+override are only ever used if the specific desired ref cannot be located.
 
 ### Deploying modules
 

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -83,7 +83,7 @@ class Puppetfile
 
     dsl = R10K::Puppetfile::DSL.new(self)
     dsl.instance_eval(puppetfile_contents, @puppetfile_path)
-    
+
     validate_no_duplicate_names(@modules)
     @loaded = true
   rescue SyntaxError, LoadError, ArgumentError, NameError => e
@@ -133,7 +133,7 @@ class Puppetfile
     end
 
     if args.is_a?(Hash) && @default_branch_override != nil
-      args[:default_branch] = @default_branch_override
+      args[:default_branch_override] = @default_branch_override
     end
 
     # Keep track of all the content this Puppetfile is managing to enable purging.

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -283,7 +283,8 @@ describe R10K::Puppetfile do
       default_branch_override = 'default_branch_override_name'
       expect { subject.load!(default_branch_override) }.not_to raise_error
       git_module = subject.modules[0]
-      expect(git_module.default_ref).to eq default_branch_override
+      expect(git_module.default_override_ref).to eq default_branch_override
+      expect(git_module.default_ref).to eq "here_lies_the_default_branch"
     end
   end
 


### PR DESCRIPTION
Currently, if a default branch override for a module is specified, if
that branch doesn't exist, r10k will error without checking the module's
normal default branch. This is not desirable, so this commit updates the
fallback logic so that the default branch ref will also be checked, if
the branch override fails to resolve. This makes it more likely that we
will successfully resolve a module, rather than erroring.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- Summary of changes. [Issue or PR #](link to issue or PR)
```
