### PR TITLE
(maint) Update action calling convention

### DIFF
--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -10,7 +10,7 @@ module R10K
 
       attr_accessor :settings
 
-      def initialize(opts, argv, settings = {})
+      def initialize(opts, argv, settings)
         @opts = opts
         @argv = argv
         @settings = settings

--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -43,7 +43,7 @@ module R10K
           puts output.to_yaml
         end
 
-        def source_info(source, argv=[])
+        def source_info(source, requested_environments = [])
           source_info = {
             :name => source.name,
             :basedir => source.basedir,
@@ -52,7 +52,8 @@ module R10K
           source_info[:prefix] = source.prefix if source.prefix
           source_info[:remote] = source.remote if source.respond_to?(:remote)
 
-          env_list = source.environments.select { |env| argv.empty? || argv.include?(env.name) }
+          select_all_envs = requested_environments.empty?
+          env_list = source.environments.select { |env| select_all_envs || requested_environments.include?(env.name) }
           source_info[:environments] = env_list.map { |env| environment_info(env) }
 
           source_info

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -15,12 +15,11 @@ module R10K
 
         attr_reader :force
 
-        def initialize(opts, argv, settings = nil)
-          settings ||= {}
-          @purge_levels = settings.fetch(:deploy, {}).fetch(:purge_levels, [])
-          @user_purge_allowlist = read_purge_allowlist(settings.fetch(:deploy, {}).fetch(:purge_whitelist, []),
-                                                       settings.fetch(:deploy, {}).fetch(:purge_allowlist, []))
-          @generate_types = settings.fetch(:deploy, {}).fetch(:generate_types, false)
+        def initialize(opts, argv, settings)
+          @purge_levels = settings.dig(:deploy, :purge_levels) || []
+          @user_purge_allowlist = read_purge_allowlist(settings.dig(:deploy, :purge_whitelist) || [],
+                                                       settings.dig(:deploy, :purge_allowlist) || [])
+          @generate_types = settings.dig(:deploy, :generate_types) || false
 
           super
 

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -25,7 +25,7 @@ module R10K
 
           # @force here is used to make it easier to reason about
           @force = !@no_force
-          @argv = @argv.map { |arg| arg.gsub(/\W/,'_') }
+          @requested_environments = @argv.map { |arg| arg.gsub(/\W/,'_') }
         end
 
         def call
@@ -68,7 +68,7 @@ module R10K
           deployment.preload!
           deployment.validate!
 
-          undeployable = undeployable_environment_names(deployment.environments, @argv)
+          undeployable = undeployable_environment_names(deployment.environments, @requested_environments)
           if !undeployable.empty?
             @visit_ok = false
             logger.error _("Environment(s) \'%{environments}\' cannot be found in any source and will not be deployed.") % {environments: undeployable.join(", ")}
@@ -84,7 +84,7 @@ module R10K
           if (postcmd = @settings[:postrun])
             if postcmd.grep('$modifiedenvs').any?
               envs = deployment.environments.map { |e| e.dirname }
-              envs.reject! { |e| !@argv.include?(e) } if @argv.any?
+              envs.reject! { |e| !@requested_environments.include?(e) } if @requested_environments.any?
               postcmd = postcmd.map { |e| e.gsub('$modifiedenvs', envs.join(' ')) }
             end
             subproc = R10K::Util::Subprocess.new(postcmd)
@@ -98,7 +98,7 @@ module R10K
         end
 
         def visit_environment(environment)
-          if !(@argv.empty? || @argv.any? { |name| environment.dirname == name })
+          if !(@requested_environments.empty? || @requested_environments.any? { |name| environment.dirname == name })
             logger.debug1(_("Environment %{env_dir} does not match environment name filter, skipping") % {env_dir: environment.dirname})
             return
           end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -12,8 +12,7 @@ module R10K
 
         attr_reader :force
 
-        def initialize(opts, argv, settings = nil)
-          settings ||= {}
+        def initialize(opts, argv, settings)
 
           super
 

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -18,6 +18,7 @@ module R10K
 
           # @force here is used to make it easier to reason about
           @force = !@no_force
+          @requested_modules = @argv
         end
 
         def call
@@ -47,7 +48,7 @@ module R10K
           if @opts[:environment] && (@opts[:environment] != environment.dirname)
             logger.debug1(_("Only updating modules in environment %{opt_env} skipping environment %{env_path}") % {opt_env: @opts[:environment], env_path: environment.path})
           else
-            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @argv.inspect, env_path: environment.path})
+            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @requested_modules.inspect, env_path: environment.path})
             yield
           end
         end
