### PR TITLE
(maint) Do not use visitors to synchronize modules

### DIFF
--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -10,6 +10,13 @@ module R10K
 
       attr_accessor :settings
 
+      # @param opts [Hash] A hash of options defined in #allowed_initialized_opts
+      #   and managed by the SetOps mixin within the Action::Base class.
+      #   Corresponds to the CLI flags and options.
+      # @param argv [CRI::ArgumentList] A list-like collection of the remaining
+      #   arguments to the CLI invocation (after removing flags and options).
+      # @param settings [Hash] A hash of configuration loaded from the relevant
+      #   config (r10k.yaml).
       def initialize(opts, argv, settings)
         @opts = opts
         @argv = argv

--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -9,6 +9,13 @@ module R10K
 
         include R10K::Action::Deploy::DeployHelpers
 
+        # @param opts [Hash] A hash of options defined in #allowed_initialized_opts
+        #   and managed by the SetOps mixin within the Action::Base class.
+        #   Corresponds to the CLI flags and options.
+        # @param argv [CRI::ArgumentList] A list-like collection of the remaining
+        #   arguments to the CLI invocation (after removing flags and options).
+        # @param settings [Hash] A hash of configuration loaded from the relevant
+        #   config (r10k.yaml).
         def initialize(opts, argv, settings)
           super
 

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -183,7 +183,6 @@ module R10K
         end
 
         def visit_module(mod)
-          logger.info _("Deploying %{origin} content %{path}") % {origin: mod.origin, path: mod.path}
           mod.sync
         end
 

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -51,11 +51,17 @@ module R10K
         def call
           @visit_ok = true
 
-          expect_config!
-          deployment = R10K::Deployment.new(@settings)
-          check_write_lock!(@settings)
+          begin
+            expect_config!
+            deployment = R10K::Deployment.new(@settings)
+            check_write_lock!(@settings)
 
-          deployment.accept(self)
+            deployment.accept(self)
+          rescue => e
+            @visit_ok = false
+            logger.error R10K::Errors::Formatting.format_exception(e, @trace)
+          end
+
           @visit_ok
         end
 
@@ -180,10 +186,6 @@ module R10K
                                     puppetfile.desired_contents,
                                     puppetfile.purge_exclusions).purge!
           end
-        end
-
-        def visit_module(mod)
-          mod.sync
         end
 
         def write_environment_info!(environment, started_at, success)

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -184,7 +184,7 @@ module R10K
 
         def visit_module(mod)
           logger.info _("Deploying %{origin} content %{path}") % {origin: mod.origin, path: mod.path}
-          mod.sync(force: @settings.dig(:overrides, :modules, :force))
+          mod.sync
         end
 
         def write_environment_info!(environment, started_at, success)

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -19,6 +19,13 @@ module R10K
 
         attr_reader :settings
 
+        # @param opts [Hash] A hash of options defined in #allowed_initialized_opts
+        #   and managed by the SetOps mixin within the Action::Base class.
+        #   Corresponds to the CLI flags and options.
+        # @param argv [CRI::ArgumentList] A list-like collection of the remaining
+        #   arguments to the CLI invocation (after removing flags and options).
+        # @param settings [Hash] A hash of configuration loaded from the relevant
+        #   config (r10k.yaml).
         def initialize(opts, argv, settings)
           super
 

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -28,7 +28,7 @@ module R10K
                 generate_types: @generate_types
               },
               modules: {
-                requested_modules: @argv,
+                requested_modules: @argv.map.to_a,
                 # force here is used to make it easier to reason about
                 force: !@no_force
               },
@@ -77,15 +77,12 @@ module R10K
         end
 
         def visit_module(mod)
-          requested_mods = @settings.dig(:overrides, :modules, :requested_modules)
-          if requested_mods.include?(mod.name)
-            mod.sync
-            if mod.environment && @settings.dig(:overrides, :environments, :generate_types)
-              logger.debug("Generating puppet types for environment '#{mod.environment.dirname}'...")
-              mod.environment.generate_types!
-            end
-          else
-            logger.debug1(_("Only updating modules %{modules}, skipping module %{mod_name}") % {modules: requested_mods.inspect, mod_name: mod.name})
+          mod.sync
+
+          requested_mods = @settings.dig(:overrides, :modules, :requested_modules) || []
+          if requested_mods.include?(mod.name) && mod.environment && @settings.dig(:overrides, :environments, :generate_types)
+            logger.debug("Generating puppet types for environment '#{mod.environment.dirname}'...")
+            mod.environment.generate_types!
           end
         end
 

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -79,7 +79,6 @@ module R10K
         def visit_module(mod)
           requested_mods = @settings.dig(:overrides, :modules, :requested_modules)
           if requested_mods.include?(mod.name)
