### PR TITLE
(maint) Deprecate `--puppetfile` as a flag to manage modules

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
-- Add '--modules' flag to deploy subcommand as a replacement to '--puppetfile`, deprecate '--puppetfile'. [#1147](https://github.com/puppetlabs/r10k/pull/1147)
+- Add '--modules' flag to `deploy` subcommand as a replacement to '--puppetfile', deprecate '--puppetfile'. [#1147](https://github.com/puppetlabs/r10k/pull/1147)
 - Deprecate 'purge_whitelist' and favor usage of 'purge_allowlist'. [#1144](https://github.com/puppetlabs/r10k/pull/1144)
 - Add 'strip\_component' environment source configuration setting, to allow deploying Git branches named like "env/production" as Puppet environments named like "production". [#1128](https://github.com/puppetlabs/r10k/pull/1128)
 - A warning will be emitted when the user supplies conflicting arguments to module definitions in a Puppetfile, such as when specifying both :commit and :branch [#1130](https://github.com/puppetlabs/r10k/pull/1130)

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- Add '--modules' flag to deploy subcommand as a replacement to '--puppetfile`, deprecate '--puppetfile'. [#1147](https://github.com/puppetlabs/r10k/pull/1147)
 - Deprecate 'purge_whitelist' and favor usage of 'purge_allowlist'. [#1144](https://github.com/puppetlabs/r10k/pull/1144)
 - Add 'strip\_component' environment source configuration setting, to allow deploying Git branches named like "env/production" as Puppet environments named like "production". [#1128](https://github.com/puppetlabs/r10k/pull/1128)
 - A warning will be emitted when the user supplies conflicting arguments to module definitions in a Puppetfile, such as when specifying both :commit and :branch [#1130](https://github.com/puppetlabs/r10k/pull/1130)

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -249,9 +249,9 @@ found which is neither committed to the control repo branch that maps to that
 environment, nor declared in a Puppetfile committed to that branch.
 
 Enabling this purge level will cause r10k to load and parse the Puppetfile for
-the environment even without the `--puppetfile` flag being set. However,
+the environment even without the `--modules` flag being set. However,
 Puppetfile content will still only be deployed if the environment is new or
-the `--puppetfile` flag is set. Additionally, no environment-level content
+the `--modules` flag is set. Additionally, no environment-level content
 will be purged if any errors are encountered while evaluating the Puppetfile
 or deploying its contents.
 

--- a/doc/dynamic-environments/usage.mkd
+++ b/doc/dynamic-environments/usage.mkd
@@ -18,16 +18,16 @@ Command line invocation
 
 Recursively update all environments:
 
-    r10k deploy environment --puppetfile
+    r10k deploy environment --modules
 
 The simplest way to use r10k is by simply updating all environments and modules
 and takes the brute force approach of "update everything, ever." When this
 command is run r10k will update all sources, create new environments and delete
 old environments, and recursively update all environment modules specified in
-environment Puppetfiles. While this is the simplest method for running r10k, is
-is also the slowest by a very large degree because it does the maximum possible
-work. This should not be something you run interactively, or use on a regular
-basis.
+environment Puppetfiles, yamldirs, etc. While this is the simplest method for
+running r10k, it is also the slowest by a very large degree because it does the
+maximum possible work. This should not be something you run interactively, or
+use on a regular basis.
 
 - - -
 
@@ -55,7 +55,7 @@ only the environment itself will be updated.
 
 Update a single environment and force an update of modules:
 
-    r10k deploy environment my_working_environment --puppetfile
+    r10k deploy environment my_working_environment --modules
 
 This will update the given environment and update all contained modules. This is
 useful if you want to make sure that a given environment is fully up to date.
@@ -64,7 +64,7 @@ useful if you want to make sure that a given environment is fully up to date.
 
 Update a single environment and specify a default branch override:
 
-    r10k deploy environment my_working_environment --puppetfile --default-branch-override default_branch_override
+    r10k deploy environment my_working_environment --modules --default-branch-override default_branch_override
 
 This will update the given environment and update all contained modules, overriding
 the :default_branch entry in the Puppetfile of each module. If the specified override branch is not

--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -59,14 +59,14 @@ module R10K
         end
 
         def environment_info(env)
-          if !@puppetfile && !@detail
+          if !@modules && !@detail
             env.dirname
           else
             env_info = env.info.merge({
               :status => (env.status rescue nil),
             })
 
-            env_info[:modules] = env.modules.map { |mod| module_info(mod) } if @puppetfile
+            env_info[:modules] = env.modules.map { |mod| module_info(mod) } if @modules
 
             env_info
           end
@@ -81,7 +81,13 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self, detail: :self, format: :self, fetch: :self)
+          super.merge({
+            puppetfile: :modules,
+            modules: :self,
+            detail: :self,
+            format: :self,
+            fetch: :self
+          })
         end
       end
     end

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -113,7 +113,7 @@ module R10K
           environment.sync
           logger.info _("Environment %{env_dir} is now at %{env_signature}") % {env_dir: environment.dirname, env_signature: environment.signature}
 
-          if status == :absent || @puppetfile
+          if status == :absent || @modules
             if status == :absent
               logger.debug(_("Environment %{env_dir} is new, updating all modules") % {env_dir: environment.dirname})
             end
@@ -204,7 +204,8 @@ module R10K
         end
 
         def allowed_initialize_opts
-          super.merge(puppetfile: :self,
+          super.merge(puppetfile: :modules,
+                      modules: :self,
                       cachedir: :self,
                       'no-force': :self,
                       'generate-types': :self,

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -55,7 +55,7 @@ branches.
 
 Environments can provide a Puppetfile at the root of the directory to deploy
 independent Puppet modules. To recursively deploy an environment, pass the
-`--puppetfile` flag to the command.
+`--modules` flag to the command.
 
 **NOTE**: If an environment has a Puppetfile when it is instantiated a
 recursive update will be forced. It is assumed that environments are dependent
@@ -63,7 +63,8 @@ on modules specified in the Puppetfile and an update will be automatically
 scheduled. On subsequent deployments, Puppetfile deployment will default to off.
           DESCRIPTION
 
-          flag :p, :puppetfile, 'Deploy modules from a puppetfile'
+          flag :p, :puppetfile, 'Deploy modules (deprecated, use -m)'
+          flag :m, :modules, 'Deploy modules'
           option nil, :'default-branch-override', 'Specify a branchname to override the default branch in the puppetfile',
                  argument: :required
 

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -100,7 +100,8 @@ try to deploy the given module names in all environments.
           usage 'display'
           summary 'Display environments and modules in the deployment'
 
-          flag :p, :puppetfile, 'Display Puppetfile modules'
+          flag :p, :puppetfile, 'Display modules (deprecated, use -m)'
+          flag :m, :modules, 'Display modules'
           flag nil, :detail, 'Display detailed information'
           flag nil, :fetch, 'Update available environment lists from all remote sources'
           option nil, :format, 'Display output in a specific format. Valid values: json, yaml. Default: yaml',

--- a/spec/unit/action/deploy/display_spec.rb
+++ b/spec/unit/action/deploy/display_spec.rb
@@ -8,6 +8,10 @@ describe R10K::Action::Deploy::Display do
       described_class.new({puppetfile: true}, [])
     end
 
+    it "accepts a modules option" do
+      described_class.new({modules: true}, [])
+    end
+
     it "accepts a detail option" do
       described_class.new({detail: true}, [])
     end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -19,6 +19,10 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({puppetfile: true}, [])
     end
 
+    it "can accept a modules option" do
+      described_class.new({modules: true}, [])
+    end
+
     it "can accept a default_branch_override option" do
       described_class.new({:'default-branch-override' => 'default_branch_override_name'}, [])
     end
@@ -69,6 +73,29 @@ describe R10K::Action::Deploy::Environment do
       )
     end
 
+    describe "with puppetfile or modules flag" do
+      let(:deployment) { R10K::Deployment.new(mock_config) }
+      let(:puppetfile) { instance_double("R10K::Puppetfile", modules: []).as_null_object }
+
+      before do
+        expect(R10K::Deployment).to receive(:new).and_return(deployment)
+        expect(R10K::Puppetfile).to receive(:new).and_return(puppetfile).at_least(:once)
+      end
+
+      it "syncs the puppetfile when given the puppetfile flag" do
+        expect(puppetfile).to receive(:accept).and_return([])
+        action = described_class.new({config: "/some/nonexistent/path", puppetfile: true}, [])
+        action.call
+      end
+
+      it "syncs the puppetfile when given the modules flag" do
+        expect(puppetfile).to receive(:accept).and_return([])
+        action = described_class.new({config: "/some/nonexistent/path", modules: true}, [])
+        action.call
+      end
+
+    end
+
     describe "with an environment that doesn't exist" do
       let(:deployment) do
         R10K::Deployment.new(mock_config)
@@ -88,7 +115,7 @@ describe R10K::Action::Deploy::Environment do
     end
 
     describe "with no-force" do
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true, :'no-force' => true}, %w[first]) }
+      subject { described_class.new({ config: "/some/nonexistent/path", modules: true, :'no-force' => true}, %w[first]) }
 
       it "tries to preserve local modifications" do
         expect(subject.force).to equal(false)
@@ -198,7 +225,7 @@ describe R10K::Action::Deploy::Environment do
         expect(R10K::Deployment).to receive(:new).and_return(deployment)
       end
 
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true }, %w[PREFIX_first], settings) }
+      subject { described_class.new({ config: "/some/nonexistent/path", modules: true }, %w[PREFIX_first], settings) }
 
       it "reads in the purge_allowlist setting and purges accordingly" do
         expect(subject.logger).to receive(:debug).with(/purging unmanaged content for environment/i)
@@ -228,7 +255,7 @@ describe R10K::Action::Deploy::Environment do
         expect(R10K::Deployment).to receive(:new).and_return(deployment)
       end
 
-      subject { described_class.new({ config: "/some/nonexistent/path", puppetfile: true }, %w[PREFIX_first], settings) }
+      subject { described_class.new({ config: "/some/nonexistent/path", modules: true }, %w[PREFIX_first], settings) }
 
       describe "deployment purge level" do
         let(:purge_levels) { [:deployment] }
@@ -304,7 +331,7 @@ describe R10K::Action::Deploy::Environment do
           described_class.new(
             {
               config: '/some/nonexistent/path',
-              puppetfile: true,
+              modules: true,
               'generate-types': true
             },
             %w[first second]
@@ -358,7 +385,7 @@ describe R10K::Action::Deploy::Environment do
           described_class.new(
             {
               config: '/some/nonexistent/path',
-              puppetfile: true,
+              modules: true,
               'generate-types': false
             },
             %w[first]


### PR DESCRIPTION
In the deploy subcommand if we wanted to act on modules (display or deploy) we would require a `-p` or `--puppetfile` flag to be passed. The Puppetfile is no longer the only means of attaching modules to an environment, so this deprecates the flag and encourages the usage of `-m` or `--modules` instead.