@@ -58,7 +59,7 @@ module R10K
         end
 
         def visit_module(mod)
-          if @argv.include?(mod.name)
+          if @requested_modules.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
             mod.sync(force: @force)
             if mod.environment && @generate_types
@@ -66,7 +67,7 @@ module R10K
               mod.environment.generate_types!
             end
           else
-            logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @argv.inspect, mod_name: mod.name})
+            logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @requested_modules.inspect, mod_name: mod.name})
           end
         end
 

--- a/spec/shared-examples/puppetfile-action.rb
+++ b/spec/shared-examples/puppetfile-action.rb
@@ -3,15 +3,15 @@ require 'spec_helper'
 shared_examples_for "a puppetfile action" do
   describe "initializing" do
     it "accepts the :root option" do
-      described_class.new({root: "/some/nonexistent/path"}, [])
+      described_class.new({root: "/some/nonexistent/path"}, [], {})
     end
 
     it "accepts the :puppetfile option" do
-      described_class.new({puppetfile: "/some/nonexistent/path/Puppetfile"}, [])
+      described_class.new({puppetfile: "/some/nonexistent/path/Puppetfile"}, [], {})
     end
 
     it "accepts the :moduledir option" do
-      described_class.new({moduledir: "/some/nonexistent/path/modules"}, [])
+      described_class.new({moduledir: "/some/nonexistent/path/modules"}, [], {})
     end
 
   end
@@ -20,19 +20,19 @@ end
 shared_examples_for "a puppetfile install action" do
   describe "initializing" do
     it "accepts the :root option" do
-      described_class.new({root: "/some/nonexistent/path"}, [])
+      described_class.new({root: "/some/nonexistent/path"}, [], {})
     end
 
     it "accepts the :puppetfile option" do
-      described_class.new({puppetfile: "/some/nonexistent/path/Puppetfile"}, [])
+      described_class.new({puppetfile: "/some/nonexistent/path/Puppetfile"}, [], {})
     end
 
     it "accepts the :moduledir option" do
-      described_class.new({moduledir: "/some/nonexistent/path/modules"}, [])
+      described_class.new({moduledir: "/some/nonexistent/path/modules"}, [], {})
     end
 
     it "accepts the :force option" do
-      described_class.new({force: true}, [])
+      described_class.new({force: true}, [], {})
     end
 
   end

--- a/spec/unit/action/deploy/display_spec.rb
+++ b/spec/unit/action/deploy/display_spec.rb
@@ -32,4 +32,30 @@ describe R10K::Action::Deploy::Display do
   end
 
   it_behaves_like "a deploy action that requires a config file"
+
+  describe "collecting info" do
+    subject { described_class.new({config: "/some/nonexistent/path", format: 'json', puppetfile: true, detail: true}, ['first'], {}) }
+
+    let(:mock_config) do
+      R10K::Deployment::MockConfig.new(
+        :sources => {
+          :control => {
+            :type => :mock,
+            :basedir => '/some/nonexistent/path/control',
+            :environments => %w[first second third env-that/will-be-corrected],
+            :prefix => 'PREFIX'
+          }
+        }
+      )
+    end
+
+    let(:deployment) { R10K::Deployment.new(mock_config) }
+
+    it "gathers environment info" do
+      source_info = subject.send(:source_info, deployment.sources.first, ['first'])
+      expect(source_info[:name]).to eq(:control)
+      expect(source_info[:environments].length).to eq(1)
+      expect(source_info[:environments][0][:name]).to eq('first')
+    end
+  end
 end

--- a/spec/unit/action/deploy/display_spec.rb
+++ b/spec/unit/action/deploy/display_spec.rb
@@ -5,27 +5,27 @@ require 'r10k/action/deploy/display'
 describe R10K::Action::Deploy::Display do
   describe "initializing" do
     it "accepts a puppetfile option" do
-      described_class.new({puppetfile: true}, [])
+      described_class.new({puppetfile: true}, [], {})
     end
 
     it "accepts a modules option" do
-      described_class.new({modules: true}, [])
+      described_class.new({modules: true}, [], {})
     end
 
     it "accepts a detail option" do
