### PR TITLE
(maint) Use docker-compose style testing

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.7'
+
+services:
+  r10k_check:
+    image: ${R10K_IMAGE:-puppet/r10k}
+    environment:
+      - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-false}
+    command: ['puppetfile',
+      'check',
+      '--verbose',
+      '--trace',
+      '--puppetfile',
+      'test/Puppetfile'
+    ]
+    volumes:
+      - ${SPEC_DIRECTORY}/fixtures:/home/puppet/test
+
+  r10k_install:
+    image: ${R10K_IMAGE:-puppet/r10k}
+    environment:
+      - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-false}
+    command: ['puppetfile',
+      'install',
+      '--verbose',
+      '--trace',
+      '--puppetfile',
+      'test/Puppetfile'
+    ]
+    volumes:
+      - ${SPEC_DIRECTORY}/fixtures:/home/puppet/test
+
+networks:
+  default:
+    name: r10k_test


### PR DESCRIPTION
 - All other suites use docker-compose for testing, so do the same for
   consistency across all Puppet containers

