### PR TITLE
Standard module options

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -5,6 +5,8 @@ Unreleased
 ----------
 
 - Add 'strip\_component' environment source configuration setting, to allow deploying Git branches named like "env/production" as Puppet environments named like "production". [#1128](https://github.com/puppetlabs/r10k/pull/1128)
+- A warning will be emitted when the user supplies conflicting arguments to module definitions in a Puppetfile, such as when specifying both :commit and :branch [#1130](https://github.com/puppetlabs/r10k/pull/1130)
+- Add optional standard module and environment specification interface: name, type, source, version. These options can be used when specifying environments and/or modules in a yaml/exec source, as well as when specifying modules in a Puppetfile. Providing the standard interface simplifies integrations with external services [#1131](https://github.com/puppetlabs/r10k/pull/1131)
 
 3.8.0
 -----

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -645,7 +645,7 @@ sources:
 
 The environment modules feature allows module content to be attached to an environment at environment definition time. This happens before modules specified in a Puppetfile are attached to an environment, which does not happen until deploy time. Environment module implementation depends on the environment source type.
 
-For the YAML environment source type, attach modules to an environment by specifying a modules key for the environment, and providing a hash of modules to attach. Each module accepts the same arguments accepted by the `mod` method in a Puppetfile.
+For the YAML environment source type, attach modules to an environment by specifying a modules key for the environment, and providing a hash of modules to attach. Each module accepts the same arguments accepted by the `mod` method in a Puppetfile. For ease of reading and consistency, however, it is perferred to use the generic type, source, and version options over implementation-specific formats and options such as "ref" and "git".
 
 The example below includes two Forge modules and one module sourced from a Git repository. The two environments are almost identical. However, a new version of the stdlib module has been deployed in development (6.2.0), that has not yet been deployed to production.
 
@@ -653,25 +653,35 @@ The example below includes two Forge modules and one module sourced from a Git r
 ---
 production:
   type: git
-  remote: git@github.com:puppetlabs/control-repo.git
-  ref: 8820892
+  source: git@github.com:puppetlabs/control-repo.git
+  version: 8820892
   modules:
-    puppetlabs-stdlib: 6.0.0
-    puppetlabs-concat: 6.1.0
+    puppetlabs-stdlib:
+      type: forge
+      version: 6.0.0
+    puppetlabs-concat:
+      type: forge
+      version: 6.1.0
     reidmv-xampl:
-      git: https://github.com/reidmv/reidmv-xampl.git
-      ref: 62d07f2
+      type: git
+      source: https://github.com/reidmv/reidmv-xampl.git
+      version: 62d07f2
 
 development:
   type: git
-  remote: git@github.com:puppetlabs/control-repo.git
-  ref: 8820892
+  source: git@github.com:puppetlabs/control-repo.git
+  version: 8820892
   modules:
-    puppetlabs-stdlib: 6.2.0
-    puppetlabs-concat: 6.1.0
+    puppetlabs-stdlib:
+      type: forge
+      version: 6.2.0
+    puppetlabs-concat:
+      type: forge
+      version: 6.1.0
     reidmv-xampl:
-      git: https://github.com/reidmv/reidmv-xampl.git
-      ref: 62d07f2
+      type: git
+      source: https://github.com/reidmv/reidmv-xampl.git
+      version: 62d07f2
 ```
 
 An example of a single environment definition for the YAMLdir environment source type:
@@ -680,14 +690,19 @@ An example of a single environment definition for the YAMLdir environment source
 # production.yaml
 ---
 type: git
-remote: git@github.com:puppetlabs/control-repo.git
-ref: 8820892
+source: git@github.com:puppetlabs/control-repo.git
+version: 8820892
 modules:
-  puppetlabs-stdlib: 6.0.0
-  puppetlabs-concat: 6.1.0
+  puppetlabs-stdlib:
+    type: forge
+    version: 6.0.0
+  puppetlabs-concat:
+    type: forge
+    version: 6.1.0
   reidmv-xampl:
-    git: https://github.com/reidmv/reidmv-xampl.git
-    ref: 62d07f2
+    type: git
+    source: https://github.com/reidmv/reidmv-xampl.git
+    version: 62d07f2
 ```
 
 #### Puppetfile module conflicts
@@ -704,15 +719,20 @@ Available `module_conflicts` options:
 # production.yaml
 ---
 type: git
-remote: git@github.com:puppetlabs/control-repo.git
-ref: 8820892
-module_conflicts: override_puppetfile_and_warn
+source: git@github.com:puppetlabs/control-repo.git
+version: 8820892
+module_conflicts: override_and_warn
 modules:
-  puppetlabs-stdlib: 6.0.0
-  puppetlabs-concat: 6.1.0
+  puppetlabs-stdlib:
+    type: forge
+    version: 6.0.0
+  puppetlabs-concat:
+    type: forge
+    version: 6.1.0
   reidmv-xampl:
-    git: https://github.com/reidmv/reidmv-xampl.git
-    ref: 62d07f2
+    type: git
+    source: https://github.com/reidmv/reidmv-xampl.git
+    version: 62d07f2
 ```
 
 ### Bare Environment Type
@@ -726,18 +746,28 @@ The bare environment type allows sources that support environment modules to ope
 production:
   type: bare
   modules:
-    puppetlabs-stdlib: 6.0.0
-    puppetlabs-concat: 6.1.0
+    puppetlabs-stdlib:
+      type: forge
+      version: 6.0.0
+    puppetlabs-concat:
+      type: forge
+      version: 6.1.0
     reidmv-xampl:
-      git: https://github.com/reidmv/reidmv-xampl.git
-      ref: 62d07f2
+      type: git
+      source: https://github.com/reidmv/reidmv-xampl.git
+      version: 62d07f2
 
 development:
   type: bare
   modules:
-    puppetlabs-stdlib: 6.0.0
-    puppetlabs-concat: 6.1.0
+    puppetlabs-stdlib:
+      type: forge
+      version: 6.0.0
+    puppetlabs-concat:
+      type: forge
+      version: 6.1.0
     reidmv-xampl:
-      git: https://github.com/reidmv/reidmv-xampl.git
-      ref: 62d07f2
+      type: git
+      source: https://github.com/reidmv/reidmv-xampl.git
+      version: 62d07f2
 ```

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -109,11 +109,19 @@ latest version available.
 
     mod 'puppetlabs/apache', :latest
 
+An explicit type and/or version can be specified using the standard interface,
+`:type` and `:version`. The `:source` parameter is not supported for individual
+forge modules and will be ignored.
+
+    mod 'puppetlabs/apache',
+      type:    'forge',
+      version: '6.0.0'
+
 ### Git
 
 Git repositories that contain a Puppet module can be cloned and used as modules.
 When Git is used, the module version can be specified by using `:ref`, `:tag`,
-`:commit`, and `:branch`.
+`:commit`, `:branch`, or the standard interface parameter `:version`.
 
 When a module is installed using `:ref`, r10k uses some simple heuristics to
 determine the type of Git object that should be checked out. This can be used
@@ -153,6 +161,13 @@ mod 'apache',
 mod 'apache',
   :git    => 'https://github.com/puppetlabs/puppetlabs-apache',
   :branch => 'docs_experiment'
+
+# Install puppetlabs/apache and use standard interface parameters pinned to the
+# '2098a17' commit.
+mod 'puppetlabs-apache',
+  type:    'git',
+  source:  'https://github.com/puppetlabs/puppetlabs-apache',
+  version: '2098a17'
 ```
 
 #### Control Repo Branch Tracking
@@ -195,8 +210,8 @@ the latest version available in the main SVN repository.
     mod 'apache',
       :svn => 'https://github.com/puppetlabs/puppetlabs-apache/trunk'
 
-If an SVN revision number is specified with `:rev` (or `:revision`), that
-SVN revision will be kept checked out.
+If an SVN revision number is specified with `:rev`, `:revision`, or `:version`,
+that SVN revision will be kept checked out.
 
     mod 'apache',
       :svn => 'https://github.com/puppetlabs/puppetlabs-apache/trunk',
@@ -205,6 +220,11 @@ SVN revision will be kept checked out.
     mod 'apache',
       :svn      => 'https://github.com/puppetlabs/puppetlabs-apache/trunk',
       :revision => '154'
+
+    mod 'apache',
+      type:    'svn',
+      source:  'https://github.com/puppetlabs/puppetlabs-apache/trunk',
+      version: '154'
 
 If the SVN repository requires credentials, you can supply the `:username` and
 `:password` options.

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -43,7 +43,7 @@ class R10K::Environment::Base
     @basedir = basedir
     @dirname = dirname
     @options = options
-    @puppetfile_name = options[:puppetfile_name]
+    @puppetfile_name = options.delete(:puppetfile_name)
 
     @full_path = File.join(@basedir, @dirname)
     @path = Pathname.new(File.join(@basedir, @dirname))

--- a/lib/r10k/environment/git.rb
+++ b/lib/r10k/environment/git.rb
@@ -27,6 +27,8 @@ class R10K::Environment::Git < R10K::Environment::WithModules
   #   @return [R10K::Git::StatefulRepository] The git repo backing this environment
   attr_reader :repo
 
+  include R10K::Util::Setopts
+
   # Initialize the given Git environment.
   #
   # @param name [String] The unique name describing this environment.
@@ -38,8 +40,21 @@ class R10K::Environment::Git < R10K::Environment::WithModules
   # @param options [String] :ref The git reference to use for this environment
   def initialize(name, basedir, dirname, options = {})
     super
-    @remote = options[:remote]
-    @ref    = options[:ref]
+    setopts(options, {
+      # Standard option interface
+      :version => :ref,
+      :source  => :remote,
+      :type    => ::R10K::Util::Setopts::Ignore,
+
+      # Type-specific options
+      :ref     => :self,
+      :remote  => :self,
+
+    }, raise_on_unhandled: false)
+    # TODO: in r10k 4.0.0, a major version bump, stop allowing garbage options.
+    # We only allow them now, here, on this object, because prior to adopting
+    # setopts in the constructor, this object type didn't do any validation
+    # checking of options passed, and would permit garbage parameters.
 
     @repo = R10K::Git::StatefulRepository.new(@remote, @basedir, @dirname)
   end

--- a/lib/r10k/environment/svn.rb
+++ b/lib/r10k/environment/svn.rb
@@ -44,8 +44,17 @@ class R10K::Environment::SVN < R10K::Environment::Base
   # @option options [String] :password The SVN password
   def initialize(name, basedir, dirname, options = {})
     super
+    setopts(options, {
+      # Standard option interface
+      :source  => :remote,
+      :version => :expected_revision,
+      :type    => ::R10K::Util::Setopts::Ignore,
 
-    setopts(options, {:remote => :self, :username => :self, :password => :self, :puppetfile_name => :self })
+      # Type-specific options
+      :remote => :self,
+      :username => :self,
+      :password => :self,
+    })
 
     @working_dir = R10K::SVN::WorkingDir.new(Pathname.new(@full_path), :username => @username, :password => @password)
   end
@@ -61,7 +70,7 @@ class R10K::Environment::SVN < R10K::Environment::Base
     if @working_dir.is_svn?
       @working_dir.update
     else
-      @working_dir.checkout(@remote)
+      @working_dir.checkout(@remote, @expected_revision)
     end
     @synced = true
   end

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -24,7 +24,7 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   # @param options [String] :moduledir The path to install modules to
   # @param options [Hash] :modules Modules to add to the environment
   def initialize(name, basedir, dirname, options = {})
-    super(name, basedir, dirname, options)
+    super
 
     @managed_content = {}
     @modules = []

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -13,7 +13,7 @@ class R10K::Module::Forge < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    !!(name.match %r[\w+[/-]\w+]) && valid_version?(args)
+    (args.is_a?(Hash) && args[:type].to_s == 'forge') || (!!(name.match %r[\w+[/-]\w+]) && valid_version?(args))
   end
 
   def self.valid_version?(expected_version)
@@ -32,13 +32,24 @@ class R10K::Module::Forge < R10K::Module::Base
 
   include R10K::Logging
 
-  def initialize(title, dirname, expected_version, environment=nil)
+  include R10K::Util::Setopts
+
+  def initialize(title, dirname, opts, environment=nil)
     super
+
+    if opts.is_a?(Hash)
+      setopts(opts, {
+        # Standard option interface
+        :version => :expected_version,
+        :source  => ::R10K::Util::Setopts::Ignore,
+        :type    => ::R10K::Util::Setopts::Ignore,
+      })
+    else
+      @expected_version = opts || current_version || :latest
+    end
 
     @metadata_file = R10K::Module::MetadataFile.new(path + 'metadata.json')
     @metadata = @metadata_file.read
-
-    @expected_version = expected_version || current_version || :latest
     @v3_module = PuppetForge::V3::Module.new(:slug => @title)
   end
 

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -9,7 +9,7 @@ class R10K::Module::Local < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    args.is_a?(Hash) && args[:local]
+    args.is_a?(Hash) && (args[:local] || args[:type].to_s == 'local')
   end
 
   include R10K::Logging

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -7,7 +7,7 @@ class R10K::Module::SVN < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    args.is_a? Hash and args.has_key? :svn
+    args.is_a?(Hash) && (args.has_key?(:svn) || args[:type].to_s == 'svn')
   end
 
   # @!attribute [r] expected_revision
@@ -36,18 +36,21 @@ class R10K::Module::SVN < R10K::Module::Base
 
   include R10K::Util::Setopts
 
-  INITIALIZE_OPTS = {
-    :svn => :url,
-    :rev => :expected_revision,
-    :revision => :expected_revision,
-    :username => :self,
-    :password => :self
-  }
-
   def initialize(name, dirname, opts, environment=nil)
     super
+    setopts(opts, {
+      # Standard option interface
+      :source   => :url,
+      :version  => :expected_revision,
+      :type     => ::R10K::Util::Setopts::Ignore,
 
-    setopts(opts, INITIALIZE_OPTS)
+      # Type-specific options
+      :svn      => :url,
+      :rev      => :expected_revision,
+      :revision => :expected_revision,
+      :username => :self,
+      :password => :self
+    })
 
     @working_dir = R10K::SVN::WorkingDir.new(@path, :username => @username, :password => @password)
   end

--- a/spec/unit/environment/git_spec.rb
+++ b/spec/unit/environment/git_spec.rb
@@ -15,6 +15,22 @@ describe R10K::Environment::Git do
     )
   end
 
+  describe "initializing" do
+    subject do
+      described_class.new('name', '/dir', 'ref', {
+        :remote          => 'url',
+        :ref             => 'value',
+        :puppetfile_name => 'Puppetfile',
+        :moduledir       => 'modules',
+        :modules         => { },
+      })
+    end
+
+    it "accepts valid base class initialization arguments" do
+      expect(subject.name).to eq 'name'
+    end
+  end
+
   describe "storing attributes" do
     it "can return the environment name" do
       expect(subject.name).to eq 'myenv'

--- a/spec/unit/environment/svn_spec.rb
+++ b/spec/unit/environment/svn_spec.rb
@@ -16,6 +16,18 @@ describe R10K::Environment::SVN do
 
   let(:working_dir) { subject.working_dir }
 
+  describe "initializing" do
+    subject do
+      described_class.new('name', '/dir', 'ref', {
+        :puppetfile_name => 'Puppetfile',
+      })
+    end
+
+    it "accepts valid base class initialization arguments" do
+      expect(subject.name).to eq 'name'
+    end
+  end
+
   describe "storing attributes" do
     it "can return the environment name" do
       expect(subject.name).to eq 'myenv'

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -23,6 +23,12 @@ describe R10K::Module::Forge do
     end
   end
 
+  describe "implementing the standard options interface" do
+    it "should implement {type: forge}" do
+      expect(described_class).to be_implement('branan-eight_hundred', {type: 'forge', version: '8.0.0', source: 'not implemented'})
+    end
+  end
+
   describe "setting attributes" do
     subject { described_class.new('branan/eight_hundred', '/moduledir', '8.0.0') }
 

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -123,7 +123,7 @@ describe R10K::Module::Git do
       let(:opts) { { unrecognized: true } }
 
       it "raises an error" do
-        expect { test_module(opts) }.to raise_error(ArgumentError, /unhandled options.*unrecognized/i)
+        expect { test_module(opts) }.to raise_error(ArgumentError, /cannot handle option 'unrecognized'/)
       end
     end
 

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -3,20 +3,45 @@ require 'r10k/module'
 
 describe R10K::Module do
   describe 'delegating to R10K::Module::Git' do
-    it "accepts args {:git => 'git url}" do
-      obj = R10K::Module.new('foo', '/modulepath', :git => 'git url')
-      expect(obj).to be_a_kind_of(R10K::Module::Git)
+    [ {git: 'git url'},
+      {type: 'git', source: 'git url'},
+    ].each do |scenario|
+      it "accepts a name matching 'test' and args #{scenario.inspect}" do
+        obj = R10K::Module.new('test', '/modulepath', scenario)
+        expect(obj).to be_a_kind_of(R10K::Module::Git)
+        expect(obj.send(:instance_variable_get, :'@remote')).to eq('git url')
+      end
+    end
+  end
+
+  describe 'delegating to R10K::Module::Svn' do
+    [ {svn: 'svn url'},
+      {type: 'svn', source: 'svn url'},
+    ].each do |scenario|
+      it "accepts a name matching 'test' and args #{scenario.inspect}" do
+        obj = R10K::Module.new('test', '/modulepath', scenario)
+        expect(obj).to be_a_kind_of(R10K::Module::SVN)
+        expect(obj.send(:instance_variable_get, :'@url')).to eq('svn url')
+      end
     end
   end
 
   describe 'delegating to R10K::Module::Forge' do
-    [
-      ['bar/quux', nil],
-      ['bar-quux', nil],
-      ['bar/quux', '8.0.0'],
+    [ 'bar/quux',
+      'bar-quux',
     ].each do |scenario|
-      it "accepts a name matching #{scenario[0]} and args #{scenario[1].inspect}" do
-        expect(R10K::Module.new(scenario[0], '/modulepath', scenario[1])).to be_a_kind_of(R10K::Module::Forge)
+      it "accepts a name matching #{scenario} and args nil" do
+        obj = R10K::Module.new(scenario, '/modulepath', nil)
+        expect(obj).to be_a_kind_of(R10K::Module::Forge)
+      end
+    end
+    [ '8.0.0',
+      {type: 'forge', version: '8.0.0'},
+    ].each do |scenario|
+      it "accepts a name matching bar-quux and args #{scenario.inspect}" do
+        obj = R10K::Module.new('bar-quux', '/modulepath', scenario)
+        expect(obj).to be_a_kind_of(R10K::Module::Forge)
+        expect(obj.send(:instance_variable_get, :'@expected_version')).to eq('8.0.0')
       end
     end
   end

--- a/spec/unit/util/setopts_spec.rb
+++ b/spec/unit/util/setopts_spec.rb
@@ -56,6 +56,17 @@ describe R10K::Util::Setopts do
     }.to raise_error(ArgumentError, /cannot handle option 'notvalid'/)
   end
 
+  it "warns when given an unhandled option and raise_on_unhandled=false" do
+    test = Class.new { include R10K::Util::Setopts }.new
+    allow(test).to receive(:logger).and_return(spy)
+
+    test.send(:setopts, {valid: :value, invalid: :value},
+                        {valid: :self},
+                        raise_on_unhandled: false)
+
+    expect(test.logger).to have_received(:warn).with(%r{cannot handle option 'invalid'})
+  end
+
   it "ignores values that are marked as unhandled" do
     klass.new(:ignoreme => "IGNORE ME!")
   end


### PR DESCRIPTION
This PR is primarily designed to sanitize the schema used by the Hash source type to define environments and modules, adopting a standard way of describing content (environments, modules) which is not implementation-dependent, the way today's modules especially are.

The idea is that when specifying content in a data hash, it should be possible to specify it using these standard keys.

```yaml
---
object-name:
  type: <string> # E.g. "git", "forge", "svn"
  source: <string> # E.g. "git://server.tld/project/repo.git", "https://forge.puppet.com", etc.
  version: <string> # E.g. "main", "06a32bc", "6.1.0", etc.
```

This PR assumes #1130 exists to improve the visibility of what happens if users use conflicting ways of specifying values like version, such as by using both `version` and an implementation-specific key like `git`, but does not depend on that improvement.

This PR homogenizes how options are parsed for many objects by standardizing on the use of `R10K::Util::Setopts`.

See the [rich diff of the doc/dynamic-environments/configuration.mkd](https://github.com/puppetlabs/r10k/pull/1131/files?short_path=5a41a0b#diff-5a41a0b389c98bce0313a7b6e74d1dcb2a7dfb8e09d5c7f983c33b9fb46c9ec6) page for the best visual of what this change accomplishes for consumers.

This improvement takes a UX step in the direction of r10k being able to support other types of environment sources and module sources, such as e.g. tarballs from Artifactory or S3.

This PR should be backwards compatible, without behavior changes, with one exception. Some object types did not validate schema in any way for keys passed into them. `R10K::Util::Setopts` does validate schema, and so garbage keys that would have been ignored previously may now cause an error.