### PR TITLE
(maint) Update CODEOWNERS for docker

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 *        @puppetlabs/puppetserver-maintainers
-/docker/ @puppetlabs/pupperware
+/docker/ @puppetlabs/platform-services


### PR DESCRIPTION
This commit adds the Platform Services team as codeowners for the docker
directory, since the Pupperware team doesn't really exist anymore.