### PR TITLE
(PE-31100) Use 'main' branch instead of 'master'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Tag and release
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'lib/r10k/version.rb'
 

--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -3,7 +3,7 @@ name: Rspec tests
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   rspec_tests:


### PR DESCRIPTION
Once this is merged, I will rename the branch.