### PR TITLE
(maint) Extract Puppetfile accept logic to ContentSynchronizer

### DIFF
--- a/lib/r10k/content_synchronizer.rb
+++ b/lib/r10k/content_synchronizer.rb
@@ -1,0 +1,60 @@
+module R10K
+  module ContentSynchronizer
+
+    def self.serial_accept(modules, visitor, loader)
+      visitor.visit(:puppetfile, loader) do
+        modules.each do |mod|
+          mod.accept(visitor)
+        end
+      end
+    end
+
+    def self.concurrent_accept(modules, visitor, loader, pool_size, logger)
+      logger.debug _("Updating modules with %{pool_size} threads") % {pool_size: pool_size}
+      mods_queue = modules_queue(modules, visitor, loader)
+      thread_pool = pool_size.times.map { visitor_thread(visitor, mods_queue, logger) }
+      thread_exception = nil
+
+      # If any threads raise an exception the deployment is considered a failure.
+      # In that event clear the queue, wait for other threads to finish their
+      # current work, then re-raise the first exception caught.
+      begin
+        thread_pool.each(&:join)
+      rescue => e
+        logger.error _("Error during concurrent deploy of a module: %{message}") % {message: e.message}
+        mods_queue.clear
+        thread_exception ||= e
+        retry
+      ensure
+        raise thread_exception unless thread_exception.nil?
+      end
+    end
+
+    def self.modules_queue(modules, visitor, loader)
+      Queue.new.tap do |queue|
+        visitor.visit(:puppetfile, loader) do
+          modules_by_cachedir = modules.group_by { |mod| mod.cachedir }
+          modules_without_vcs_cachedir = modules_by_cachedir.delete(:none) || []
+
+          modules_without_vcs_cachedir.each {|mod| queue << Array(mod) }
+          modules_by_cachedir.values.each {|mods| queue << mods }
+        end
+      end
+    end
+
+    def self.visitor_thread(visitor, mods_queue, logger)
+      Thread.new do
+        begin
+          while mods = mods_queue.pop(true) do
+            mods.each {|mod| mod.accept(visitor) }
+          end
+        rescue ThreadError => e
+          logger.debug _("Module thread %{id} exiting: %{message}") % {message: e.message, id: Thread.current.object_id}
+          Thread.exit
+        rescue => e
+          Thread.main.raise(e)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -343,9 +343,9 @@ describe R10K::Puppetfile do
       m5 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/D')
       m6 = instance_double('R10K::Module::Base', :cachedir => '/dev/null/D')
 
-      expect(subject).to receive(:modules).and_return([m1, m2, m3, m4, m5, m6])
+      modules = [m1, m2, m3, m4, m5, m6]
 
-      queue = subject.modules_queue(visitor)
+      queue = R10K::ContentSynchronizer.modules_queue(modules, visitor, subject)
       expect(queue.length).to be 4
       queue_array = 4.times.map { queue.pop }
       expect(queue_array).to match_array([[m1], [m2], [m3, m4], [m5, m6]])


### PR DESCRIPTION
The Puppetfile internally contains logic to sync modules either
concurrently or serially depending on pool size. This would be valuable
to other means of attaching modules to an environment. The first step in
doing so is to extract the sync code into a helper module called
R10K::ContentSynchronizer.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- Summary of changes. [Issue or PR #](link to issue or PR)
```
