### PR TITLE
(maint) Pass Action configuration through helper objects all the way to Modules

### DIFF
--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -16,7 +16,7 @@ module R10K
             overrides: {
               environments: {
                 preload_environment: @fetch,
-                requested_environments: @argv
+                requested_environments: @argv.map { |arg| arg.gsub(/\W/, '_') }
               },
               modules: {},
               output: {

--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -33,14 +33,14 @@ module R10K
           expect_config!
           deployment = R10K::Deployment.new(@settings)
 
-          if @settings[:overrides][:environments][:preload_environments]
+          if @settings.dig(:overrides, :environments, :preload_environments)
             deployment.preload!
             deployment.validate!
           end
 
-          output = { :sources => deployment.sources.map { |source| source_info(source, @settings[:overrides][:environments][:requested_environments]) } }
+          output = { :sources => deployment.sources.map { |source| source_info(source, @settings.dig(:overrides, :environments, :requested_environments)) } }
 
-          case @settings[:overrides][:output][:format]
+          case @settings.dig(:overrides, :output, :format)
           when 'json' then json_format(output)
           else yaml_format(output)
           end
@@ -48,7 +48,7 @@ module R10K
           # exit 0
           true
         rescue => e
-          logger.error R10K::Errors::Formatting.format_exception(e, @settings[:overrides][:output][:trace])
+          logger.error R10K::Errors::Formatting.format_exception(e, @settings.dig(:overrides, :output, :trace))
           false
         end
 
@@ -81,8 +81,8 @@ module R10K
         end
 
         def environment_info(env)
-          modules = @settings[:overrides][:environments][:deploy_modules]
-          if !modules && !@settings[:overrides][:output][:detail]
+          modules = @settings.dig(:overrides, :environments, :deploy_modules)
+          if !modules && !@settings.dig(:overrides, :output, :detail)
             env.dirname
           else
             env_info = env.info.merge({
@@ -96,7 +96,7 @@ module R10K
         end
 
         def module_info(mod)
-          if @settings[:overrides][:output][:detail]
+          if @settings.dig(:overrides, :output, :detail)
             { :name => mod.title, :properties => mod.properties }
           else
             mod.title

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -14,19 +14,38 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
+        # Deprecated
         attr_reader :force
 
-        def initialize(opts, argv, settings)
-          @purge_levels = settings.dig(:deploy, :purge_levels) || []
-          @user_purge_allowlist = read_purge_allowlist(settings.dig(:deploy, :purge_whitelist) || [],
-                                                       settings.dig(:deploy, :purge_allowlist) || [])
-          @generate_types = settings.dig(:deploy, :generate_types) || false
+        attr_reader :settings
 
+        def initialize(opts, argv, settings)
           super
 
-          # @force here is used to make it easier to reason about
-          @force = !@no_force
-          @requested_environments = @argv.map { |arg| arg.gsub(/\W/,'_') }
+          # instance variables below are set by the super class based on the
+          # spec of #allowed_initialize_opts and any command line flags. This
+          # gives a preference order of cli flags > config files > defaults.
+          @settings = @settings.merge({
+            overrides: {
+              environments: {
+                requested_environments: @argv.map { |arg| arg.gsub(/\W/,'_') },
+                default_branch_override: @default_branch_override,
+                generate_types: @generate_types || settings.dig(:deploy, :generate_types) || false,
+                preload_environments: true
+              },
+              modules: {
+                requested_modules: [],
+                deploy_modules: @modules,
+                force: !@no_force, # force here is used to make it easier to reason about
+              },
+              purging: {
+                purge_levels: settings.dig(:deploy, :purge_levels) || [],
+                purge_allowlist: read_purge_allowlist(settings.dig(:deploy, :purge_whitelist) || [],
+                                                      settings.dig(:deploy, :purge_allowlist) || [])
+              },
+              output: {}
+            }
+          })
         end
 
         def call
@@ -66,10 +85,12 @@ module R10K
           # sources then we can't fully enumerate all environments which
           # could be dangerous. If this fails then an exception will be raised
           # and execution will be halted.
-          deployment.preload!
-          deployment.validate!
+          if @settings[:overrides][:environments][:preload_environments]
+            deployment.preload!
+            deployment.validate!
+          end
 
-          undeployable = undeployable_environment_names(deployment.environments, @requested_environments)
+          undeployable = undeployable_environment_names(deployment.environments, @settings[:overrides][:environments][:requested_environments])
           if !undeployable.empty?
             @visit_ok = false
             logger.error _("Environment(s) \'%{environments}\' cannot be found in any source and will not be deployed.") % {environments: undeployable.join(", ")}
@@ -77,7 +98,7 @@ module R10K
 
           yield
 
-          if @purge_levels.include?(:deployment)
+          if @settings[:overrides][:purging][:purge_levels].include?(:deployment)
             logger.debug("Purging unmanaged environments for deployment...")
             deployment.purge!
           end
@@ -85,7 +106,8 @@ module R10K
           if (postcmd = @settings[:postrun])
             if postcmd.grep('$modifiedenvs').any?
               envs = deployment.environments.map { |e| e.dirname }
-              envs.reject! { |e| !@requested_environments.include?(e) } if @requested_environments.any?
+              requested_envs = @settings[:overrides][:environments][:requested_environments]
+              envs.reject! { |e| !requested_envs.include?(e) } if requested_envs.any?
               postcmd = postcmd.map { |e| e.gsub('$modifiedenvs', envs.join(' ')) }
             end
             subproc = R10K::Util::Subprocess.new(postcmd)
@@ -99,7 +121,8 @@ module R10K
         end
 
         def visit_environment(environment)
-          if !(@requested_environments.empty? || @requested_environments.any? { |name| environment.dirname == name })
+          requested_envs = @settings[:overrides][:environments][:requested_environments]
+          if !(requested_envs.empty? || requested_envs.any? { |name| environment.dirname == name })
             logger.debug1(_("Environment %{env_dir} does not match environment name filter, skipping") % {env_dir: environment.dirname})
             return
           end
@@ -113,7 +136,7 @@ module R10K
           environment.sync
           logger.info _("Environment %{env_dir} is now at %{env_signature}") % {env_dir: environment.dirname, env_signature: environment.signature}
 
-          if status == :absent || @modules
+          if status == :absent || @settings[:overrides][:modules][:deploy_modules]
             if status == :absent
               logger.debug(_("Environment %{env_dir} is new, updating all modules") % {env_dir: environment.dirname})
             end
@@ -125,16 +148,16 @@ module R10K
             @visit_ok &&= previous_ok
           end
 
-          if @purge_levels.include?(:environment)
+          if @settings[:overrides][:purging][:purge_levels].include?(:environment)
             if @visit_ok
               logger.debug("Purging unmanaged content for environment '#{environment.dirname}'...")
-              environment.purge!(:recurse => true, :whitelist => environment.whitelist(@user_purge_allowlist))
+              environment.purge!(:recurse => true, :whitelist => environment.whitelist(@settings[:overrides][:purging][:purge_allowlist]))
             else
               logger.debug("Not purging unmanaged content for environment '#{environment.dirname}' due to prior deploy failures.")
             end
           end
 
-          if @generate_types
+          if @settings[:overrides][:environments][:generate_types]
             if @environment_ok
               logger.debug("Generating puppet types for environment '#{environment.dirname}'...")
               environment.generate_types!
@@ -147,11 +170,11 @@ module R10K
         end
 
         def visit_puppetfile(puppetfile)
-          puppetfile.load(@opts[:'default-branch-override'])
+          puppetfile.load(@settings[:overrides][:environments][:default_branch_override])
 
           yield
 
-          if @purge_levels.include?(:puppetfile)
+          if @settings[:overrides][:purging][:purge_levels].include?(:puppetfile)
             logger.debug("Purging unmanaged Puppetfile content for environment '#{puppetfile.environment.dirname}'...")
             R10K::Util::Cleaner.new(puppetfile.managed_directories,
                                     puppetfile.desired_contents,
@@ -161,7 +184,7 @@ module R10K
 
         def visit_module(mod)
           logger.info _("Deploying %{origin} content %{path}") % {origin: mod.origin, path: mod.path}
-          mod.sync(force: @force)
+          mod.sync(force: @settings[:overrides][:modules][:force])
         end
 
         def write_environment_info!(environment, started_at, success)

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -62,11 +62,11 @@ module R10K
         end
 
         def visit_environment(environment)
-          requested_envs = @settings[:overrides][:environments][:requested_environments]
-          if !requested_envs.empty? && requested_envs.none? { |env| env != environment.dirname }
+          requested_envs = @settings.dig(:overrides, :environments, :requested_environments)
+          if !requested_envs.empty? && requested_envs.include?(environment.dirname)
             logger.debug1(_("Only updating modules in environment(s) %{opt_env} skipping environment %{env_path}") % {opt_env: requested_envs.inspect, env_path: environment.path})
           else
-            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @settings[:overrides][:modules][:requested_modules].inspect, env_path: environment.path})
+            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @settings.dig(:overrides, :modules, :requested_modules).inspect, env_path: environment.path})
             yield
           end
         end
@@ -77,11 +77,11 @@ module R10K
         end
 
         def visit_module(mod)
-          requested_mods = @settings[:overrides][:modules][:requested_modules]
+          requested_mods = @settings.dig(:overrides, :modules, :requested_modules)
           if requested_mods.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
-            mod.sync(force: @settings[:overrides][:modules][:force])
-            if mod.environment && @settings[:overrides][:environments][:generate_types]
+            mod.sync(force: @settings.dig(:overrides, :modules, :force))
+            if mod.environment && @settings.dig(:overrides, :environments, :generate_types)
               logger.debug("Generating puppet types for environment '#{mod.environment.dirname}'...")
               mod.environment.generate_types!
             end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -19,10 +19,12 @@ module R10K
 
           super
 
+          requested_env = @opts[:environment] ? [@opts[:environment].gsub(/\W/, '_')] : []
+
           @settings = @settings.merge({
             overrides: {
               environments: {
-                requested_environments: [@opts[:environment]],
+                requested_environments: requested_env,
                 generate_types: @generate_types
               },
               modules: {

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -10,15 +10,30 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
+        # Deprecated
         attr_reader :force
+
+        attr_reader :settings
 
         def initialize(opts, argv, settings)
 
           super
 
-          # @force here is used to make it easier to reason about
-          @force = !@no_force
-          @requested_modules = @argv
+          @settings = @settings.merge({
+            overrides: {
+              environments: {
+                requested_environments: [@opts[:environment]],
+                generate_types: @generate_types
+              },
+              modules: {
+                requested_modules: @argv,
+                # force here is used to make it easier to reason about
+                force: !@no_force
+              },
+              purging: {},
+              output: {}
+            }
+          })
         end
 
         def call
@@ -45,10 +60,11 @@ module R10K
         end
 
         def visit_environment(environment)
-          if @opts[:environment] && (@opts[:environment] != environment.dirname)
-            logger.debug1(_("Only updating modules in environment %{opt_env} skipping environment %{env_path}") % {opt_env: @opts[:environment], env_path: environment.path})
+          requested_envs = @settings[:overrides][:environments][:requested_environments]
+          if !requested_envs.empty? && requested_envs.none? { |env| env != environment.dirname }
+            logger.debug1(_("Only updating modules in environment(s) %{opt_env} skipping environment %{env_path}") % {opt_env: requested_envs.inspect, env_path: environment.path})
           else
-            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @requested_modules.inspect, env_path: environment.path})
+            logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @settings[:overrides][:modules][:requested_modules].inspect, env_path: environment.path})
             yield
           end
         end
@@ -59,15 +75,16 @@ module R10K
         end
 
         def visit_module(mod)
-          if @requested_modules.include?(mod.name)
+          requested_mods = @settings[:overrides][:modules][:requested_modules]
+          if requested_mods.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
-            mod.sync(force: @force)
-            if mod.environment && @generate_types
+            mod.sync(force: @settings[:overrides][:modules][:force])
+            if mod.environment && @settings[:overrides][:environments][:generate_types]
               logger.debug("Generating puppet types for environment '#{mod.environment.dirname}'...")
               mod.environment.generate_types!
             end
           else
-            logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: @requested_modules.inspect, mod_name: mod.name})
+            logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: requested_mods.inspect, mod_name: mod.name})
           end
         end
 

