### PR TITLE
(maint) Remove community partners from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-*        @puppetlabs/puppetserver-maintainers @adrienthebo @dhollinger
+*        @puppetlabs/puppetserver-maintainers
 /docker/ @puppetlabs/pupperware


### PR DESCRIPTION
Our community partners did not end up having the bandwidth to contribute to r10k
as much as we all would have liked. We can revisit the community partnership at
any point when community members want to take this on.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- Summary of changes. [Issue or PR #](link to issue or PR)
```