-            logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
             mod.sync
             if mod.environment && @settings.dig(:overrides, :environments, :generate_types)
               logger.debug("Generating puppet types for environment '#{mod.environment.dirname}'...")

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -15,8 +15,14 @@ module R10K
 
         attr_reader :settings
 
+        # @param opts [Hash] A hash of options defined in #allowed_initialized_opts
+        #   and managed by the SetOps mixin within the Action::Base class.
+        #   Corresponds to the CLI flags and options.
+        # @param argv [CRI::ArgumentList] A list-like collection of the remaining
+        #   arguments to the CLI invocation (after removing flags and options).
+        # @param settings [Hash] A hash of configuration loaded from the relevant
+        #   config (r10k.yaml).
         def initialize(opts, argv, settings)
-
           super
 
           requested_env = @opts[:environment] ? [@opts[:environment].gsub(/\W/, '_')] : []

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -80,7 +80,7 @@ module R10K
           requested_mods = @settings.dig(:overrides, :modules, :requested_modules)
           if requested_mods.include?(mod.name)
             logger.info _("Deploying module %{mod_path}") % {mod_path: mod.path}
-            mod.sync(force: @settings.dig(:overrides, :modules, :force))
+            mod.sync
             if mod.environment && @settings.dig(:overrides, :environments, :generate_types)
               logger.debug("Generating puppet types for environment '#{mod.environment.dirname}'...")
               mod.environment.generate_types!

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -34,10 +34,6 @@ module R10K
         end
 
         def visit_module(mod)
-          if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
-            logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})
-          end
-
           mod.sync
         end
 

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -11,11 +11,17 @@ module R10K
 
         def call
           @visit_ok = true
-          pf = R10K::Puppetfile.new(@root,
-                                    {moduledir: @moduledir,
-                                     puppetfile_path: @puppetfile,
-                                     force: @force || false})
-          pf.accept(self)
+          begin
+            pf = R10K::Puppetfile.new(@root,
+                                      {moduledir: @moduledir,
+                                       puppetfile_path: @puppetfile,
+                                       force: @force || false})
+            pf.accept(self)
+          rescue => e
+            @visit_ok = false
+            logger.error R10K::Errors::Formatting.format_exception(e, @trace)
+          end
+
           @visit_ok
         end
 
@@ -31,10 +37,6 @@ module R10K
           R10K::Util::Cleaner.new(pf.managed_directories,
                                   pf.desired_contents,
                                   pf.purge_exclusions).purge!
-        end
-
-        def visit_module(mod)
-          mod.sync
         end
 
         def allowed_initialize_opts

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -34,8 +34,6 @@ module R10K
         end
 
         def visit_module(mod)
-          logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
-
           if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
             logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})
           end

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -14,7 +14,7 @@ module R10K
           pf = R10K::Puppetfile.new(@root,
                                     {moduledir: @moduledir,
                                      puppetfile_path: @puppetfile,
-                                     force: @force})
+                                     force: @force || false})
           pf.accept(self)
           @visit_ok
         end
@@ -34,14 +34,13 @@ module R10K
         end
 
         def visit_module(mod)
-          @force ||= false
           logger.info _("Updating module %{mod_path}") % {mod_path: mod.path}
 
           if mod.respond_to?(:desired_ref) && mod.desired_ref == :control_branch
             logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a 'deploy' action, will use default if available." % {name: mod.name})
           end
 
-          mod.sync(force: @force)
+          mod.sync
         end
 
         def allowed_initialize_opts

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -44,14 +44,14 @@ class R10K::Environment::Base
     @dirname = dirname
     @options = options
     @puppetfile_name = options.delete(:puppetfile_name)