-      described_class.new({detail: true}, [])
+      described_class.new({detail: true}, [], {})
     end
 
     it "accepts a format option" do
-      described_class.new({format: "json"}, [])
+      described_class.new({format: "json"}, [], {})
     end
 
     it "accepts a fetch option" do
-      described_class.new({fetch: true}, [])
+      described_class.new({fetch: true}, [], {})
     end
   end
 
-  subject { described_class.new({config: "/some/nonexistent/path"}, []) }
+  subject { described_class.new({config: "/some/nonexistent/path"}, [], {}) }
 
   before do
     allow(subject).to receive(:puts)

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -344,7 +344,7 @@ describe R10K::Action::Deploy::Environment do
         end
 
         it 'only calls puppet generate types on specified environment' do
-          subject.instance_variable_set(:@argv, %w[first])
+          subject.instance_variable_set(:@requested_environments, %w[first])
           expect(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
             if environment.dirname == 'first'
               expect(environment).to receive(:generate_types!)

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -5,46 +5,46 @@ require 'r10k/action/deploy/environment'
 
 describe R10K::Action::Deploy::Environment do
 
-  subject { described_class.new({config: "/some/nonexistent/path"}, []) }
+  subject { described_class.new({config: "/some/nonexistent/path"}, [], {}) }
 
   it_behaves_like "a deploy action that can be write locked"
   it_behaves_like "a deploy action that requires a config file"
 
   describe "initializing" do
     it "can accept a cachedir option" do
-      described_class.new({cachedir: "/some/nonexistent/cachedir"}, [])
+      described_class.new({cachedir: "/some/nonexistent/cachedir"}, [], {})
     end
 
     it "can accept a puppetfile option" do
-      described_class.new({puppetfile: true}, [])
+      described_class.new({puppetfile: true}, [], {})
     end
 
     it "can accept a modules option" do
-      described_class.new({modules: true}, [])
+      described_class.new({modules: true}, [], {})
     end
 
     it "can accept a default_branch_override option" do
-      described_class.new({:'default-branch-override' => 'default_branch_override_name'}, [])
+      described_class.new({:'default-branch-override' => 'default_branch_override_name'}, [], {})
     end
 
     it "can accept a no-force option" do
-      described_class.new({:'no-force' => true}, [])
+      described_class.new({:'no-force' => true}, [], {})
     end
 
     it 'can accept a generate-types option' do
-      described_class.new({ 'generate-types': true }, [])
+      described_class.new({ 'generate-types': true }, [], {})
     end
 
     it 'can accept a puppet-path option' do
-      described_class.new({ 'puppet-path': '/nonexistent' }, [])
+      described_class.new({ 'puppet-path': '/nonexistent' }, [], {})
     end
 
     it 'can accept a private-key option' do
-      described_class.new({ 'private-key': '/nonexistent' }, [])
+      described_class.new({ 'private-key': '/nonexistent' }, [], {})
     end
 
     it 'can accept a token option' do
-      described_class.new({ 'oauth-token': '/nonexistent' }, [])
+      described_class.new({ 'oauth-token': '/nonexistent' }, [], {})
     end
 
     describe "initializing errors" do
@@ -84,13 +84,13 @@ describe R10K::Action::Deploy::Environment do
 
       it "syncs the puppetfile when given the puppetfile flag" do
         expect(puppetfile).to receive(:accept).and_return([])
-        action = described_class.new({config: "/some/nonexistent/path", puppetfile: true}, [])
+        action = described_class.new({config: "/some/nonexistent/path", puppetfile: true}, [], {})
         action.call
       end
 
       it "syncs the puppetfile when given the modules flag" do
         expect(puppetfile).to receive(:accept).and_return([])
-        action = described_class.new({config: "/some/nonexistent/path", modules: true}, [])
+        action = described_class.new({config: "/some/nonexistent/path", modules: true}, [], {})
         action.call
       end
 
@@ -105,7 +105,7 @@ describe R10K::Action::Deploy::Environment do
         expect(R10K::Deployment).to receive(:new).and_return(deployment)
       end
 
-      subject { described_class.new({config: "/some/nonexistent/path"}, %w[not_an_environment]) }
+      subject { described_class.new({config: "/some/nonexistent/path"}, %w[not_an_environment], {}) }
 
       it "logs that the environments can't be deployed and returns false" do
         expect(subject.logger).to receive(:error).with("Environment(s) 'not_an_environment' cannot be found in any source and will not be deployed.")
@@ -115,7 +115,7 @@ describe R10K::Action::Deploy::Environment do
     end
 
     describe "with no-force" do
-      subject { described_class.new({ config: "/some/nonexistent/path", modules: true, :'no-force' => true}, %w[first]) }
+      subject { described_class.new({ config: "/some/nonexistent/path", modules: true, :'no-force' => true}, %w[first], {}) }
 
       it "tries to preserve local modifications" do
         expect(subject.force).to equal(false)
@@ -334,7 +334,8 @@ describe R10K::Action::Deploy::Environment do
               modules: true,
               'generate-types': true
             },