--- a/lib/r10k/action/puppetfile/check.rb
+++ b/lib/r10k/action/puppetfile/check.rb
@@ -8,7 +8,9 @@ module R10K
       class Check < R10K::Action::Base
 
         def call
-          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
+          pf = R10K::Puppetfile.new(@root,
+                                    {moduledir: @moduledir,
+                                     puppetfile_path: @puppetfile})
           begin
             pf.load!
             $stderr.puts _("Syntax OK")

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -11,7 +11,10 @@ module R10K
 
         def call
           @visit_ok = true
-          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile, nil , @force)
+          pf = R10K::Puppetfile.new(@root,
+                                    {moduledir: @moduledir,
+                                     puppetfile_path: @puppetfile,
+                                     force: @force})
           pf.accept(self)
           @visit_ok
         end

--- a/lib/r10k/action/puppetfile/purge.rb
+++ b/lib/r10k/action/puppetfile/purge.rb
@@ -9,7 +9,9 @@ module R10K
       class Purge < R10K::Action::Base
 
         def call
-          pf = R10K::Puppetfile.new(@root, @moduledir, @puppetfile)
+          pf = R10K::Puppetfile.new(@root,
+                                    {moduledir: @moduledir,
+                                     puppetfile_path: @puppetfile})
           pf.load!
           R10K::Util::Cleaner.new(pf.managed_directories,
                                   pf.desired_contents,

--- a/lib/r10k/deployment.rb
+++ b/lib/r10k/deployment.rb
@@ -118,7 +118,7 @@ module R10K
         raise R10K::Error, _("Unable to load sources; the supplied configuration does not define the 'sources' key")
       end
       @_sources = sources.map do |(name, hash)|
-        R10K::Source.from_hash(name, hash)
+        R10K::Source.from_hash(name, hash.merge({overrides: @config[:overrides]}))
       end
     end
 

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -49,7 +49,10 @@ class R10K::Environment::Base
     @full_path = File.join(@basedir, @dirname)
     @path = Pathname.new(File.join(@basedir, @dirname))
 
-    @puppetfile  = R10K::Puppetfile.new(@full_path, nil, nil, @puppetfile_name)
+    @puppetfile  = R10K::Puppetfile.new(@full_path,
+                                        {overrides: @options[:overrides],
+                                         force: @options.dig(:overrides, :modules, :force),
+                                         puppetfile_name: @puppetfile_name})
     @puppetfile.environment = self
   end
 

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -44,6 +44,7 @@ class R10K::Environment::Base
     @dirname = dirname
     @options = options
     @puppetfile_name = options.delete(:puppetfile_name)
+    @overrides = options.delete(:overrides)
 
     @full_path = File.join(@basedir, @dirname)
     @path = Pathname.new(File.join(@basedir, @dirname))

--- a/lib/r10k/environment/svn.rb
+++ b/lib/r10k/environment/svn.rb
@@ -46,12 +46,12 @@ class R10K::Environment::SVN < R10K::Environment::Base
     super
     setopts(options, {
       # Standard option interface
-      :source  => :remote,
-      :version => :expected_revision,
-      :type    => ::R10K::Util::Setopts::Ignore,
+      :source   => :remote,
+      :version  => :expected_revision,
+      :type     => ::R10K::Util::Setopts::Ignore,
 
       # Type-specific options
-      :remote => :self,
+      :remote   => :self,
       :username => :self,
       :password => :self,
     })

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -97,14 +97,15 @@ class R10K::Environment::WithModules < R10K::Environment::Base
     if args.is_a?(Hash)
       # symbolize keys in the args hash
       args = args.inject({}) { |memo,(k,v)| memo[k.to_sym] = v; memo }
+      args[:overrides] = @overrides
+
+      if install_path = args.delete(:install_path)
+        install_path = resolve_install_path(install_path)
+        validate_install_path(install_path, name)
+      end
     end
 
-    if args.is_a?(Hash) && install_path = args.delete(:install_path)
-      install_path = resolve_install_path(install_path)
-      validate_install_path(install_path, name)
-    else
-      install_path = @moduledir
-    end
+    install_path ||= @moduledir
 
     # Keep track of all the content this environment is managing to enable purging.
     @managed_content[install_path] = Array.new unless @managed_content.has_key?(install_path)

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -43,9 +43,10 @@ class R10K::Module::Forge < R10K::Module::Base
     if opts.is_a?(Hash)
       setopts(opts, {
         # Standard option interface
-        :version => :expected_version,
-        :source  => ::R10K::Util::Setopts::Ignore,
-        :type    => ::R10K::Util::Setopts::Ignore,
+        :version   => :expected_version,
+        :source    => ::R10K::Util::Setopts::Ignore,
+        :type      => ::R10K::Util::Setopts::Ignore,
+        :overrides => :self,
       })
     else
       @expected_version = opts || current_version || :latest

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -39,16 +39,17 @@ class R10K::Module::Git < R10K::Module::Base
     super
     setopts(opts, {
       # Standard option interface
-      :version => :desired_ref,
-      :source  => :remote,
-      :type    => ::R10K::Util::Setopts::Ignore,
+      :version   => :desired_ref,
+      :source    => :remote,
+      :type      => ::R10K::Util::Setopts::Ignore,
+      :overrides => :self,
 
       # Type-specific options
-      :branch  => :desired_ref,
-      :tag     => :desired_ref,
-      :commit  => :desired_ref,
-      :ref     => :desired_ref,
-      :git     => :remote,
+      :branch    => :desired_ref,
+      :tag       => :desired_ref,
+      :commit    => :desired_ref,
+      :ref       => :desired_ref,
+      :git       => :remote,
       :default_branch          => :default_ref,
       :default_branch_override => :default_override_ref,
     })

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -40,16 +40,17 @@ class R10K::Module::SVN < R10K::Module::Base
     super
     setopts(opts, {
       # Standard option interface
-      :source   => :url,
-      :version  => :expected_revision,
-      :type     => ::R10K::Util::Setopts::Ignore,
+      :source    => :url,
+      :version   => :expected_revision,
+      :type      => ::R10K::Util::Setopts::Ignore,
+      :overrides => :self,
 
       # Type-specific options
-      :svn      => :url,
-      :rev      => :expected_revision,
-      :revision => :expected_revision,
-      :username => :self,
-      :password => :self
+      :svn       => :url,
+      :rev       => :expected_revision,
+      :revision  => :expected_revision,
+      :username  => :self,
+      :password  => :self
     })
 
     @working_dir = R10K::SVN::WorkingDir.new(@path, :username => @username, :password => @password)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -43,17 +43,32 @@ class Puppetfile
   #   @return [Boolean] Overwrite any locally made changes
   attr_accessor :force
 
+  # @!attribute [r] overrides
+  #   @return [Hash] Various settings overridden from normal configs
+  attr_reader :overrides
+
   # @param [String] basedir
-  # @param [String] moduledir The directory to install the modules, default to #{basedir}/modules
-  # @param [String] puppetfile_path The path to the Puppetfile, default to #{basedir}/Puppetfile
-  # @param [String] puppetfile_name The name of the Puppetfile, default to 'Puppetfile'
-  # @param [Boolean] force Shall we overwrite locally made changes?
-  def initialize(basedir, moduledir = nil, puppetfile_path = nil, puppetfile_name = nil, force = nil )
+  # @param [Hash, String, nil] options_or_moduledir The directory to install the modules or a Hash of options.
+  #         Usage as moduledir is deprecated. Only use as options, defaults to nil
+  # @param [String, nil] puppetfile_path Deprecated - The path to the Puppetfile, defaults to nil
+  # @param [String, nil] puppetfile_name Deprecated - The name of the Puppetfile, defaults to nil
+  # @param [Boolean, nil] force Deprecated - Shall we overwrite locally made changes?
+  def initialize(basedir, options_or_moduledir = nil, deprecated_path_arg = nil, deprecated_name_arg = nil, deprecated_force_arg = nil)
     @basedir         = basedir
-    @force           = force || false
-    @moduledir       = moduledir  || File.join(basedir, 'modules')
-    @puppetfile_name = puppetfile_name || 'Puppetfile'
-    @puppetfile_path = puppetfile_path || File.join(basedir, @puppetfile_name)
+    if options_or_moduledir.is_a? Hash
+      options = options_or_moduledir
+      deprecated_moduledir_arg = nil
+    else
+      options = {}
+      deprecated_moduledir_arg = options_or_moduledir
+    end
+
+    @force           = deprecated_force_arg     || options.delete(:force)           || false
+    @moduledir       = deprecated_moduledir_arg || options.delete(:moduledir)       || File.join(basedir, 'modules')
+    @puppetfile_name = deprecated_name_arg      || options.delete(:puppetfile_name) || 'Puppetfile'
+    @puppetfile_path = deprecated_path_arg      || options.delete(:puppetfile_path) || File.join(basedir, @puppetfile_name)
+
+    @overrides       = options.delete(:overrides) || {}
 
     logger.info _("Using Puppetfile '%{puppetfile}'") % {puppetfile: @puppetfile_path}
 

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -135,16 +135,20 @@ class Puppetfile
   # @param [String] name
   # @param [*Object] args
   def add_module(name, args)
-    if args.is_a?(Hash) && install_path = args.delete(:install_path)
-      install_path = resolve_install_path(install_path)
-      validate_install_path(install_path, name)
-    else
-      install_path = @moduledir
+    if args.is_a?(Hash)
+      args[:overrides] = @overrides
+
+      if install_path = args.delete(:install_path)
+        install_path = resolve_install_path(install_path)
+        validate_install_path(install_path, name)
+      end
+
+      if @default_branch_override != nil
+        args[:default_branch_override] = @default_branch_override
+      end
     end
 
-    if args.is_a?(Hash) && @default_branch_override != nil
-      args[:default_branch_override] = @default_branch_override
-    end
+    install_path ||= @moduledir
 
     mod = R10K::Module.new(name, install_path, args, @environment)
     mod.origin = :puppetfile

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -99,12 +99,22 @@ class R10K::Source::Git < R10K::Source::Base
     envs = []
     branch_names.each do |bn|
       if bn.valid?
-        envs << R10K::Environment::Git.new(bn.name, @basedir, bn.dirname,
-                                       {:remote => remote, :ref => bn.name, :puppetfile_name => puppetfile_name })
+        envs << R10K::Environment::Git.new(bn.name,
+                                           @basedir,
+                                           bn.dirname,
+                                           {remote: remote,
+                                            ref: bn.name,
+                                            puppetfile_name: puppetfile_name,
+                                            overrides: @options[:overrides]})
       elsif bn.correct?
        logger.warn _("Environment %{env_name} contained non-word characters, correcting name to %{corrected_env_name}") % {env_name: bn.name.inspect, corrected_env_name: bn.dirname}
-        envs << R10K::Environment::Git.new(bn.name, @basedir, bn.dirname,
-                                       {:remote => remote, :ref => bn.name, :puppetfile_name => puppetfile_name})
+        envs << R10K::Environment::Git.new(bn.name,
+                                           @basedir,
+                                           bn.dirname,
+                                           {remote: remote,
+                                            ref: bn.name,
+                                            puppetfile_name: puppetfile_name,
+                                            overrides: @options[:overrides]})
       elsif bn.validate?
        logger.error _("Environment %{env_name} contained non-word characters, ignoring it.") % {env_name: bn.name.inspect}
       end

--- a/lib/r10k/source/hash.rb
+++ b/lib/r10k/source/hash.rb
@@ -170,7 +170,7 @@ class R10K::Source::Hash < R10K::Source::Base
 
   def environments
     @environments ||= environments_hash.map do |name, hash|
-      R10K::Environment.from_hash(name, hash)
+      R10K::Environment.from_hash(name, hash.merge({overrides: @options[:overrides]}))
     end
   end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -457,7 +457,7 @@ describe R10K::Action::Deploy::Environment do
       def initialize(path, info)
         @path = path
         @info = info
-        @puppetfile = R10K::Puppetfile.new
+        @puppetfile = R10K::Puppetfile.new("", {})
       end
     end
 

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -118,7 +118,7 @@ describe R10K::Action::Deploy::Environment do
       subject { described_class.new({ config: "/some/nonexistent/path", modules: true, :'no-force' => true}, %w[first], {}) }
 
       it "tries to preserve local modifications" do
-        expect(subject.force).to equal(false)
+        expect(subject.settings[:overrides][:modules][:force]).to equal(false)
       end
     end
 
@@ -229,7 +229,7 @@ describe R10K::Action::Deploy::Environment do
 
       it "reads in the purge_allowlist setting and purges accordingly" do
         expect(subject.logger).to receive(:debug).with(/purging unmanaged content for environment/i)
-        expect(subject.instance_variable_get(:@user_purge_allowlist)).to eq(['coolfile', 'coolfile2'])
+        expect(subject.settings[:overrides][:purging][:purge_allowlist]).to eq(['coolfile', 'coolfile2'])
         subject.call
       end
 
@@ -238,7 +238,7 @@ describe R10K::Action::Deploy::Environment do
 
         it "reads in the purge_whitelist setting and still sets it to purge_allowlist and purges accordingly" do
           expect(subject.logger).to receive(:debug).with(/purging unmanaged content for environment/i)
-          expect(subject.instance_variable_get(:@user_purge_allowlist)).to eq(['coolfile', 'coolfile2'])
+          expect(subject.settings[:overrides][:purging][:purge_allowlist]).to eq(['coolfile', 'coolfile2'])
           subject.call
         end
       end
@@ -340,11 +340,13 @@ describe R10K::Action::Deploy::Environment do
         end
 
         it 'generate_types is true' do
-          expect(subject.instance_variable_get(:@generate_types)).to eq(true)
+          expect(subject.settings[:overrides][:environments][:generate_types]).to eq(true)
         end
 
         it 'only calls puppet generate types on specified environment' do
-          subject.instance_variable_set(:@requested_environments, %w[first])
+          settings = subject.instance_variable_get(:@settings)
+          settings[:overrides][:environments][:requested_environments] = %w{first}
+          subject.instance_variable_set(:@settings, settings)
           expect(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
             if environment.dirname == 'first'
               expect(environment).to receive(:generate_types!)
@@ -395,7 +397,7 @@ describe R10K::Action::Deploy::Environment do
         end
 
         it 'generate_types is false' do
-          expect(subject.instance_variable_get(:@generate_types)).to eq(false)
+          expect(subject.settings[:overrides][:environments][:generate_types]).to eq(false)
         end
 
         it 'does not call puppet generate types' do

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -48,7 +48,7 @@ describe R10K::Action::Deploy::Module do
     subject { described_class.new({ config: "/some/nonexistent/path", :'no-force' => true}, [], {}) }
 
     it "tries to preserve local modifications" do
-      expect(subject.force).to equal(false)
+      expect(subject.settings[:overrides][:modules][:force]).to equal(false)
     end
   end
 
@@ -91,7 +91,7 @@ describe R10K::Action::Deploy::Module do
       end
 
       it 'generate_types is true' do
-        expect(subject.instance_variable_get(:@generate_types)).to eq(true)
+        expect(subject.settings[:overrides][:environments][:generate_types]).to eq(true)
       end
 
       it 'only calls puppet generate types on environments with specified module' do
@@ -120,7 +120,7 @@ describe R10K::Action::Deploy::Module do
       end
 
       it 'generate_types is false' do
-        expect(subject.instance_variable_get(:@generate_types)).to eq(false)
+        expect(subject.settings[:overrides][:environments][:generate_types]).to eq(false)
       end
 
       it 'does not call puppet generate types' do |it|

--- a/spec/unit/action/puppetfile/check_spec.rb
+++ b/spec/unit/action/puppetfile/check_spec.rb
@@ -11,7 +11,7 @@ describe R10K::Action::Puppetfile::Check do
   end
 
   before(:each) do
-    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
+    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", {moduledir: nil, puppetfile_path: nil}).and_return(puppetfile)
   end
 
   it_behaves_like "a puppetfile action"
@@ -34,7 +34,7 @@ describe R10K::Action::Puppetfile::Check do
   it "respects --puppetfile option" do
     allow($stderr).to receive(:puts)
 
-    expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/custom/puppetfile/path").and_return(puppetfile)
+    expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", {moduledir: nil, puppetfile_path: "/custom/puppetfile/path"}).and_return(puppetfile)
 
     checker({puppetfile: "/custom/puppetfile/path"}).call
   end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -2,8 +2,11 @@ require 'spec_helper'
 require 'r10k/action/puppetfile/install'
 
 describe R10K::Action::Puppetfile::Install do
-  let(:default_opts) { {root: "/some/nonexistent/path"} }
-  let(:puppetfile) { R10K::Puppetfile.new('/some/nonexistent/path', nil, nil) }
+  let(:default_opts) { { root: "/some/nonexistent/path" } }
+  let(:puppetfile) {
+    R10K::Puppetfile.new('/some/nonexistent/path',
+                         {:moduledir => nil, :puppetfile_path => nil, :force => nil})
+  }
 
   def installer(opts = {}, argv = [], settings = {})
     opts = default_opts.merge(opts)
@@ -12,7 +15,10 @@ describe R10K::Action::Puppetfile::Install do
 
   before(:each) do
     allow(puppetfile).to receive(:load!).and_return(nil)
-    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, nil).and_return(puppetfile)
+    allow(R10K::Puppetfile).to receive(:new).
+      with("/some/nonexistent/path",
+           {:moduledir => nil, :puppetfile_path => nil, :force => nil}).
+      and_return(puppetfile)
   end
 
   it_behaves_like "a puppetfile install action"
@@ -65,13 +71,19 @@ describe R10K::Action::Puppetfile::Install do
 
   describe "using custom paths" do
     it "can use a custom puppetfile path" do
-      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/some/other/path/Puppetfile", nil, nil).and_return(puppetfile)
+      expect(R10K::Puppetfile).to receive(:new).
+        with("/some/nonexistent/path",
+             {:moduledir => nil, :force => nil, puppetfile_path: "/some/other/path/Puppetfile"}).
+        and_return(puppetfile)
 
       installer({puppetfile: "/some/other/path/Puppetfile"}).call
     end
 
     it "can use a custom moduledir path" do
-      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", "/some/other/path/site-modules", nil, nil, nil).and_return(puppetfile)
+      expect(R10K::Puppetfile).to receive(:new).
+        with("/some/nonexistent/path",
+             {:puppetfile_path => nil, :force => nil, moduledir: "/some/other/path/site-modules"}).
+        and_return(puppetfile)
 
       installer({moduledir: "/some/other/path/site-modules"}).call
     end
@@ -84,7 +96,9 @@ describe R10K::Action::Puppetfile::Install do
 
     it "can use the force overwrite option" do
       subject = described_class.new({root: "/some/nonexistent/path", force: true}, [], {})
-      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil, nil, true).and_return(puppetfile)
+      expect(R10K::Puppetfile).to receive(:new).
+        with("/some/nonexistent/path", {:moduledir => nil, :puppetfile_path => nil, :force => true}).
+        and_return(puppetfile)
       subject.call
     end
 