-    @overrides = options.delete(:overrides)
+    @overrides = options.delete(:overrides) || {}
 
     @full_path = File.join(@basedir, @dirname)
     @path = Pathname.new(File.join(@basedir, @dirname))
 
     @puppetfile  = R10K::Puppetfile.new(@full_path,
-                                        {overrides: @options[:overrides],
-                                         force: @options.dig(:overrides, :modules, :force),
+                                        {overrides: @overrides,
+                                         force: @overrides.dig(:modules, :force),
                                          puppetfile_name: @puppetfile_name})
     @puppetfile.environment = self
   end

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -96,7 +96,7 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   end
 
   # @param [String] name
-  # @param [*Object] args
+  # @param [Hash] args
   def add_module(name, args)
     # symbolize keys in the args hash
     args = args.inject({}) { |memo,(k,v)| memo[k.to_sym] = v; memo }

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -78,7 +78,7 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   def accept(visitor)
     visitor.visit(:environment, self) do
       @modules.each do |mod|
-        mod.accept(visitor)
+        mod.sync
       end
 
       puppetfile.accept(visitor)

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -87,6 +87,10 @@ class R10K::Environment::WithModules < R10K::Environment::Base
 
   def load_modules(module_hash)
     module_hash.each do |name, args|
+      if !args.is_a?(Hash)
+        args = { version: args }
+      end
+
       add_module(name, args)
     end
   end
@@ -94,18 +98,16 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   # @param [String] name
   # @param [*Object] args
   def add_module(name, args)
-    if args.is_a?(Hash)
-      # symbolize keys in the args hash
-      args = args.inject({}) { |memo,(k,v)| memo[k.to_sym] = v; memo }
-      args[:overrides] = @overrides
+    # symbolize keys in the args hash
+    args = args.inject({}) { |memo,(k,v)| memo[k.to_sym] = v; memo }
+    args[:overrides] = @overrides
 
-      if install_path = args.delete(:install_path)
-        install_path = resolve_install_path(install_path)
-        validate_install_path(install_path, name)
-      end
+    if install_path = args.delete(:install_path)
+      install_path = resolve_install_path(install_path)
+      validate_install_path(install_path, name)
+    else
+      install_path = @moduledir
     end
-
-    install_path ||= @moduledir
 
     # Keep track of all the content this environment is managing to enable purging.
     @managed_content[install_path] = Array.new unless @managed_content.has_key?(install_path)

--- a/lib/r10k/module.rb
+++ b/lib/r10k/module.rb
@@ -17,7 +17,7 @@ module R10K::Module
   #
   # @param [String] name The unique name of the module
   # @param [String] basedir The root to install the module in
-  # @param [Object] args An arbitary value or set of values that specifies the implementation
+  # @param [Hash] args An arbitary Hash that specifies the implementation
   # @param [R10K::Environment] environment Optional environment that this module is a part of
   #
   # @return [Object < R10K::Module] A member of the implementing subclass

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -55,7 +55,7 @@ class R10K::Module::Base
     @origin = 'external' # Expect Puppetfile or R10k::Environment to set this to a specific value
 
     @requested_modules = @overrides.dig(:modules, :requested_modules) || []
-    @to_be_synced = (@requested_modules.empty? || @requested_modules.include?(@name))
+    @should_sync = (@requested_modules.empty? || @requested_modules.include?(@name))
   end
 
   # @deprecated
@@ -70,8 +70,8 @@ class R10K::Module::Base
     raise NotImplementedError
   end
 
-  def will_sync?
-    if @to_be_synced
+  def should_sync?
+    if @should_sync
       logger.info _("Checking module %{path}") % {path: path}
       true
     else

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -102,6 +102,7 @@ class R10K::Module::Base
     raise NotImplementedError
   end
 
+  # Deprecated
   def accept(visitor)
     visitor.visit(:module, self)
   end

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -72,7 +72,7 @@ class R10K::Module::Base
 
   def should_sync?
     if @should_sync
-      logger.info _("Checking module %{path}") % {path: path}
+      logger.info _("Deploying module to %{path}") % {path: path}
       true
     else
       logger.debug1(_("Only updating modules %{modules}, skipping module %{name}") % {modules: @requested_modules.inspect, name: name})

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -61,6 +61,7 @@ class R10K::Module::Base
   end
 
   # Synchronize this module with the indicated state.
+  # @param [Hash] opts Deprecated
   # @abstract
   def sync(opts={})
     raise NotImplementedError

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -62,9 +62,8 @@ class R10K::Module::Base
 
   # Synchronize this module with the indicated state.
   # @param [Hash] opts Deprecated
-  # @abstract
   def sync(opts={})
-    raise NotImplementedError
+    logger.info _("Checking module %{path}") % {path: path}
   end
 
   # Return the desired version of this module

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -47,10 +47,9 @@ class R10K::Module::Forge < R10K::Module::Base
 
     setopts(opts, {
       # Standard option interface
-      :version   => :expected_version,
-      :source    => ::R10K::Util::Setopts::Ignore,
-      :type      => ::R10K::Util::Setopts::Ignore,
-      :overrides => :self,
+      :version => :expected_version,
+      :source  => ::R10K::Util::Setopts::Ignore,
+      :type    => ::R10K::Util::Setopts::Ignore,
     })
 
     @expected_version ||= current_version || :latest
@@ -60,15 +59,15 @@ class R10K::Module::Forge < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
-    super
-
-    case status
-    when :absent
-      install
-    when :outdated
-      upgrade
-    when :mismatched
-      reinstall
+    if will_sync?
+      case status
+      when :absent
+        install
+      when :outdated
+        upgrade
+      when :mismatched
+        reinstall
+      end
     end
   end
 

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -13,7 +13,12 @@ class R10K::Module::Forge < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    (args.is_a?(Hash) && args[:type].to_s == 'forge') || (!!(name.match %r[\w+[/-]\w+]) && valid_version?(args))
+    args[:type].to_s == 'forge' ||
+      (!!
+       ((args.keys & %i{git svn type}).empty? &&
+        args.has_key?(:version) &&
+        name.match(%r[\w+[/-]\w+]) &&
+        valid_version?(args[:version])))
   end
 
   def self.valid_version?(expected_version)
@@ -40,17 +45,15 @@ class R10K::Module::Forge < R10K::Module::Base
     @metadata_file = R10K::Module::MetadataFile.new(path + 'metadata.json')
     @metadata = @metadata_file.read
 
-    if opts.is_a?(Hash)
-      setopts(opts, {
-        # Standard option interface
-        :version   => :expected_version,
-        :source    => ::R10K::Util::Setopts::Ignore,
-        :type      => ::R10K::Util::Setopts::Ignore,
-        :overrides => :self,
-      })
-    else
-      @expected_version = opts || current_version || :latest
-    end
+    setopts(opts, {
+      # Standard option interface
+      :version   => :expected_version,
+      :source    => ::R10K::Util::Setopts::Ignore,
+      :type      => ::R10K::Util::Setopts::Ignore,
+      :overrides => :self,
+    })
+
+    @expected_version ||= current_version || :latest
 
     @v3_module = PuppetForge::V3::Module.new(:slug => @title)
   end

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -58,6 +58,7 @@ class R10K::Module::Forge < R10K::Module::Base
     @v3_module = PuppetForge::V3::Module.new(:slug => @title)
   end
 
+  # @param [Hash] opts Deprecated
   def sync(opts={})
     case status
     when :absent

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -60,6 +60,8 @@ class R10K::Module::Forge < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
+    super
+
     case status
     when :absent
       install

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -59,7 +59,7 @@ class R10K::Module::Forge < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
-    if will_sync?
+    if should_sync?
       case status
       when :absent
         install

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -54,6 +54,9 @@ class R10K::Module::Git < R10K::Module::Base
       :default_branch_override => :default_override_ref,
     })
 