-            %w[first second]
+            %w[first second],
+            {}
           )
         end
 
@@ -388,7 +389,8 @@ describe R10K::Action::Deploy::Environment do
               modules: true,
               'generate-types': false
             },
-            %w[first]
+            %w[first],
+            {}
           )
         end
 
@@ -408,7 +410,7 @@ describe R10K::Action::Deploy::Environment do
 
     describe 'with puppet-path' do
 
-      subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-path': '/nonexistent' }, []) }
+      subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-path': '/nonexistent' }, [], {}) }
 
       it 'sets puppet_path' do
         expect(subject.instance_variable_get(:@puppet_path)).to eq('/nonexistent')
@@ -417,7 +419,7 @@ describe R10K::Action::Deploy::Environment do
 
     describe 'with puppet-conf' do
 
-      subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-conf': '/nonexistent' }, []) }
+      subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-conf': '/nonexistent' }, [], {}) }
 
       it 'sets puppet_conf' do
         expect(subject.instance_variable_get(:@puppet_conf)).to eq('/nonexistent')
@@ -426,7 +428,7 @@ describe R10K::Action::Deploy::Environment do
 
     describe 'with private-key' do
 
-      subject { described_class.new({ config: '/some/nonexistent/path', 'private-key': '/nonexistent' }, []) }
+      subject { described_class.new({ config: '/some/nonexistent/path', 'private-key': '/nonexistent' }, [], {}) }
 
       it 'sets private_key' do
         expect(subject.instance_variable_get(:@private_key)).to eq('/nonexistent')
@@ -435,7 +437,7 @@ describe R10K::Action::Deploy::Environment do
 
     describe 'with oauth-token' do
 
-      subject { described_class.new({ config: '/some/nonexistent/path', 'oauth-token': '/nonexistent' }, []) }
+      subject { described_class.new({ config: '/some/nonexistent/path', 'oauth-token': '/nonexistent' }, [], {}) }
 
       it 'sets oauth_token' do
         expect(subject.instance_variable_get(:@oauth_token)).to eq('/nonexistent')

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -4,48 +4,48 @@ require 'r10k/action/deploy/module'
 
 describe R10K::Action::Deploy::Module do
 
-  subject { described_class.new({config: "/some/nonexistent/path"}, []) }
+  subject { described_class.new({config: "/some/nonexistent/path"}, [], {}) }
 
   it_behaves_like "a deploy action that requires a config file"
   it_behaves_like "a deploy action that can be write locked"
 
   describe "initializing" do
     it "accepts an environment option" do
-      described_class.new({environment: "production"}, [])
+      described_class.new({environment: "production"}, [], {})
     end
 
     it "can accept a no-force option" do
-      described_class.new({:'no-force' => true}, [])
+      described_class.new({:'no-force' => true}, [], {})
     end
 
     it 'can accept a generate-types option' do
-      described_class.new({ 'generate-types': true }, [])
+      described_class.new({ 'generate-types': true }, [], {})
     end
 
     it 'can accept a puppet-path option' do
-      described_class.new({ 'puppet-path': '/nonexistent' }, [])
+      described_class.new({ 'puppet-path': '/nonexistent' }, [], {})
     end
 
     it 'can accept a puppet-conf option' do
-      described_class.new({ 'puppet-conf': '/nonexistent' }, [])
+      described_class.new({ 'puppet-conf': '/nonexistent' }, [], {})
     end
 
     it 'can accept a cachedir option' do
-      described_class.new({ cachedir: '/nonexistent' }, [])
+      described_class.new({ cachedir: '/nonexistent' }, [], {})
     end
 
     it 'can accept a private-key option' do