--- a/spec/unit/action/puppetfile/purge_spec.rb
+++ b/spec/unit/action/puppetfile/purge_spec.rb
@@ -17,7 +17,9 @@ describe R10K::Action::Puppetfile::Purge do
   end
 
   before(:each) do
-    allow(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, nil).and_return(puppetfile)
+    allow(R10K::Puppetfile).to receive(:new).
+      with("/some/nonexistent/path", {moduledir: nil, puppetfile_path: nil}).
+      and_return(puppetfile)
   end
 
   it_behaves_like "a puppetfile action"
@@ -40,13 +42,19 @@ describe R10K::Action::Puppetfile::Purge do
     end
 
     it "can use a custom puppetfile path" do
-      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", nil, "/some/other/path/Puppetfile").and_return(puppetfile)
+      expect(R10K::Puppetfile).to receive(:new).
+        with("/some/nonexistent/path",
+             {moduledir: nil, puppetfile_path: "/some/other/path/Puppetfile"}).
+        and_return(puppetfile)
 
       purger({puppetfile: "/some/other/path/Puppetfile"}).call
     end
 
     it "can use a custom moduledir path" do
-      expect(R10K::Puppetfile).to receive(:new).with("/some/nonexistent/path", "/some/other/path/site-modules", nil).and_return(puppetfile)
+      expect(R10K::Puppetfile).to receive(:new).
+        with("/some/nonexistent/path",
+             {moduledir: "/some/other/path/site-modules", puppetfile_path: nil}).
+        and_return(puppetfile)
 
       purger({moduledir: "/some/other/path/site-modules"}).call
     end


### PR DESCRIPTION
The visitor pattern can be confusing for new comers and has a considerable maintenance burden. For some in progress features it would be ideal to embed the `visit_module` and `visit_puppetfile` functionality into the modules & environments themselves.

To do so we need the configuration that comes in from the command line and is up-to-now own by the Action classes. This patch seeks to enable the above goal by passing the configuration currently owned by Actions all the way through the helper classes that participate in the visitor pattern down to the modules. Because of the scope of this work, this PR is intentionally naive. It passes _all_ the configuration _all_ the way down to Modules in a very naively shaped data structure.

The hope being that once we have that data everywhere we may need it we can start unwinding some of the visitor usage starting at Modules and working our way up. In doing so, only some values will need to be passed down and the data structure can be tweaked to better represent the values that are really needed, how they are needed.

Two small, potentially user facing changes snuck in while doing this:
1. If calling `r10k deploy display --fetch` the fetched source & environment code will now also be validated.
2. The debug message in `r10k deploy module --environment foo` will display the environment name "foo" in a single element array rather than a simple string

These small changes normalize some trivial behavior between different Actions `visit_*` calls so they may use the same data structures.

It may be best to step through the PR by commit rather than all at once.