+    force = @overrides && @overrides.dig(:modules, :force)
+    @force = force == false ? false : true
+
     @desired_ref ||= 'master'
 
     if @desired_ref == :control_branch && @environment && @environment.respond_to?(:ref)
@@ -75,8 +78,9 @@ class R10K::Module::Git < R10K::Module::Base
     }
   end
 
+  # @param [Hash] opts Deprecated
   def sync(opts={})
-    force = opts && opts.fetch(:force, true)
+    force = opts[:force] || @force
     @repo.sync(version, force)
   end
 

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -85,7 +85,7 @@ class R10K::Module::Git < R10K::Module::Base
   # @param [Hash] opts Deprecated
   def sync(opts={})
     force = opts[:force] || @force
-    @repo.sync(version, force) if will_sync?
+    @repo.sync(version, force) if should_sync?
   end
 
   def status

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -59,8 +59,12 @@ class R10K::Module::Git < R10K::Module::Base
 
     @desired_ref ||= 'master'
 
-    if @desired_ref == :control_branch && @environment && @environment.respond_to?(:ref)
-      @desired_ref = @environment.ref
+    if @desired_ref == :control_branch
+      if @environment && @environment.respond_to?(:ref)
+        @desired_ref = @environment.ref
+      else
+        logger.warn _("Cannot track control repo branch for content '%{name}' when not part of a git-backed environment, will use default if available." % {name: name})
+      end
     end
 
     @repo = R10K::Git::StatefulRepository.new(@remote, @dirname, @name)

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -80,6 +80,8 @@ class R10K::Module::Git < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
+    super
+
     force = opts[:force] || @force
     @repo.sync(version, force)
   end

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -8,7 +8,7 @@ class R10K::Module::Git < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    args.is_a?(Hash) && (args.has_key?(:git) || args[:type].to_s == 'git')
+    args.has_key?(:git) || args[:type].to_s == 'git'
   rescue
     false
   end

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -36,25 +36,25 @@ class R10K::Module::Git < R10K::Module::Base
   include R10K::Util::Setopts
 
   def initialize(title, dirname, opts, environment=nil)
+
     super
     setopts(opts, {
       # Standard option interface
-      :version   => :desired_ref,
-      :source    => :remote,
-      :type      => ::R10K::Util::Setopts::Ignore,
-      :overrides => :self,
+      :version                 => :desired_ref,
+      :source                  => :remote,
+      :type                    => ::R10K::Util::Setopts::Ignore,
 
       # Type-specific options
-      :branch    => :desired_ref,
-      :tag       => :desired_ref,
-      :commit    => :desired_ref,
-      :ref       => :desired_ref,
-      :git       => :remote,
+      :branch                  => :desired_ref,
+      :tag                     => :desired_ref,
+      :commit                  => :desired_ref,
+      :ref                     => :desired_ref,
+      :git                     => :remote,
       :default_branch          => :default_ref,
       :default_branch_override => :default_override_ref,
     })
 
