### PR TITLE
(maint) Base new tags on the current branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,11 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.17.2
+        uses: anothrNick/github-tag-action@1.35.0
         env:
           GITHUB_TOKEN: ${{ secrets.PUPPET_RELEASE_GH_TOKEN }}
           DEFAULT_BUMP: patch
+          TAG_CONTEXT: branch
           WITH_V: false
           # Uncomment this if the tag and version file become out-of-sync and
           # you need to tag at a specific version.


### PR DESCRIPTION
Previously, the GitHub Action to tag a new release would base the new tag on the
latest tag in the repo, rather than on the latest tag for the *current branch*
of the repo. This change allows us to release from various branches without
worrying about newer tags landing on older branches.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- Summary of changes. [Issue or PR #](link to issue or PR)
```
