### PR TITLE
(RK-308) Use alternate forge from Puppetfile

### DIFF
--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -134,6 +134,28 @@ class Puppetfile
     @loaded_content[:modules]
   end
 
+  # @param [String] forge
+  def set_forge(forge)
+    unless @forge.nil?
+      raise R10K::Error.new(_('You cannot declare multiple \'forge\' settings in the same Puppetfile'))
+    end
+    @forge = forge
+  end
+
+  # @param [Array<String>] modules
+  def validate_no_duplicate_names(modules)
+    dupes = modules
+            .group_by { |mod| mod.name }
+            .select { |_, v| v.size > 1 }
+            .map(&:first)
+    unless dupes.empty?
+      msg = _('Puppetfiles cannot contain duplicate module names.')
+      msg += ' '
+      msg += _("Remove the duplicates of the following modules: %{dupes}" % { dupes: dupes.join(' ') })
+      raise R10K::Error.new(msg)
+    end
+  end
+
   # @see R10K::ModuleLoader::Puppetfile#add_module for upcoming signature changes
   def add_module(name, args)
     @loader.add_module(name, args)

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -128,7 +128,12 @@ module R10K
         }),
         Definition.new(:authorization_token, {
           :desc => "The token for Puppet Forge authorization. Leave blank for unauthorized or license-based connections."
-        })
+        }),
+        Definition.new(:allow_override, {
+          :desc => "Whether or not to allow the Forge URL to be overridden by a 'forge' directive inside an environment Puppetfile.",
+          :default => lambda { false },
+          :normalize => lambda { |v| v.to_s.strip == 'true' },
+        }),
       ])
     end
 

--- a/r10k.yaml.example
+++ b/r10k.yaml.example
@@ -110,3 +110,8 @@ forge:
   # The 'baseurl' setting indicates where Forge modules should be installed
   # from. This defaults to 'https://forgeapi.puppetlabs.com'
   #baseurl: 'https://forgemirror.example.com'
+
+  # The 'allow_override' setting controls whether or not to allow the Forge
+  # 'baseurl' to be overridden by a 'forge' directive inside a Puppetfile.
+  # This defaults to 'false'.
+  #allow_override: true

--- a/spec/fixtures/unit/puppetfile/alternate-forge/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/alternate-forge/Puppetfile
@@ -1,0 +1,3 @@
+forge 'http://forge.example.com/'
+
+mod 'puppetlabs/stdlib'

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -228,6 +228,14 @@ describe R10K::Puppetfile do
       loaded_module = subject.modules.first
       expect(loaded_module.version).to eq('foo')
     end
+
+    it "accepts alternate forge" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'alternate-forge')
+      pf_path = File.join(path, 'Puppetfile')
+      subject = described_class.new(path)
+      expect { subject.load! }.not_to raise_error
+      expect(subject).to have_attributes(:forge => 'http://forge.example.com/')
+    end
   end
 
   describe "accepting a visitor" do

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -90,6 +90,22 @@ describe R10K::Settings do
         end
       end
     end
+    describe "allow_override" do
+      it "defaults to false" do
+        output = subject.evaluate({})
+        expect(output[:allow_override]).to eq false
+      end
+
+      it "recognizes the string 'true' as boolean true" do
+        output = subject.evaluate("allow_override" => "true")
+        expect(output[:allow_override]).to eq true
+      end
+
+      it "treats all values other than 'true' as false" do
+        output = subject.evaluate("allow_override" => "yes")
+        expect(output[:allow_override]).to eq false
+      end
+    end
   end
 
   describe "deploy settings" do


### PR DESCRIPTION
 - R10K setting to allow_override to use forge setting
 - Tests updated for using alternate forge
 - Rebased off master


- Summary of changes.  Rebased against master - Replaces old PR #779