-    force = @overrides && @overrides.dig(:modules, :force)
+    force = @overrides.dig(:modules, :force)
     @force = force == false ? false : true
 
     @desired_ref ||= 'master'
@@ -84,10 +84,8 @@ class R10K::Module::Git < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
-    super
-
     force = opts[:force] || @force
-    @repo.sync(version, force)
+    @repo.sync(version, force) if will_sync?
   end
 
   def status

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -30,6 +30,7 @@ class R10K::Module::Local < R10K::Module::Base
     :insync
   end
 
+  # @param [Hash] opts Deprecated
   def sync(opts={})
     logger.debug1 _("Module %{title} is a local module, always indicating synced.") % {title: title}
   end

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -70,6 +70,7 @@ class R10K::Module::SVN < R10K::Module::Base
     end
   end
 
+  # @param [Hash] opts Deprecated
   def sync(opts={})
     case status
     when :absent

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -71,7 +71,7 @@ class R10K::Module::SVN < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
-    if will_sync?
+    if should_sync?
       case status
       when :absent
         install

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -7,7 +7,7 @@ class R10K::Module::SVN < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    args.is_a?(Hash) && (args.has_key?(:svn) || args[:type].to_s == 'svn')
+    args.has_key?(:svn) || args[:type].to_s == 'svn'
   end
 
   # @!attribute [r] expected_revision

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -40,17 +40,16 @@ class R10K::Module::SVN < R10K::Module::Base
     super
     setopts(opts, {
       # Standard option interface
-      :source    => :url,
-      :version   => :expected_revision,
-      :type      => ::R10K::Util::Setopts::Ignore,
-      :overrides => :self,
+      :source   => :url,
+      :version  => :expected_revision,
+      :type     => ::R10K::Util::Setopts::Ignore,
 
       # Type-specific options
-      :svn       => :url,
-      :rev       => :expected_revision,
-      :revision  => :expected_revision,
-      :username  => :self,
-      :password  => :self
+      :svn      => :url,
+      :rev      => :expected_revision,
+      :revision => :expected_revision,
+      :username => :self,
+      :password => :self
     })
 
     @working_dir = R10K::SVN::WorkingDir.new(@path, :username => @username, :password => @password)
@@ -72,15 +71,15 @@ class R10K::Module::SVN < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
-    super
-
-    case status
-    when :absent
-      install
-    when :mismatched
-      reinstall
-    when :outdated
-      update
+    if will_sync?
+      case status
+      when :absent
+        install
+      when :mismatched
+        reinstall
+      when :outdated
+        update
+      end
     end
   end
 

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -72,6 +72,8 @@ class R10K::Module::SVN < R10K::Module::Base
 
   # @param [Hash] opts Deprecated
   def sync(opts={})
+    super
+
     case status
     when :absent
       install

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -209,9 +209,9 @@ describe R10K::Action::Deploy::Module do
         end
         puppetfile.modules.each do |mod|
           if ['mod1', 'mod2'].include?(mod.name)
-            expect(mod.will_sync?).to be(true)
+            expect(mod.should_sync?).to be(true)
           else
-            expect(mod.will_sync?).to be(false)
+            expect(mod.should_sync?).to be(false)
           end
 
           expect(mod).to receive(:sync).and_call_original

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -85,7 +85,7 @@ describe R10K::Action::Deploy::Module do
         allow(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
           expect(environment.puppetfile).to receive(:modules).and_return(
             [R10K::Module::Local.new(environment.name, '/fakedir', {}, environment)]
-          )
+          ).twice
           original.call(environment, &block)
         end
       end

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -5,7 +5,7 @@ describe R10K::Action::Puppetfile::Install do
   let(:default_opts) { { root: "/some/nonexistent/path" } }
   let(:puppetfile) {
     R10K::Puppetfile.new('/some/nonexistent/path',
-                         {:moduledir => nil, :puppetfile_path => nil, :force => nil})
+                         {:moduledir => nil, :puppetfile_path => nil, :force => false})
   }
 
   def installer(opts = {}, argv = [], settings = {})
@@ -17,7 +17,7 @@ describe R10K::Action::Puppetfile::Install do
     allow(puppetfile).to receive(:load!).and_return(nil)
     allow(R10K::Puppetfile).to receive(:new).
       with("/some/nonexistent/path",
-           {:moduledir => nil, :puppetfile_path => nil, :force => nil}).
+           {:moduledir => nil, :puppetfile_path => nil, :force => false}).
       and_return(puppetfile)
   end
 
@@ -73,7 +73,7 @@ describe R10K::Action::Puppetfile::Install do
     it "can use a custom puppetfile path" do
       expect(R10K::Puppetfile).to receive(:new).
         with("/some/nonexistent/path",
-             {:moduledir => nil, :force => nil, puppetfile_path: "/some/other/path/Puppetfile"}).
+             {:moduledir => nil, :force => false, puppetfile_path: "/some/other/path/Puppetfile"}).
         and_return(puppetfile)
 
       installer({puppetfile: "/some/other/path/Puppetfile"}).call
