### PR TITLE
Make setopts warn on conflicting args

### DIFF
--- a/spec/unit/util/setopts_spec.rb
+++ b/spec/unit/util/setopts_spec.rb
@@ -10,7 +10,10 @@ describe R10K::Util::Setopts do
 
       def initialize(opts = {})
         setopts(opts, {
-          :valid => :self, :alsovalid => :self, :truthyvalid => true,
+          :valid => :self,
+          :duplicate => :valid,
+          :alsovalid => :self,
+          :truthyvalid => true,
           :validalias => :valid,
           :ignoreme => nil
         })
@@ -55,5 +58,15 @@ describe R10K::Util::Setopts do
 
   it "ignores values that are marked as unhandled" do
     klass.new(:ignoreme => "IGNORE ME!")
+  end
+
+  it "warns when given conflicting options" do
+    test = Class.new { include R10K::Util::Setopts }.new
+    allow(test).to receive(:logger).and_return(spy)
+
+    test.send(:setopts, {valid: :one, duplicate: :two},
+                        {valid: :arg, duplicate: :arg})
+
+    expect(test.logger).to have_received(:warn).with(%r{valid.*duplicate.*conflict.*not both})
   end
 end


### PR DESCRIPTION
r10k may have several different ways to specify basically the same thing. E.g., in the git module type, r10k accepts `:branch`, `:commit`, and `:ref`, all of which just set the `@desired_ref` instance variable.

When the user intent is not clear because the user has used multiple equivalent parameters, log a warning, at least if `R10K::Util::Setopts` is being used.

This should more ideally raise an exception, but that would be a behavior change.