### PR TITLE
(maint) Normalize deploy display override structure

### DIFF
--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -15,7 +15,7 @@ module R10K
           @settings = @settings.merge({
             overrides: {
               environments: {
-                preload_environment: @fetch,
+                preload_environments: @fetch,
                 requested_environments: @argv.map { |arg| arg.gsub(/\W/, '_') }
               },
               modules: {},


### PR DESCRIPTION
Previously, the structure in Action::Deploy::Display contained a key at
`overrides.environments.preload_environment` rather than the plural
`overrides.environments.preload_environments`, which is used elsewhere and
what the body of the action actually checked for. Without preloading the
environments changes to the list of environments since the last deploy
will not be shown.

This particularly affects code-manager which uses the display command to
retreive a list of environments when requested to do a "deploy all".

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- Summary of changes. [Issue or PR #](link to issue or PR)
```