@@ -82,7 +82,7 @@ describe R10K::Action::Puppetfile::Install do
     it "can use a custom moduledir path" do
       expect(R10K::Puppetfile).to receive(:new).
         with("/some/nonexistent/path",
-             {:puppetfile_path => nil, :force => nil, moduledir: "/some/other/path/site-modules"}).
+             {:puppetfile_path => nil, :force => false, moduledir: "/some/other/path/site-modules"}).
         and_return(puppetfile)
 
       installer({moduledir: "/some/other/path/site-modules"}).call

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -26,7 +26,7 @@ describe R10K::Action::Puppetfile::Install do
   describe "installing modules" do
     let(:modules) do
       (1..4).map do |idx|
-        R10K::Module::Base.new("author/modname#{idx}", "/some/nonexistent/path/modname#{idx}", nil)
+        R10K::Module::Base.new("author/modname#{idx}", "/some/nonexistent/path/modname#{idx}", {})
       end
     end
 

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -77,7 +77,7 @@ describe R10K::Module::Forge do
       logger_dbl = double(Log4r::Logger)
       allow_any_instance_of(described_class).to receive(:logger).and_return(logger_dbl)
 
-      allow(logger_dbl).to receive(:info).with(/Checking module.*/)
+      allow(logger_dbl).to receive(:info).with(/Deploying module to.*/)
       expect(logger_dbl).to receive(:warn).with(/puppet forge module.*puppetlabs-corosync.*has been deprecated/i)
 
       subject.sync
@@ -89,7 +89,7 @@ describe R10K::Module::Forge do
       logger_dbl = double(Log4r::Logger)
       allow_any_instance_of(described_class).to receive(:logger).and_return(logger_dbl)
 
-      allow(logger_dbl).to receive(:info).with(/Checking module.*/)
+      allow(logger_dbl).to receive(:info).with(/Deploying module to.*/)
       expect(logger_dbl).to_not receive(:warn).with(/puppet forge module.*puppetlabs-corosync.*has been deprecated/i)
 
       subject.sync

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -11,15 +11,15 @@ describe R10K::Module::Forge do
 
   describe "implementing the Puppetfile spec" do
     it "should implement 'branan/eight_hundred', '8.0.0'" do
-      expect(described_class).to be_implement('branan/eight_hundred', '8.0.0')
+      expect(described_class).to be_implement('branan/eight_hundred', { version: '8.0.0' })
     end
 
     it "should implement 'branan-eight_hundred', '8.0.0'" do
-      expect(described_class).to be_implement('branan-eight_hundred', '8.0.0')
+      expect(described_class).to be_implement('branan-eight_hundred', { version: '8.0.0' })
     end
 
     it "should fail with an invalid title" do
-      expect(described_class).to_not be_implement('branan!eight_hundred', '8.0.0')
+      expect(described_class).to_not be_implement('branan!eight_hundred', { version: '8.0.0' })
     end
   end
 
@@ -30,7 +30,7 @@ describe R10K::Module::Forge do
   end
 
   describe "setting attributes" do
-    subject { described_class.new('branan/eight_hundred', '/moduledir', '8.0.0') }
+    subject { described_class.new('branan/eight_hundred', '/moduledir', { version: '8.0.0' }) }
 
     it "sets the name" do
       expect(subject.name).to eq 'eight_hundred'
@@ -50,7 +50,7 @@ describe R10K::Module::Forge do
   end
 
   describe "properties" do
-    subject { described_class.new('branan/eight_hundred', fixture_modulepath, '8.0.0') }
+    subject { described_class.new('branan/eight_hundred', fixture_modulepath, { version: '8.0.0' }) }
 
     it "sets the module type to :forge" do
       expect(subject.properties).to include(:type => :forge)
@@ -67,7 +67,7 @@ describe R10K::Module::Forge do
   end
 
   context "when a module is deprecated" do
-    subject { described_class.new('puppetlabs/corosync', fixture_modulepath, :latest) }
+    subject { described_class.new('puppetlabs/corosync', fixture_modulepath, { version: :latest }) }
 
     it "warns on sync if module is not already insync" do
       allow(subject).to receive(:status).and_return(:absent)
@@ -96,12 +96,12 @@ describe R10K::Module::Forge do
 
   describe '#expected_version' do
     it "returns an explicitly given expected version" do
-      subject = described_class.new('branan/eight_hundred', fixture_modulepath, '8.0.0')
+      subject = described_class.new('branan/eight_hundred', fixture_modulepath, { version: '8.0.0' })
       expect(subject.expected_version).to eq '8.0.0'
     end
 
     it "uses the latest version from the forge when the version is :latest" do