-      described_class.new({ 'private-key': '/nonexistent' }, [])
+      described_class.new({ 'private-key': '/nonexistent' }, [], {})
     end
 
     it 'can accept a token option' do
-      described_class.new({ 'oauth-token': '/nonexistent' }, [])
+      described_class.new({ 'oauth-token': '/nonexistent' }, [], {})
     end
   end
 
   describe "with no-force" do
 
-    subject { described_class.new({ config: "/some/nonexistent/path", :'no-force' => true}, [] )}
+    subject { described_class.new({ config: "/some/nonexistent/path", :'no-force' => true}, [], {}) }
 
     it "tries to preserve local modifications" do
       expect(subject.force).to equal(false)
@@ -76,7 +76,8 @@ describe R10K::Action::Deploy::Module do
             config: '/some/nonexistent/path',
             'generate-types': true
           },
-          %w[first]
+          %w[first],
+          {}
         )
       end
 
@@ -113,7 +114,8 @@ describe R10K::Action::Deploy::Module do
             config: '/some/nonexistent/path',
             'generate-types': false
           },
-          %w[first]
+          %w[first],
+          {}
         )
       end
 
@@ -133,7 +135,7 @@ describe R10K::Action::Deploy::Module do
 
   describe 'with puppet-path' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-path': '/nonexistent' }, []) }
+    subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-path': '/nonexistent' }, [], {}) }
 
     it 'sets puppet_path' do
       expect(subject.instance_variable_get(:@puppet_path)).to eq('/nonexistent')
@@ -142,7 +144,7 @@ describe R10K::Action::Deploy::Module do
 
   describe 'with puppet-conf' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-conf': '/nonexistent' }, []) }
+    subject { described_class.new({ config: '/some/nonexistent/path', 'puppet-conf': '/nonexistent' }, [], {}) }
 
     it 'sets puppet_conf' do
       expect(subject.instance_variable_get(:@puppet_conf)).to eq('/nonexistent')
@@ -151,7 +153,7 @@ describe R10K::Action::Deploy::Module do
 
   describe 'with cachedir' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path', cachedir: '/nonexistent' }, []) }
+    subject { described_class.new({ config: '/some/nonexistent/path', cachedir: '/nonexistent' }, [], {}) }
 
     it 'sets cachedir' do
       expect(subject.instance_variable_get(:@cachedir)).to eq('/nonexistent')
@@ -160,7 +162,7 @@ describe R10K::Action::Deploy::Module do
 
   describe 'with private-key' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path', 'private-key': '/nonexistent' }, []) }
+    subject { described_class.new({ config: '/some/nonexistent/path', 'private-key': '/nonexistent' }, [], {}) }
 
     it 'sets private_key' do
       expect(subject.instance_variable_get(:@private_key)).to eq('/nonexistent')
@@ -169,7 +171,7 @@ describe R10K::Action::Deploy::Module do
 
   describe 'with oauth-token' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path', 'oauth-token': '/nonexistent' }, []) }
+    subject { described_class.new({ config: '/some/nonexistent/path', 'oauth-token': '/nonexistent' }, [], {}) }
 
     it 'sets token_path' do
       expect(subject.instance_variable_get(:@oauth_token)).to eq('/nonexistent')

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -76,7 +76,7 @@ describe R10K::Action::Puppetfile::Install do
     end
 
     it "can use the force overwrite option" do
-      subject = described_class.new({root: "/some/nonexistent/path", force: true}, [])
+      subject = described_class.new({root: "/some/nonexistent/path", force: true}, [], {})
       expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, true).and_return(puppetfile)
       subject.call
     end


### PR DESCRIPTION
----
(maint) Use Ruby 2.3's Hash#dig & default arg values

R10K only supports Ruby >= 2.3 which means we can use Hash#dig instead
of Hash#fetch#fetch.

Also, it is never okay (outside of testing) to not pass a Hash for
the Action#new `settings` arg. Because of this, make the setting
argument mandatory.

for the settings, no need for a `nil` default that we later
conditionally override.

---

(maint) Give @argv a more meaningful name when used

Previously, some actions would use the argv values given to them but
never name them semantically. This patch names them "requested_modules"
or "requested_environments" where the content of argv should be one or
more modules or environments respectively.
