### PR TITLE
(maint) Stop using master branch for git modules

### DIFF
--- a/integration/tests/git_source/git_source_repeated_remote.rb
+++ b/integration/tests/git_source/git_source_repeated_remote.rb
@@ -30,11 +30,11 @@ CONF
 puppetfile = <<-EOS
 mod 'prod_apache',
   :git => 'git://github.com/puppetlabs/puppetlabs-apache.git',
-  :branch => 'master'
+  :tag => 'v6.0.0'
 
 mod 'test_apache',
   :git => 'git://github.com/puppetlabs/puppetlabs-apache.git',
-  :branch => 'master'
+  :tag => 'v6.0.0'
 EOS
 
 teardown do

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
@@ -27,7 +27,8 @@ stdlib_notify_message_regex = /The test message is:.*one.*=>.*1.*two.*=>.*bats.*
 puppet_file = <<-PUPPETFILE
 mod "puppetlabs/motd"
 mod 'puppetlabs/stdlib',
-  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git',
+  :tag => 'v7.0.1'
 PUPPETFILE
 
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
@@ -31,7 +31,8 @@ puppet_file = <<-PUPPETFILE
 moduledir '#{@module_path}'
 mod "puppetlabs/motd"
 mod 'puppetlabs/stdlib',
-  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git',
+  :tag => 'v7.0.1'
 PUPPETFILE
 
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -65,7 +65,7 @@ env_structs = {:production => GitEnv.new('/git_repos',
                                          '/git_repos_alt/environments_alt.git',
                                          '/root/environments_alt',
                                          '/root/environments_alt/Puppetfile',
-                                         'mod "puppetlabs/stdlib", :git => "git://github.com/puppetlabs/puppetlabs-stdlib.git"',
+                                         'mod "puppetlabs/stdlib", :git => "git://github.com/puppetlabs/puppetlabs-stdlib.git", :tag => "v7.0.1"',
                                          '/root/environments_alt/manifests/site.pp',
                                          create_site_pp(master_certname, stage_env_manifest)
                                         ),

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
@@ -28,7 +28,8 @@ notify_message_regex = /I am in the production environment/
 puppet_file = <<-PUPPETFILE
 mod "puppetlabs/motd"
 mod 'puppetlabs/inifile',
-  :git => 'git://github.com/puppetlabs/puppetlabs-inifile'
+  :git => 'git://github.com/puppetlabs/puppetlabs-inifile',
+  :tag => 'v5.0.1'
 PUPPETFILE
 
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')


### PR DESCRIPTION
Many modules have removed their master branches. This commit updates the
test puppetfile fixtures to use module refs instead of explicit or
default branches.