-      subject = described_class.new('branan/eight_hundred', fixture_modulepath, :latest)
+      subject = described_class.new('branan/eight_hundred', fixture_modulepath, { version: :latest })
       expect(subject.v3_module).to receive_message_chain(:current_release, :version).and_return('8.8.8')
       expect(subject.expected_version).to eq '8.8.8'
     end
@@ -109,7 +109,7 @@ describe R10K::Module::Forge do
 
   describe "determining the status" do
 
-    subject { described_class.new('branan/eight_hundred', fixture_modulepath, '8.0.0') }
+    subject { described_class.new('branan/eight_hundred', fixture_modulepath, { version: '8.0.0' }) }
 
     it "is :absent if the module directory is absent" do
       allow(subject).to receive(:exist?).and_return false
@@ -154,7 +154,7 @@ describe R10K::Module::Forge do
   end
 
   describe "#sync" do
-    subject { described_class.new('branan/eight_hundred', fixture_modulepath, '8.0.0') }
+    subject { described_class.new('branan/eight_hundred', fixture_modulepath, { version: '8.0.0' }) }
 
     it 'does nothing when the module is in sync' do
       allow(subject).to receive(:status).and_return :insync
@@ -186,7 +186,7 @@ describe R10K::Module::Forge do
 
   describe '#install' do
     it 'installs the module from the forge' do
-      subject = described_class.new('branan/eight_hundred', fixture_modulepath, '8.0.0')
+      subject = described_class.new('branan/eight_hundred', fixture_modulepath, { version: '8.0.0' })
       release = instance_double('R10K::Forge::ModuleRelease')
       expect(R10K::Forge::ModuleRelease).to receive(:new).with('branan-eight_hundred', '8.0.0').and_return(release)
       expect(release).to receive(:install).with(subject.path)
@@ -196,7 +196,7 @@ describe R10K::Module::Forge do
 
   describe '#uninstall' do
     it 'removes the module path' do
-      subject = described_class.new('branan/eight_hundred', fixture_modulepath, '8.0.0')
+      subject = described_class.new('branan/eight_hundred', fixture_modulepath, { version: '8.0.0' })
       expect(FileUtils).to receive(:rm_rf).with(subject.path.to_s)
       subject.uninstall
     end
@@ -204,7 +204,7 @@ describe R10K::Module::Forge do
 
   describe '#reinstall' do
     it 'uninstalls and then installs the module' do
-      subject = described_class.new('branan/eight_hundred', fixture_modulepath, '8.0.0')
+      subject = described_class.new('branan/eight_hundred', fixture_modulepath, { version: '8.0.0' })
       expect(subject).to receive(:uninstall)
       expect(subject).to receive(:install)
       subject.reinstall

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -77,6 +77,7 @@ describe R10K::Module::Forge do
       logger_dbl = double(Log4r::Logger)
       allow_any_instance_of(described_class).to receive(:logger).and_return(logger_dbl)
 
+      allow(logger_dbl).to receive(:info).with(/Checking module.*/)
       expect(logger_dbl).to receive(:warn).with(/puppet forge module.*puppetlabs-corosync.*has been deprecated/i)
 
       subject.sync
@@ -88,6 +89,7 @@ describe R10K::Module::Forge do
       logger_dbl = double(Log4r::Logger)
       allow_any_instance_of(described_class).to receive(:logger).and_return(logger_dbl)
 
+      allow(logger_dbl).to receive(:info).with(/Checking module.*/)
       expect(logger_dbl).to_not receive(:warn).with(/puppet forge module.*puppetlabs-corosync.*has been deprecated/i)
 
       subject.sync

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -210,6 +210,14 @@ describe R10K::Module::Git do
             expect(mod.desired_ref).to eq(:control_branch)
           end
 
+          it "warns control branch may be unresolvable" do
+            logger = double("logger")
+            allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
+            expect(logger).to receive(:warn).with(/Cannot track control repo branch.*boolean.*/)
+
+            test_module(branch: :control_branch)
+          end
+
           context "when default ref is provided and resolvable" do
             it "uses default ref" do
               expect(mock_repo).to receive(:resolve).with('default').and_return('abc123')

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -30,12 +30,12 @@ describe R10K::Module do
     [ 'bar/quux',
       'bar-quux',
     ].each do |scenario|
-      it "accepts a name matching #{scenario} and args nil" do
-        obj = R10K::Module.new(scenario, '/modulepath', nil)
+      it "accepts a name matching #{scenario} and version nil" do
+        obj = R10K::Module.new(scenario, '/modulepath', { version: nil })
         expect(obj).to be_a_kind_of(R10K::Module::Forge)
       end
     end
