### PR TITLE
(maint) Use docker-compose style testing

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.7'
+
+services:
+  r10k_check:
+    image: ${R10K_IMAGE:-puppet/r10k}
+    environment:
+      - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-false}
+    command: 'puppetfile check --verbose --trace --puppetfile test/Puppetfile'
+    volumes:
+      - ${SPEC_DIRECTORY}/fixtures:/home/puppet/test
+
+  r10k_install:
+    image: ${R10K_IMAGE:-puppet/r10k}
+    environment:
+      - PUPPERWARE_ANALYTICS_ENABLED=${PUPPERWARE_ANALYTICS_ENABLED:-false}
+    command: 'puppetfile install --verbose --trace --puppetfile test/Puppetfile'
+    volumes:
+      - ${SPEC_DIRECTORY}/fixtures:/home/puppet/test

--- a/docker/spec/dockerfile_spec.rb
+++ b/docker/spec/dockerfile_spec.rb
@@ -1,43 +1,37 @@
 require 'rspec/core'
 require 'fileutils'
 require 'open3'
+include Pupperware::SpecHelpers
 
-SPEC_DIRECTORY = File.dirname(__FILE__)
+ENV['SPEC_DIRECTORY'] = File.dirname(__FILE__)
+# unifies volume naming
+ENV['COMPOSE_PROJECT_NAME'] ||= 'r10k'
+
+RSpec.configure do |c|
+  c.before(:suite) do
+    ENV['R10K_IMAGE'] = require_test_image
+    pull_images(['r10k_check','r10k_install'])
+    teardown_cluster()
+    # no certs to preload, but if the suite adds puppetserver, be explicit
+    docker_compose_up(preload_certs: true)
+  end
+
+  c.after(:suite) do
+    teardown_cluster()
+    FileUtils.rm_rf(File.join(ENV['SPEC_DIRECTORY'], 'fixtures', 'modules'))
+  end
+end
 
 describe 'r10k container' do
-  include Pupperware::SpecHelpers
-  def run_r10k(command)
-    run_command("docker run --detach \
-                   --volume #{File.join(SPEC_DIRECTORY, 'fixtures')}:/home/puppet/test \
-                   #{@image} #{command} \
-                   --verbose \
-                   --trace \
-                   --puppetfile test/Puppetfile")
-  end
-
-  before(:all) do
-    @image = require_test_image
-  end
-
-  after(:all) do
-    FileUtils.rm_rf(File.join(SPEC_DIRECTORY, 'fixtures', 'modules'))
-  end
-
-  it 'should validate the Puppetfile' do
-    result = run_r10k('puppetfile check')
-    container = result[:stdout].chomp
-    wait_on_container_exit(container)
-    expect(get_container_exit_code(container)).to eq(0)
-    emit_log(container)
-    teardown_container(container)
-  end
-
-  it 'should install the Puppetfile' do
-    result = run_r10k('puppetfile install')
-    container = result[:stdout].chomp
-    wait_on_container_exit(container)
-    expect(get_container_exit_code(container)).to eq(0)
-    emit_log(container)
-    teardown_container(container)
+  {
+    'r10k_check': 'validate',
+    'r10k_install': 'install',
+  }.each do |container, op|
+    it "should #{op} the Puppetfile" do
+      container = get_service_container(container)
+      wait_on_container_exit(container)
+      expect(get_container_exit_code(container)).to eq(0)
+      emit_log(container)
+    end
   end
 end


### PR DESCRIPTION
New version of #1142 since I couldn't repush my own branch for some reason.

 - All other suites use docker-compose for testing, so do the same for
   consistency across all Puppet containers

 - Remove repetitive spec code
