### PR TITLE
(maint) Change Forge initialization order

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -37,6 +37,9 @@ class R10K::Module::Forge < R10K::Module::Base
   def initialize(title, dirname, opts, environment=nil)
     super
 
+    @metadata_file = R10K::Module::MetadataFile.new(path + 'metadata.json')
+    @metadata = @metadata_file.read
+
     if opts.is_a?(Hash)
       setopts(opts, {
         # Standard option interface
@@ -48,8 +51,6 @@ class R10K::Module::Forge < R10K::Module::Base
       @expected_version = opts || current_version || :latest
     end
 
-    @metadata_file = R10K::Module::MetadataFile.new(path + 'metadata.json')
-    @metadata = @metadata_file.read
     @v3_module = PuppetForge::V3::Module.new(:slug => @title)
   end
 

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -44,6 +44,31 @@ describe R10K::Module do
         expect(obj.send(:instance_variable_get, :'@expected_version')).to eq('8.0.0')
       end
     end
+
+    describe 'when the module is ostensibly on disk' do
+      before do
+        owner = 'theowner'
+        module_name = 'themodulename'
+        @title = "#{owner}-#{module_name}"
+        metadata = <<~METADATA
+          {
+            "name": "#{@title}",
+            "version": "1.2.0"
+          }
+        METADATA
+        @dirname = Dir.mktmpdir
+        module_path = File.join(@dirname, module_name)
+        FileUtils.mkdir(module_path)
+        File.open("#{module_path}/metadata.json", 'w') do |file|
+           file.write(metadata)
+        end
+      end
+
+      it 'sets the expected version to what is found in the metadata' do
+        obj = R10K::Module.new(@title, @dirname, nil)
+        expect(obj.send(:instance_variable_get, :'@expected_version')).to eq('1.2.0')
+      end
+    end
   end
 
   it "raises an error if delegation fails" do


### PR DESCRIPTION
The PR #1131 changed the order of method calls in the Forge initialization;
that ended up breaking scenarios where the opts was not a Hash and the
else branch in the logic called `current_version`, which needs the
@metadata object defined before it can be successfully called. This change
moves that instantiation up to happen before that `current_version` could
be called.