### PR TITLE
Revert "(maint) Update template to not reference Jira"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
 ```
-- Summary of changes. [Issue or PR #](link to issue or PR)
+- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
 ```


### PR DESCRIPTION
This reverts commit 9d128482ea4cfc691725943772497bbdd1613431.
We decided to continue using the public RK Jira project afterall, so this puts
back the reminder to include the ticket number (if applicable) in the changelog.
