### PR TITLE
(maint) Fix Travis docker build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,12 @@ matrix:
         - curl --location https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname --kernel-name`-`uname --machine` > docker-compose
         - chmod +x docker-compose
         - sudo mv docker-compose /usr/local/bin
+        - docker buildx create --name travis_builder --use
       script:
         - set -e
         - cd docker
         - make lint
         - make build
         - make test
+      after_script:
+        - docker buildx rm travis_builder

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -50,8 +50,9 @@ endif
 
 build: prep
 	docker pull alpine:$(alpine_version)
-	docker build \
+	docker buildx build \
 		${DOCKER_BUILD_FLAGS} \
+		--load \
 		--build-arg alpine_version=$(alpine_version) \
 		--build-arg vcs_ref=$(vcs_ref) \
 		--build-arg build_date=$(build_date) \


### PR DESCRIPTION
 - Upgrading to Travis 20.10 from 19.03 doesn't seem to have fully
   resolved the docker buildkit precondition issues. Implement the
   workaround suggestion from https://github.com/moby/moby/issues/41864

   This switches to the docker buildx build cli from docker build cli
