### PR TITLE
[#1121] Pin cri to 2.15.10

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -7,6 +7,7 @@ Unreleased
 - Add 'strip\_component' environment source configuration setting, to allow deploying Git branches named like "env/production" as Puppet environments named like "production". [#1128](https://github.com/puppetlabs/r10k/pull/1128)
 - A warning will be emitted when the user supplies conflicting arguments to module definitions in a Puppetfile, such as when specifying both :commit and :branch [#1130](https://github.com/puppetlabs/r10k/pull/1130)
 - Add optional standard module and environment specification interface: name, type, source, version. These options can be used when specifying environments and/or modules in a yaml/exec source, as well as when specifying modules in a Puppetfile. Providing the standard interface simplifies integrations with external services [#1131](https://github.com/puppetlabs/r10k/pull/1131)
+- Pin cri to 2.15.10 to maintain support for Ruby 2.3 and 2.4 [#1121](https://github.com/puppetlabs/r10k/issues/1121)
 
 3.8.0
 -----

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_dependency 'colored2',   '3.1.2'
-  s.add_dependency 'cri', ['>= 2.15.10', '< 3.0.0']
+  s.add_dependency 'cri', '2.15.10'
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
This commit pins cri to 2.15.10 because they dropped support for Ruby 2.3 and
2.4 in cri 2.15.11. This allows us to maintain support for those Ruby versions,
since we still support them in the Puppet 6 stream. We plan to loosen this
dependency and drop support for Ruby < 2.5 in the next major release of r10k.
