### PR TITLE
(maint) Use a "Cleaner" helper to purge Puppetfile content

### DIFF
--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -1,4 +1,5 @@
 require 'r10k/util/setopts'
+require 'r10k/util/cleaner'
 require 'r10k/deployment'
 require 'r10k/logging'
 require 'r10k/action/visitor'
@@ -153,7 +154,9 @@ module R10K
 
           if @purge_levels.include?(:puppetfile)
             logger.debug("Purging unmanaged Puppetfile content for environment '#{puppetfile.environment.dirname}'...")
-            puppetfile.purge!
+            R10K::Util::Cleaner.new(puppetfile.managed_directories,
+                                    puppetfile.desired_contents,
+                                    puppetfile.purge_exclusions).purge!
           end
         end
 

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -2,6 +2,7 @@ require 'r10k/puppetfile'
 require 'r10k/errors/formatting'
 require 'r10k/action/visitor'
 require 'r10k/action/base'
+require 'r10k/util/cleaner'
 
 module R10K
   module Action
@@ -21,8 +22,12 @@ module R10K
 
         def visit_puppetfile(pf)
           pf.load!
+
           yield
-          pf.purge!
+
+          R10K::Util::Cleaner.new(pf.managed_directories,
+                                  pf.desired_contents,
+                                  pf.purge_exclusions).purge!
         end
 
         def visit_module(mod)

--- a/lib/r10k/action/puppetfile/purge.rb
+++ b/lib/r10k/action/puppetfile/purge.rb
@@ -1,4 +1,5 @@
 require 'r10k/puppetfile'
+require 'r10k/util/cleaner'
 require 'r10k/action/base'
 require 'r10k/errors/formatting'
 
@@ -10,7 +11,10 @@ module R10K
         def call
           pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
           pf.load!
-          pf.purge!
+          R10K::Util::Cleaner.new(pf.managed_directories,
+                                  pf.desired_contents,
+                                  pf.purge_exclusions).purge!
+
           true
         rescue => e
           logger.error R10K::Errors::Formatting.format_exception(e, @trace)

--- a/lib/r10k/util/cleaner.rb
+++ b/lib/r10k/util/cleaner.rb
@@ -1,0 +1,21 @@
+require 'r10k/logging'
+require 'r10k/util/purgeable'
+
+module R10K
+  module Util
+    class Cleaner
+
+      include R10K::Logging
+      include R10K::Util::Purgeable
+
+      attr_reader :managed_directories, :desired_contents, :purge_exclusions
+
+      def initialize(managed_directories, desired_contents, purge_exclusions = [])
+        @managed_directories = managed_directories
+        @desired_contents    = desired_contents
+        @purge_exclusions    = purge_exclusions
+      end
+
+    end
+  end
+end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -25,7 +25,6 @@ describe R10K::Action::Puppetfile::Install do
     end
 
     before do
-      allow(puppetfile).to receive(:purge!)
       allow(puppetfile).to receive(:modules).and_return(modules)
       allow(puppetfile).to receive(:modules_by_vcs_cachedir).and_return({none: modules})
     end
@@ -50,7 +49,15 @@ describe R10K::Action::Puppetfile::Install do
     end
 
     it "purges the moduledir after installation" do
-      expect(puppetfile).to receive(:purge!)
+      mock_cleaner = double("cleaner")
+      allow(puppetfile).to receive(:desired_contents).and_return(["root/foo"])
+      allow(puppetfile).to receive(:managed_directories).and_return(["root"])
+      allow(puppetfile).to receive(:purge_exclusions).and_return(["root/**/**.rb"])
+
+      expect(R10K::Util::Cleaner).to receive(:new).
+        with(["root"], ["root/foo"], ["root/**/**.rb"]).
+        and_return(mock_cleaner)
+      expect(mock_cleaner).to receive(:purge!)
 
       installer.call
     end

--- a/spec/unit/action/puppetfile/purge_spec.rb
+++ b/spec/unit/action/puppetfile/purge_spec.rb
@@ -3,7 +3,13 @@ require 'r10k/action/puppetfile/purge'
 
 describe R10K::Action::Puppetfile::Purge do
   let(:default_opts) { {root: "/some/nonexistent/path"} }
-  let(:puppetfile) { instance_double('R10K::Puppetfile', :load! => nil) }
+  let(:puppetfile) do
+    instance_double('R10K::Puppetfile',
+                    :load!               => nil,
+                    :managed_directories => %w{foo},
+                    :desired_contents    => %w{bar},
+                    :purge_exclusions    => %w{baz})
+  end
 
   def purger(opts = {}, argv = [], settings = {})
     opts = default_opts.merge(opts)
@@ -17,7 +23,13 @@ describe R10K::Action::Puppetfile::Purge do
   it_behaves_like "a puppetfile action"
 
   it "purges unmanaged entries in the Puppetfile moduledir" do
-    expect(puppetfile).to receive(:purge!)
+    mock_cleaner = double("cleaner")
+
+    expect(R10K::Util::Cleaner).to receive(:new).
+      with(["foo"], ["bar"], ["baz"]).
+      and_return(mock_cleaner)
+
+    expect(mock_cleaner).to receive(:purge!)
 
     purger.call
   end

--- a/spec/unit/util/purgeable_spec.rb
+++ b/spec/unit/util/purgeable_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'r10k/util/purgeable'
+require 'r10k/util/cleaner'
 
 RSpec.describe R10K::Util::Purgeable do
   let(:managed_directories) do
@@ -21,14 +22,7 @@ RSpec.describe R10K::Util::Purgeable do
     ]
   end
 
-  let(:test_class) do
-    Struct.new(:managed_directories, :desired_contents) do
-      include R10K::Util::Purgeable
-      include R10K::Logging
-    end
-  end
-
-  subject { test_class.new(managed_directories, desired_contents) }
+  subject { R10K::Util::Cleaner.new(managed_directories, desired_contents) }
 
   context 'without recurse option' do
     let(:recurse) { false }


### PR DESCRIPTION
Prior to this Puppetfile content was managed via the Purgeable mixin.
As a long term direction it would be valuable to move the Puppetfile in
a direction of acting on, or contributing to, modules connected to an
environment. In the processing of "dumbing" down the Puppetfile class
this patch moves the responsibility of purging to a helper class
(`R10K::Util::Cleaner`), leaving the Puppetfile class only the
responsibility of determining the Cleaner's inputs.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- Summary of changes. [Issue or PR #](link to issue or PR)
```