-    [ '8.0.0',
+    [ {version: '8.0.0'},
       {type: 'forge', version: '8.0.0'},
     ].each do |scenario|
       it "accepts a name matching bar-quux and args #{scenario.inspect}" do
@@ -65,7 +65,7 @@ describe R10K::Module do
       end
 
       it 'sets the expected version to what is found in the metadata' do
-        obj = R10K::Module.new(@title, @dirname, nil)
+        obj = R10K::Module.new(@title, @dirname, {version: nil})
         expect(obj.send(:instance_variable_get, :'@expected_version')).to eq('1.2.0')
       end
     end
@@ -73,7 +73,7 @@ describe R10K::Module do
 
   it "raises an error if delegation fails" do
     expect {
-      R10K::Module.new('bar!quux', '/modulepath', ["NOPE NOPE NOPE NOPE!"])
+      R10K::Module.new('bar!quux', '/modulepath', {version: ["NOPE NOPE NOPE NOPE!"]})
     }.to raise_error RuntimeError, /doesn't have an implementation/
   end
 end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -301,7 +301,7 @@ describe R10K::Puppetfile do
       subject.accept(visitor)
     end
 
-    it "passes the visitor to each module if the visitor yields" do
+    it "synchronizes each module if the visitor yields" do
       visitor = spy('visitor')
       expect(visitor).to receive(:visit) do |type, other, &block|
         expect(type).to eq :puppetfile
@@ -311,8 +311,8 @@ describe R10K::Puppetfile do
 
       mod1 = instance_double('R10K::Module::Base', :cachedir => :none)
       mod2 = instance_double('R10K::Module::Base', :cachedir => :none)
-      expect(mod1).to receive(:accept).with(visitor)
-      expect(mod2).to receive(:accept).with(visitor)
+      expect(mod1).to receive(:sync)
+      expect(mod2).to receive(:sync)
       expect(subject).to receive(:modules).and_return([mod1, mod2])
 
       subject.accept(visitor)
@@ -332,8 +332,8 @@ describe R10K::Puppetfile do
 
       mod1 = instance_double('R10K::Module::Base', :cachedir => :none)
       mod2 = instance_double('R10K::Module::Base', :cachedir => :none)
-      expect(mod1).to receive(:accept).with(visitor)
-      expect(mod2).to receive(:accept).with(visitor)
+      expect(mod1).to receive(:sync)
+      expect(mod2).to receive(:sync)
       expect(subject).to receive(:modules).and_return([mod1, mod2])
 
       expect(Thread).to receive(:new).exactly(pool_size).and_call_original

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -68,15 +68,15 @@ describe R10K::Puppetfile do
   end
 
   describe "adding modules" do
-    it "should accept Forge modules with a string arg" do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, '1.2.3', anything).and_call_original
+    it "should transform Forge modules with a string arg to have a version key" do
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
 
       expect { subject.add_module('puppet/test_module', '1.2.3') }.to change { subject.modules }
       expect(subject.modules.collect(&:name)).to include('test_module')
     end
 
     it "should not accept Forge modules with a version comparison" do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, '< 1.2.0', anything).and_call_original
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '< 1.2.0'), anything).and_call_original
 
       expect {
         subject.add_module('puppet/test_module', '< 1.2.0')
@@ -181,7 +181,7 @@ describe R10K::Puppetfile do
 
   describe '#managed_directories' do
     it 'returns an array of paths that can be purged' do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, '1.2.3', anything).and_call_original
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
 
       subject.add_module('puppet/test_module', '1.2.3')
       expect(subject.managed_directories).to match_array(["/some/nonexistent/basedir/modules"])


### PR DESCRIPTION
In removing the visit_module functionality logic that was duplicated within actions has been consolidated. Notably the info message in each action before it called `module.sync` was one of:
```
"Deploying %{origin} content %{path}"
"Deploying module %{mod_path}"
"Updating module %{mod_path}"
```
And now is:
```
"Checking module %{path}"
```
(Open to to a better message, btw).

By moving the `control_branch` logic from the `puppetfile install` command into Module::Git users will see the warning about invalid control branches if applicable during regular deploys as well (eg, if they are deploying git modules with the control_branch pattern in an SVN or Yaml backed environment).

Giving the Module::Base have a method like `will_sync?`seems a bit unnecessary for the single use case of the `deploy module` action, however I think it will provide a useful start to the kind of behavior that Reid mentions in https://github.com/puppetlabs/r10k/pull/1145#discussion_r616076004.

The first commit is a separate refactor that changes the API of Module.new to work more like the (Source|Environment).from_hash that is very similar to. I'm torn on whether that level of breaking change should go in. Would love to hear comments about how much it might be used in the wild (vs being a private API to R10K). I'm also happy to remove that commit as it isn't directly related to the remaining changes.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- Summary of changes. [Issue or PR #](link to issue or PR)
```
