### PR TITLE
(maint) Fix problem introduced in #1120

### DIFF
--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -679,8 +679,8 @@ When a module is defined in an environment and also in a Puppetfile, the default
 
 Available `module_conflicts` options:
 
-* `override_puppetfile_and_warn` (default): the version of the module defined by the environment will be used, and the version defined in the Puppetfile will be ignored. A warning will be printed.
-* `override_puppetfile`: the version of the module defined by the environment will be used, and the version defined in the Puppetfile will be ignored.
+* `override_and_warn` (default): the version of the module defined by the environment will be used, and the version defined in the Puppetfile will be ignored. A warning will be printed.
+* `override`: the version of the module defined by the environment will be used, and the version defined in the Puppetfile will be ignored.
 * `error`: an error will be raised alerting the user to the conflict. The environment will not be deployed.
 
 ```yaml

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -103,6 +103,13 @@ class R10K::Environment::Base
     @puppetfile.modules
   end
 
+  # @return [Array<R10K::Module::Base>] Whether or not the given module
+  #   conflicts with any modules already defined in the r10k environment
+  #   object.
+  def module_conflicts?(mod)
+    false
+  end
+
   def accept(visitor)
     visitor.visit(:environment, self) do
       puppetfile.accept(visitor)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -22,10 +22,6 @@ class Puppetfile
   #   @return [Array<R10K::Module>]
   attr_reader :modules
 
-  # @!attribute [r] disabled_modules
-  #   @return [Array<R10K::Module>]
-  attr_reader :disabled_modules
-
   # @!attribute [r] basedir
   #   @return [String] The base directory that contains the Puppetfile
   attr_reader :basedir
@@ -61,7 +57,6 @@ class Puppetfile
     logger.info _("Using Puppetfile '%{puppetfile}'") % {puppetfile: @puppetfile_path}
 
     @modules = []
-    @disabled_modules = []
     @managed_content = {}
     @forge   = 'forgeapi.puppetlabs.com'
 
@@ -141,7 +136,7 @@ class Puppetfile
     # Do not load modules if they would conflict with the attached
     # environment
     if environment && environment.module_conflicts?(mod)
-      @disabled_modules << mod
+      mod = nil
       return @modules
     end
 

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -22,6 +22,10 @@ class Puppetfile
   #   @return [Array<R10K::Module>]
   attr_reader :modules
 
+  # @!attribute [r] disabled_modules
+  #   @return [Array<R10K::Module>]
+  attr_reader :disabled_modules
+
   # @!attribute [r] basedir
   #   @return [String] The base directory that contains the Puppetfile
   attr_reader :basedir
@@ -57,6 +61,7 @@ class Puppetfile
     logger.info _("Using Puppetfile '%{puppetfile}'") % {puppetfile: @puppetfile_path}
 
     @modules = []
+    @disabled_modules = []
     @managed_content = {}
     @forge   = 'forgeapi.puppetlabs.com'
 
@@ -130,23 +135,21 @@ class Puppetfile
       args[:default_branch_override] = @default_branch_override
     end
 
-    # Keep track of all the content this Puppetfile is managing to enable purging.
-    @managed_content[install_path] = Array.new unless @managed_content.has_key?(install_path)
-
     mod = R10K::Module.new(name, install_path, args, @environment)
     mod.origin = :puppetfile
 
-    @managed_content[install_path] << mod.name
-    @modules << mod
-  end
+    # Do not load modules if they would conflict with the attached
+    # environment
+    if environment && environment.module_conflicts?(mod)
+      @disabled_modules << mod
+      return @modules
+    end
 
-  # Removes a loaded module from the set of content being managed
-  # @param [R10K::Module::Base] mod
-  def remove_module(mod)
-    return unless @modules.include?(mod)
-    @modules -= [mod]
-    @managed_content[mod.dirname] -= [mod.name]
-    @managed_content.delete(mod.dirname) if @managed_content[mod.dirname].empty?
+    # Keep track of all the content this Puppetfile is managing to enable purging.
+    @managed_content[install_path] = Array.new unless @managed_content.has_key?(install_path)
+    @managed_content[install_path] << mod.name
+
+    @modules << mod
   end
 
   include R10K::Util::Purgeable

--- a/spec/unit/environment/with_modules_spec.rb
+++ b/spec/unit/environment/with_modules_spec.rb
@@ -21,90 +21,54 @@ describe R10K::Environment::WithModules do
   # Default no additional params
   let(:subject_params) { {} }
 
-  describe "dealing with Puppetfile module conflicts" do
+  describe "dealing with module conflicts" do
     context "with no module conflicts" do
       it "validates when there are no conflicts" do
-        mod = instance_double('R10K::Module::Base', :name => 'nonconflict')
-        expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).and_return [mod]
-        expect { subject.validate_no_module_conflicts }.not_to raise_error
+        mod = instance_double('R10K::Module::Base', name: 'nonconflict', origin: :puppetfile)
+        expect(subject.module_conflicts?(mod)).to eq false
       end
     end
 
     context "with module conflicts and default behavior" do
       it "does not raise an error" do
-        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
-        expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
+        mod = instance_double('R10K::Module::Base', name: 'stdlib', origin: :puppetfile)
         expect(subject.logger).to receive(:warn).with(/Puppetfile.*both define.*ignored/i)
-        expect { subject.validate_no_module_conflicts }.not_to raise_error
-      end
-
-      it "does not visit puppetfile modules overridden by environment modules" do
-        mod1 = instance_double('R10K::Module::Base', name: 'nondup', dirname: '/dev/null', cachedir: :none)
-        mod2 = instance_double('R10K::Module::Base', name: 'stdlib', dirname: '/dev/null', cachedir: :none)
-
-        pf = R10K::Puppetfile.new('/some/nonexistent/path', nil, nil)
-        pf.instance_variable_set(:@managed_content, {'/dev/null' => []})
-        pf.instance_variable_set(:@modules, [mod1, mod2])
-
-        allow(subject).to receive(:puppetfile).and_return(pf)
-        allow(pf).to receive(:load).and_return(nil)
-
-        visitor = spy('visitor')
-        expect(visitor).to receive(:visit).with(:environment, subject) { |&block| block.call }
-        expect(visitor).to receive(:visit).with(:puppetfile, pf) { |&block| block.call }
-
-        expect(mod1).to receive(:accept)
-        expect(mod2).not_to receive(:accept)
-
-        subject.accept(visitor)
+        expect(subject.module_conflicts?(mod)).to eq true
       end
     end
 
     context "with module conflicts and 'error' behavior" do
       let(:subject_params) {{ :module_conflicts => 'error' }}
       it "raises an error" do
-        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
-        expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
-        expect { subject.validate_no_module_conflicts }.to raise_error(R10K::Error, /Puppetfile.*defined.*conflict/i)
+        mod = instance_double('R10K::Module::Base', name: 'stdlib', origin: :puppetfile)
+        expect { subject.module_conflicts?(mod) }.to raise_error(R10K::Error, /Puppetfile.*both define.*/i)
       end
     end
 
-    context "with module conflicts and 'override_puppetfile' behavior" do
-      let(:subject_params) {{ :module_conflicts => 'override_puppetfile' }}
+    context "with module conflicts and 'override' behavior" do
+      let(:subject_params) {{ :module_conflicts => 'override' }}
       it "does not raise an error" do
-        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
-        expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
+        mod = instance_double('R10K::Module::Base', name: 'stdlib', origin: :puppetfile)
         expect(subject.logger).to receive(:debug).with(/Puppetfile.*both define.*ignored/i)
-        expect { subject.validate_no_module_conflicts }.not_to raise_error
+        expect(subject.module_conflicts?(mod)).to eq true
       end
     end
 
     context "with module conflicts and invalid configuration" do
       let(:subject_params) {{ :module_conflicts => 'batman' }}
       it "raises an error" do
-        mod = instance_double('R10K::Module::Base', :name => 'stdlib')
-        expect(subject.puppetfile).to receive(:load)
-        expect(subject.puppetfile).to receive(:modules).at_least(:once).and_return([mod])
-        expect { subject.validate_no_module_conflicts }.to raise_error(R10K::Error, /Unexpected value.*module_conflicts/i)
+        mod = instance_double('R10K::Module::Base', name: 'stdlib', origin: :puppetfile)
+        expect { subject.module_conflicts?(mod) }.to raise_error(R10K::Error, /Unexpected value.*module_conflicts.*/i)
       end
     end
   end
 
   describe "modules method" do
-    it "overrides duplicates, choosing the environment version" do
-      puppetfile_mod = instance_double('R10K::Module::Base', name: 'stdlib')
-      expect(subject.puppetfile).to receive(:load)
+    it "returns the configured modules, and Puppetfile modules" do
+      puppetfile_mod = instance_double('R10K::Module::Base', name: 'zebra')
       expect(subject.puppetfile).to receive(:modules).and_return [puppetfile_mod]
       returned_modules = subject.modules
-      expect(returned_modules.map(&:name).sort).to eq(%w[concat exec stdlib])
-
-      # Make sure the module that was picked was the environment one, not the Puppetfile one
-      selected_stdlib = returned_modules.find { |m| m.name == 'stdlib' }
-      expect(selected_stdlib).not_to eq(puppetfile_mod)
+      expect(returned_modules.map(&:name).sort).to eq(%w[concat exec stdlib zebra])
     end
   end
 end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -127,6 +127,18 @@ describe R10K::Puppetfile do
 
       expect { subject.add_module('puppet/test_module', module_opts) }.to raise_error(R10K::Error, /cannot manage content.*is not within/i).and not_change { subject.modules }
     end
+
+    it "should disable and not add modules that conflict with the environment" do
+      env = instance_double('R10K::Environment::Base')
+      mod = instance_double('R10K::Module::Base', name: 'conflict', origin: :puppetfile)
+      allow(mod).to receive(:origin=).and_return(nil)
+      allow(subject).to receive(:environment).and_return(env)
+      allow(env).to receive(:'module_conflicts?').with(mod).and_return(true)
+
+      allow(R10K::Module).to receive(:new).with('test', anything, anything, anything).and_return(mod)
+      expect { subject.add_module('test', {}) }.not_to change { subject.modules }
+      expect(subject.disabled_modules).to eq [mod]
+    end
   end
 
   describe "#purge_exclusions" do

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -137,7 +137,6 @@ describe R10K::Puppetfile do
 
       allow(R10K::Module).to receive(:new).with('test', anything, anything, anything).and_return(mod)
       expect { subject.add_module('test', {}) }.not_to change { subject.modules }
-      expect(subject.disabled_modules).to eq [mod]
     end
   end
 


### PR DESCRIPTION
The changes in #1120 caused the Puppetfile to be loaded too early,
breaking deploys when performed with a default-branch-override. This
commit refactors how Puppetfile module conflicts are handled to avoid
needing to load the Puppetfile early.
