### PR TITLE
(main) Only deploy modules to requested envs

### DIFF
--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -74,7 +74,7 @@ module R10K
 
         def visit_environment(environment)
           requested_envs = @settings.dig(:overrides, :environments, :requested_environments)
-          if !requested_envs.empty? && requested_envs.include?(environment.dirname)
+          if !requested_envs.empty? && !requested_envs.include?(environment.dirname)
             logger.debug1(_("Only updating modules in environment(s) %{opt_env} skipping environment %{env_path}") % {opt_env: requested_envs.inspect, env_path: environment.path})
           else
             logger.debug1(_("Updating modules %{modules} in environment %{env_path}") % {modules: @settings.dig(:overrides, :modules, :requested_modules).inspect, env_path: environment.path})


### PR DESCRIPTION
This commit fixes a logic error in the check for which environments to
deploy modules to when using `r10k deploy module -e <env> <mod>`.
Previously, it would deploy to all envs except the one you asked for.
Now it will only deploy to the requested env.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
