### PR TITLE
(maint) Use a module loader within the Puppetfile class

### DIFF
--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -19,8 +19,8 @@ module R10K
       #     absolute full path or a relative path with regards to the basedir.
       # @param forge [String] The url (without protocol) to the Forge
       # @param overrides [Hash] Configuration for loaded modules' behavior
-      # @param environment [R10K::Environment] The environment loading may be
-      #     taking place within
+      # @param environment [R10K::Environment] When provided, the environment
+      #     in which loading takes place
       def initialize(basedir:,
                      moduledir: DEFAULT_MODULEDIR,
                      puppetfile: DEFAULT_PUPPETFILE_NAME,
@@ -52,16 +52,16 @@ module R10K
 
         managed_content = @modules.group_by(&:dirname).freeze
 
-        @managed_directories = determine_managed_directories(managed_content).freeze
-        @desired_contents = determine_desired_contents(managed_content).freeze
-        @purge_exclusions = determine_purge_exclusions(@managed_directories.clone).freeze
+        @managed_directories = determine_managed_directories(managed_content)
+        @desired_contents = determine_desired_contents(managed_content)
+        @purge_exclusions = determine_purge_exclusions(@managed_directories)
 
         {
           modules: @modules,
           managed_directories: @managed_directories,
           desired_contents: @desired_contents,
           purge_exclusions: @purge_exclusions
-        }.freeze
+        }
 
       rescue SyntaxError, LoadError, ArgumentError, NameError => e
         raise R10K::Error.wrap(e, _("Failed to evaluate %{path}") % {path: @puppetfile})
@@ -110,7 +110,7 @@ module R10K
           install_path = @moduledir
         end
 
-        if @default_branch_override != nil
+        if @default_branch_override
           module_info[:default_branch_override] = @default_branch_override
         end
 

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -1,0 +1,143 @@
+require 'r10k/logging'
+
+module R10K
+  module ModuleLoader
+    class Puppetfile
+
+      include R10K::Logging
+
+      attr_accessor :default_branch_override, :environment
+      attr_reader :modules, :managed_content, :moduledir
+
+      # @param [Hash] options
+      # @option options [String] :puppetfile
+      # @option options [String] :moduledir
+      # @option options [String] :basedir
+      # @option options [String] :forge
+      # @option options [Hash] :overrides
+      # @option options [R10K::Environment] :environment
+      def initialize(puppetfile:, moduledir:, forge:, basedir:, overrides:, environment:)
+        @puppetfile  = puppetfile
+        @moduledir   = moduledir
+        @basedir     = basedir
+        @overrides   = overrides
+        @environment = environment
+
+        @modules = []
+        @managed_content = {}
+      end
+
+      def load!
+        if !File.readable?(@puppetfile)
+          logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile.inspect}
+          return false
+        end
+
+        dsl = R10K::ModuleLoader::Puppetfile::DSL.new(self)
+        dsl.instance_eval(File.read(@puppetfile), @puppetfile)
+
+        validate_no_duplicate_names(@modules)
+      rescue SyntaxError, LoadError, ArgumentError, NameError => e
+        raise R10K::Error.wrap(e, _("Failed to evaluate %{path}") % {path: @puppetfile})
+      end
+
+      # @param [String] forge
+      def set_forge(forge)
+        @forge = forge
+      end
+
+      # @param [String] moduledir
+      def set_moduledir(moduledir)
+        @moduledir = if Pathname.new(moduledir).absolute?
+          moduledir
+        else
+          File.join(@basedir, moduledir)
+        end
+      end
+
+      # @param [String] name
+      # @param [Hash, String, Symbol] args Calling with anything but a Hash is
+      #   deprecated. The DSL will now convert String and Symbol versions to
+      #   Hashes of the shape
+      #     { version: <String or Symbol> }
+      #
+      def add_module(name, args)
+        if !args.is_a?(Hash)
+          args = { version: args }
+        end
+
+        args[:overrides] = @overrides
+
+        if install_path = args.delete(:install_path)
+          install_path = resolve_install_path(install_path)
+          validate_install_path(install_path, name)
+        else
+          install_path = @moduledir
+        end
+
+        if @default_branch_override != nil
+          args[:default_branch_override] = @default_branch_override
+        end
+
+        mod = R10K::Module.new(name, install_path, args, @environment)
+        mod.origin = :puppetfile
+
+        # Do not load modules if they would conflict with the attached
+        # environment
+        if @environment && @environment.module_conflicts?(mod)
+          mod = nil
+          return @modules
+        end
+
+        # Keep track of all the content this Puppetfile is managing to enable purging.
+        @managed_content[install_path] = Array.new unless @managed_content.has_key?(install_path)
+        @managed_content[install_path] << mod.name
+
+        @modules << mod
+      end
+
+
+
+     private
+      # @param [Array<String>] modules
+      def validate_no_duplicate_names(modules)
+        dupes = modules
+                .group_by { |mod| mod.name }
+                .select { |_, v| v.size > 1 }
+                .map(&:first)
+        unless dupes.empty?
+          msg = _('Puppetfiles cannot contain duplicate module names.')
+          msg += ' '
+          msg += _("Remove the duplicates of the following modules: %{dupes}" % { dupes: dupes.join(' ') })
+          raise R10K::Error.new(msg)
+        end
+      end
+
+      def resolve_install_path(path)
+        pn = Pathname.new(path)
+
+        unless pn.absolute?
+          pn = Pathname.new(File.join(@basedir, path))
+        end
+
+        # .cleanpath is as good as we can do without touching the filesystem.
+        # The .realpath methods will also choke if some of the intermediate
+        # paths are missing, even though we will create them later as needed.
+        pn.cleanpath.to_s
+      end
+
+      def validate_install_path(path, modname)
+        unless /^#{Regexp.escape(real_basedir)}.*/ =~ path
+          raise R10K::Error.new("Puppetfile cannot manage content '#{modname}' outside of containing environment: #{path} is not within #{real_basedir}")
+        end
+
+        true
+      end
+
+      def real_basedir
+        Pathname.new(@basedir).cleanpath.to_s
+      end
+
+    end
+  end
+end

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -34,6 +34,7 @@ module R10K
         @forge       = forge
         @overrides   = overrides
         @environment = environment
+        @default_branch_override = @overrides.dig(:environments, :default_branch_override)
 
         @modules = []
 

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -116,10 +116,9 @@ module R10K
         mod = R10K::Module.new(name, install_path, module_info, @environment)
         mod.origin = :puppetfile
 
-        # Do not load modules if they would conflict with the attached
+        # Do not save modules if they would conflict with the attached
         # environment
         if @environment && @environment.module_conflicts?(mod)
-          mod = nil
           return @modules
         end
 

--- a/lib/r10k/module_loader/puppetfile/dsl.rb
+++ b/lib/r10k/module_loader/puppetfile/dsl.rb
@@ -1,0 +1,37 @@
+module R10K
+  module ModuleLoader
+    class Puppetfile
+      class DSL
+        # A barebones implementation of the Puppetfile DSL
+        #
+        # @api private
+
+        def initialize(librarian)
+          @librarian = librarian
+        end
+
+        def mod(name, args = nil)
+          if args.is_a?(Hash)
+            opts = args
+          else
+            opts = { version: args }
+          end
+
+          @librarian.add_module(name, opts)
+        end
+
+        def forge(location)
+          @librarian.set_forge(location)
+        end
+
+        def moduledir(location)
+          @librarian.set_moduledir(location)
+        end
+
+        def method_missing(method, *args)
+          raise NoMethodError, _("unrecognized declaration '%{method}'") % {method: method}
+        end
+      end
+    end
+  end
+end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -5,10 +5,13 @@ require 'r10k/util/purgeable'
 require 'r10k/errors'
 require 'r10k/content_synchronizer'
 require 'r10k/module_loader/puppetfile/dsl'
+require 'r10k/module_loader/puppetfile'
 
 module R10K
 class Puppetfile
   # Defines the data members of a Puppetfile
+
+  NotGiven = BasicObject.new
 
   include R10K::Settings::Mixin
 
@@ -20,25 +23,17 @@ class Puppetfile
   #   @return [String] The URL to use for the Puppet Forge
   attr_reader :forge
 
-  # @!attribute [r] modules
-  #   @return [Array<R10K::Module>]
-  attr_reader :modules
-
   # @!attribute [r] basedir
   #   @return [String] The base directory that contains the Puppetfile
   attr_reader :basedir
-
-  # @!attribute [r] moduledir
-  #   @return [String] The directory to install the modules #{basedir}/modules
-  attr_reader :moduledir
 
   # @!attrbute [r] puppetfile_path
   #   @return [String] The path to the Puppetfile
   attr_reader :puppetfile_path
 
-  # @!attribute [rw] environment
+  # @!attribute [r] environment
   #   @return [R10K::Environment] Optional R10K::Environment that this Puppetfile belongs to.
-  attr_accessor :environment
+  attr_reader :environment
 
   # @!attribute [rw] force
   #   @return [Boolean] Overwrite any locally made changes
@@ -68,119 +63,84 @@ class Puppetfile
     @moduledir       = deprecated_moduledir_arg || options.delete(:moduledir)       || File.join(basedir, 'modules')
     @puppetfile_name = deprecated_name_arg      || options.delete(:puppetfile_name) || 'Puppetfile'
     @puppetfile_path = deprecated_path_arg      || options.delete(:puppetfile_path) || File.join(basedir, @puppetfile_name)
+    @environment     = options.delete(:environment)
 
     @overrides       = options.delete(:overrides) || {}
+    @default_branch_override = @overrides.dig(:environments, :default_branch_overrides)
 
     logger.info _("Using Puppetfile '%{puppetfile}'") % {puppetfile: @puppetfile_path}
 
-    @modules = []
-    @managed_content = {}
     @forge   = 'forgeapi.puppetlabs.com'
+
+    @loader = ::R10K::ModuleLoader::Puppetfile.new(
+      puppetfile: @puppetfile_path,
+      moduledir: @moduledir,
+      forge: @forge,
+      basedir: @basedir,
+      overrides: @overrides,
+      environment: @environment
+    )
 
     @loaded = false
   end
 
-  def load(default_branch_override = nil)
-    return true if self.loaded?
-    if File.readable? @puppetfile_path
-      self.load!(default_branch_override)
+  def load(default_branch_override = NotGiven)
+    if self.loaded?
+      return true 
     else
-      logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile_path.inspect}
+      self.load!(default_branch_override)
     end
   end
 
-  def load!(default_branch_override = nil)
-    @default_branch_override = default_branch_override
+  def load!(dbo = NotGiven)
+    if (dbo != NotGiven) && (dbo != @default_branch_override)
+      logger.warn("Mismatch between passed and initialized default branch overrides, preferring passed value.")
+      @loader.default_branch_override = dbo
+    end
 
-    dsl = R10K::ModuleLoader::Puppetfile::DSL.new(self)
-    dsl.instance_eval(puppetfile_contents, @puppetfile_path)
-
-    validate_no_duplicate_names(@modules)
+    @loader.load!
     @loaded = true
-  rescue SyntaxError, LoadError, ArgumentError, NameError => e
-    raise R10K::Error.wrap(e, _("Failed to evaluate %{path}") % {path: @puppetfile_path})
   end
 
   def loaded?
     @loaded
   end
 
-  # @param [Array<String>] modules
-  def validate_no_duplicate_names(modules)
-    dupes = modules
-            .group_by { |mod| mod.name }
-            .select { |_, v| v.size > 1 }
-            .map(&:first)
-    unless dupes.empty?
-      msg = _('Puppetfiles cannot contain duplicate module names.')
-      msg += ' '
-      msg += _("Remove the duplicates of the following modules: %{dupes}" % { dupes: dupes.join(' ') })
-      raise R10K::Error.new(msg)
-    end
+  def modules
+    @loader.modules
   end
 
-  # @param [String] forge
-  def set_forge(forge)
-    @forge = forge
-  end
-
-  # @param [String] moduledir
-  def set_moduledir(moduledir)
-    @moduledir = if Pathname.new(moduledir).absolute?
-      moduledir
-    else
-      File.join(basedir, moduledir)
-    end
-  end
-
-  # @param [String] name
-  # @param [Hash, String, Symbol] args Calling with anything but a Hash is
-  #   deprecated. The DSL will now convert String and Symbol versions to
-  #   Hashes of the shape
-  #     { version: <String or Symbol> }
-  #
   def add_module(name, args)
-    if !args.is_a?(Hash)
-      args = { version: args }
-    end
+    @loader.add_module(name, args)
+  end
 
-    args[:overrides] = @overrides
+  def set_moduledir(dir)
+    @loader.set_moduledir(dir)
+  end
 
-    if install_path = args.delete(:install_path)
-      install_path = resolve_install_path(install_path)
-      validate_install_path(install_path, name)
-    else
-      install_path = @moduledir
-    end
+  def set_forge(forge)
+    @loader.set_forge(forge)
+  end
 
-    if @default_branch_override != nil
-      args[:default_branch_override] = @default_branch_override
-    end
+  def moduledir
+    @loader.moduledir
+  end
 
-
-    mod = R10K::Module.new(name, install_path, args, @environment)
-    mod.origin = :puppetfile
-
-    # Do not load modules if they would conflict with the attached
-    # environment
-    if environment && environment.module_conflicts?(mod)
-      mod = nil
-      return @modules
-    end
-
-    # Keep track of all the content this Puppetfile is managing to enable purging.
-    @managed_content[install_path] = Array.new unless @managed_content.has_key?(install_path)
-    @managed_content[install_path] << mod.name
-
-    @modules << mod
+  def environment=(env)
+    @loader.environment = env
+    @environment = env
   end
 
   include R10K::Util::Purgeable
 
+  def managed_content
+    @loader.managed_content
+  end
+
   def managed_directories
     self.load unless @loaded
 
-    dirs = @managed_content.keys
+    dirs = managed_content.keys
     dirs.delete(real_basedir)
     dirs
   end
@@ -189,9 +149,9 @@ class Puppetfile
   # @note This implements a required method for the Purgeable mixin
   # @return [Array<String>]
   def desired_contents
-    self.load unless @loaded
+    self.load unless self.loaded?
 
-    @managed_content.flat_map do |install_path, modnames|
+    managed_content.flat_map do |install_path, modnames|
       modnames.collect { |name| File.join(install_path, name) }
     end
   end
@@ -225,31 +185,6 @@ class Puppetfile
   end
 
   private
-
-  def puppetfile_contents
-    File.read(@puppetfile_path)
-  end
-
-  def resolve_install_path(path)
-    pn = Pathname.new(path)
-
-    unless pn.absolute?
-      pn = Pathname.new(File.join(basedir, path))
-    end
-
-    # .cleanpath is as good as we can do without touching the filesystem.
-    # The .realpath methods will also choke if some of the intermediate
-    # paths are missing, even though we will create them later as needed.
-    pn.cleanpath.to_s
-  end
-
-  def validate_install_path(path, modname)
-    unless /^#{Regexp.escape(real_basedir)}.*/ =~ path
-      raise R10K::Error.new("Puppetfile cannot manage content '#{modname}' outside of containing environment: #{path} is not within #{real_basedir}")
-    end
-
-    true
-  end
 
   def real_basedir
     Pathname.new(basedir).cleanpath.to_s

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -9,7 +9,7 @@ require 'r10k/module_loader/puppetfile'
 
 module R10K
 
-# Deprecated, use R10K::ModuleLoader::Puppetfile#load! to load content,
+# Deprecated, use R10K::ModuleLoader::Puppetfile#load to load content,
 # provide the `:modules` key of the returned Hash to
 # R10K::ContentSynchronizer (either the `serial_sync` or `concurrent_sync`)
 # and the remaining keys (`:managed_directories`, `:desired_contents`, and
@@ -119,7 +119,7 @@ class Puppetfile
       return false
     end
 
-    @loaded_content = @loader.load!
+    @loaded_content = @loader.load
     @loaded = true
 
     @loaded_content

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -16,8 +16,6 @@ module R10K
 # `:purge_exclusions`) to R10K::Util::Cleaner.
 class Puppetfile
 
-  NotGiven = BasicObject.new
-
   include R10K::Settings::Mixin
 
   def_setting_attr :pool_size, 4
@@ -75,7 +73,7 @@ class Puppetfile
     @environment     = options.delete(:environment)
 
     @overrides       = options.delete(:overrides) || {}
-    @default_branch_override = @overrides.dig(:environments, :default_branch_overrides)
+    @default_branch_override = @overrides.dig(:environments, :default_branch_override)
 
     logger.info _("Using Puppetfile '%{puppetfile}'") % {puppetfile: @puppetfile_path}
 
@@ -100,7 +98,11 @@ class Puppetfile
     @loaded = false
   end
 
-  def load(default_branch_override = NotGiven)
+  # @param [String] default_branch_override The default branch to use
+  #   instead of one specified in the module declaration, if applicable.
+  #   Deprecated, use R10K::ModuleLoader::Puppetfile directly and pass
+  #   the default_branch_override as an option on initialization.
+  def load(default_branch_override = nil)
     if self.loaded?
       return @loaded_content
     else
@@ -108,10 +110,14 @@ class Puppetfile
     end
   end
 
-  def load!(dbo = NotGiven)
-    if (dbo != NotGiven) && (dbo != @default_branch_override)
+  # @param [String] default_branch_override The default branch to use
+  #   instead of one specified in the module declaration, if applicable.
+  #   Deprecated, use R10K::ModuleLoader::Puppetfile directly and pass
+  #   the default_branch_override as an option on initialization.
+  def load!(default_branch_override = nil)
+    if default_branch_override && (default_branch_override != @default_branch_override)
       logger.warn("Mismatch between passed and initialized default branch overrides, preferring passed value.")
-      @loader.default_branch_override = dbo
+      @loader.default_branch_override = default_branch_override
     end
 
     if !File.readable?(@puppetfile_path)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -4,6 +4,7 @@ require 'r10k/module'
 require 'r10k/util/purgeable'
 require 'r10k/errors'
 require 'r10k/content_synchronizer'
+require 'r10k/module_loader/puppetfile/dsl'
 
 module R10K
 class Puppetfile
@@ -91,7 +92,7 @@ class Puppetfile
   def load!(default_branch_override = nil)
     @default_branch_override = default_branch_override
 
-    dsl = R10K::Puppetfile::DSL.new(self)
+    dsl = R10K::ModuleLoader::Puppetfile::DSL.new(self)
     dsl.instance_eval(puppetfile_contents, @puppetfile_path)
 
     validate_no_duplicate_names(@modules)
@@ -254,36 +255,6 @@ class Puppetfile
     Pathname.new(basedir).cleanpath.to_s
   end
 
-  class DSL
-    # A barebones implementation of the Puppetfile DSL
-    #
-    # @api private
-
-    def initialize(librarian)
-      @librarian = librarian
-    end
-
-    def mod(name, args = nil)
-      if args.is_a?(Hash)
-        opts = args
-      else
-        opts = { version: args }
-      end
-
-      @librarian.add_module(name, opts)
-    end
-
-    def forge(location)
-      @librarian.set_forge(location)
-    end
-
-    def moduledir(location)
-      @librarian.set_moduledir(location)
-    end
-
-    def method_missing(method, *args)
-      raise NoMethodError, _("unrecognized declaration '%{method}'") % {method: method}
-    end
-  end
+  DSL = R10K::ModuleLoader::Puppetfile::DSL
 end
 end

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -115,14 +115,14 @@ class Puppetfile
   #   Deprecated, use R10K::ModuleLoader::Puppetfile directly and pass
   #   the default_branch_override as an option on initialization.
   def load!(default_branch_override = nil)
-    if default_branch_override && (default_branch_override != @default_branch_override)
-      logger.warn("Mismatch between passed and initialized default branch overrides, preferring passed value.")
-      @loader.default_branch_override = default_branch_override
-    end
-
     if !File.readable?(@puppetfile_path)
       logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile_path.inspect}
       return false
+    end
+
+    if default_branch_override && (default_branch_override != @default_branch_override)
+      logger.warn("Mismatch between passed and initialized default branch overrides, preferring passed value.")
+      @loader.default_branch_override = default_branch_override
     end
 
     @loaded_content = @loader.load
@@ -166,7 +166,7 @@ class Puppetfile
   def managed_directories
     self.load
 
-    @loader.managed_directories
+    @loaded_content[:managed_directories]
   end
 
   # Returns an array of the full paths to all the content being managed.

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -133,6 +133,7 @@ class Puppetfile
     @loaded_content[:modules]
   end
 
+  # @see R10K::ModuleLoader::Puppetfile#add_module for upcoming signature changes
   def add_module(name, args)
     @loader.add_module(name, args)
   end

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -91,14 +91,14 @@ describe R10K::ModuleLoader::Puppetfile do
     subject { R10K::ModuleLoader::Puppetfile.new(basedir: basedir) }
 
     it 'should transform Forge modules with a string arg to have a version key' do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
+      expect(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
 
       expect { subject.add_module('puppet/test_module', '1.2.3') }.to change { subject.modules }
       expect(subject.modules.collect(&:name)).to include('test_module')
     end
 
     it 'should not accept Forge modules with a version comparison' do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '< 1.2.0'), anything).and_call_original
+      expect(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '< 1.2.0'), anything).and_call_original
 
       expect {
         subject.add_module('puppet/test_module', '< 1.2.0')
@@ -110,7 +110,7 @@ describe R10K::ModuleLoader::Puppetfile do
     it 'should accept non-Forge modules with a hash arg' do
       module_opts = { git: 'git@example.com:puppet/test_module.git' }
 
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, module_opts, anything).and_call_original
+      expect(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, module_opts, anything).and_call_original
 
       expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
       expect(subject.modules.collect(&:name)).to include('test_module')
@@ -122,7 +122,7 @@ describe R10K::ModuleLoader::Puppetfile do
         git: 'git@example.com:puppet/test_module.git',
       }
 
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', File.join(basedir, 'vendor'), module_opts, anything).and_call_original
+      expect(R10K::Module).to receive(:new).with('puppet/test_module', File.join(basedir, 'vendor'), module_opts, anything).and_call_original
 
       expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
       expect(subject.modules.collect(&:name)).to include('test_module')
@@ -136,7 +136,7 @@ describe R10K::ModuleLoader::Puppetfile do
         git: 'git@example.com:puppet/test_module.git',
       }
 
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', install_path, module_opts, anything).and_call_original
+      expect(R10K::Module).to receive(:new).with('puppet/test_module', install_path, module_opts, anything).and_call_original
 
       expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
       expect(subject.modules.collect(&:name)).to include('test_module')
@@ -163,10 +163,10 @@ describe R10K::ModuleLoader::Puppetfile do
     it 'should disable and not add modules that conflict with the environment' do
       env = instance_double('R10K::Environment::Base')
       mod = instance_double('R10K::Module::Base', name: 'conflict', origin: :puppetfile, 'origin=': nil)
-      loader = described_class.new(basedir: basedir, environment: env)
+      loader = R10K::ModuleLoader::Puppetfile.new(basedir: basedir, environment: env)
       allow(env).to receive(:'module_conflicts?').with(mod).and_return(true)
 
-      allow(R10K::Module).to receive(:new).with('conflict', anything, anything, anything).and_return(mod)
+      expect(R10K::Module).to receive(:new).with('conflict', anything, anything, anything).and_return(mod)
       expect { loader.add_module('conflict', {}) }.not_to change { loader.modules }
     end
   end
@@ -200,8 +200,8 @@ describe R10K::ModuleLoader::Puppetfile do
       allow(subject).to receive(:puppetfile_content).and_return('')
     end
 
-    it 'returns an array of paths that can be purged' do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
+    it 'returns an array of paths that #purge! will operate within' do
+      expect(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
       subject.add_module('puppet/test_module', '1.2.3')
       subject.load
 
@@ -213,7 +213,7 @@ describe R10K::ModuleLoader::Puppetfile do
       it "basedir isn't in the list of paths to purge" do
         module_opts = { install_path: '', git: 'git@example.com:puppet/test_module.git' }
 
-        allow(R10K::Module).to receive(:new).with('puppet/test_module', basedir, module_opts, anything).and_call_original
+        expect(R10K::Module).to receive(:new).with('puppet/test_module', basedir, module_opts, anything).and_call_original
         subject.add_module('puppet/test_module', module_opts)
         subject.load
 

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -1,0 +1,297 @@
+require 'spec_helper'
+require 'r10k/module_loader/puppetfile'
+
+describe R10K::ModuleLoader::Puppetfile do
+  describe 'initial parameters' do
+    describe 'honor' do
+      subject do
+        R10K::ModuleLoader::Puppetfile.new(basedir: '/test/basedir/env',
+                                           moduledir: '/test/basedir/env/dist-modules',
+                                           puppetfile: '/test/basedir/env/puppetfile.prod',
+                                           forge: 'localforge.internal.corp',
+                                           overrides: { modules: { deploy_modules: true } },
+                                           environment: R10K::Environment::Git.new('env',
+                                                                                   '/test/basedir/',
+                                                                                   'env',
+                                                                                   { remote: 'git://foo/remote',
+                                                                                     ref: 'env' }))
+      end
+
+      it 'the moduledir' do
+        expect(subject.instance_variable_get(:@moduledir)).to eq('/test/basedir/env/dist-modules')
+      end
+
+      it 'the Puppetfile' do
+        expect(subject.instance_variable_get(:@puppetfile)).to eq('/test/basedir/env/puppetfile.prod')
+      end
+
+      it 'the forge' do
+        expect(subject.instance_variable_get(:@forge)).to eq('localforge.internal.corp')
+      end
+
+      it 'the overrides' do
+        expect(subject.instance_variable_get(:@overrides)).to eq({ modules: { deploy_modules: true }})
+      end
+
+      it 'the environment' do
+        expect(subject.instance_variable_get(:@environment).name).to eq('env')
+      end
+    end
+
+    describe 'sane defaults' do
+      subject { R10K::ModuleLoader::Puppetfile.new(basedir: '/test/basedir') }
+
+      it 'has a moduledir rooted in the basedir' do
+        expect(subject.instance_variable_get(:@moduledir)).to eq('/test/basedir/modules')
+      end
+
+      it 'has a Puppetfile rooted in the basedir' do
+        expect(subject.instance_variable_get(:@puppetfile)).to eq('/test/basedir/Puppetfile')
+      end
+
+      it 'uses the public forge' do
+        expect(subject.instance_variable_get(:@forge)).to eq('forgeapi.puppetlabs.com')
+      end
+
+      it 'creates an empty overrides' do
+        expect(subject.instance_variable_get(:@overrides)).to eq({})
+      end
+
+      it 'does not require an environment' do
+        expect(subject.instance_variable_get(:@environment)).to eq(nil)
+      end
+    end
+  end
+
+  describe 'adding modules' do
+    let(:basedir) { '/test/basedir' }
+
+    subject { R10K::ModuleLoader::Puppetfile.new(basedir: basedir) }
+
+    it 'should transform Forge modules with a string arg to have a version key' do
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
+
+      expect { subject.add_module('puppet/test_module', '1.2.3') }.to change { subject.modules }
+      expect(subject.modules.collect(&:name)).to include('test_module')
+    end
+
+    it 'should not accept Forge modules with a version comparison' do
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '< 1.2.0'), anything).and_call_original
+
+      expect {
+        subject.add_module('puppet/test_module', '< 1.2.0')
+      }.to raise_error(RuntimeError, /module puppet\/test_module.*doesn't have an implementation/i)
+
+      expect(subject.modules.collect(&:name)).not_to include('test_module')
+    end
+
+    it 'should accept non-Forge modules with a hash arg' do
+      module_opts = { git: 'git@example.com:puppet/test_module.git' }
+
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, module_opts, anything).and_call_original
+
+      expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
+      expect(subject.modules.collect(&:name)).to include('test_module')
+    end
+
+    it 'should accept non-Forge modules with a valid relative :install_path option' do
+      module_opts = {
+        install_path: 'vendor',
+        git: 'git@example.com:puppet/test_module.git',
+      }
+
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', File.join(basedir, 'vendor'), module_opts, anything).and_call_original
+
+      expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
+      expect(subject.modules.collect(&:name)).to include('test_module')
+    end
+
+    it 'should accept non-Forge modules with a valid absolute :install_path option' do
+      install_path = File.join(basedir, 'vendor')
+
+      module_opts = {
+        install_path: install_path,
+        git: 'git@example.com:puppet/test_module.git',
+      }
+
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', install_path, module_opts, anything).and_call_original
+
+      expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
+      expect(subject.modules.collect(&:name)).to include('test_module')
+    end
+
+    it 'should reject non-Forge modules with an invalid relative :install_path option' do
+      module_opts = {
+        install_path: '../../vendor',
+        git: 'git@example.com:puppet/test_module.git',
+      }
+
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', File.join(basedir, 'vendor'), module_opts, anything).and_call_original
+
+      expect { subject.add_module('puppet/test_module', module_opts) }.to raise_error(R10K::Error, /cannot manage content.*is not within/i).and not_change { subject.modules }
+    end
+
+    it 'should reject non-Forge modules with an invalid absolute :install_path option' do
+      module_opts = {
+        install_path: '/tmp/mydata/vendor',
+        git: 'git@example.com:puppet/test_module.git',
+      }
+
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', File.join(basedir, 'vendor'), module_opts, anything).and_call_original
+
+      expect { subject.add_module('puppet/test_module', module_opts) }.to raise_error(R10K::Error, /cannot manage content.*is not within/i).and not_change { subject.modules }
+    end
+
+    it 'should disable and not add modules that conflict with the environment' do
+      env = instance_double('R10K::Environment::Base')
+      mod = instance_double('R10K::Module::Base', name: 'conflict', origin: :puppetfile)
+      allow(mod).to receive(:origin=).and_return(nil)
+      loader = described_class.new(basedir: basedir, environment: env)
+      allow(env).to receive(:'module_conflicts?').with(mod).and_return(true)
+
+      allow(R10K::Module).to receive(:new).with('test', anything, anything, anything).and_return(mod)
+      expect { loader.add_module('test', {}) }.not_to change { loader.modules }
+    end
+  end
+
+  describe '#purge_exclusions' do
+    let(:managed_dirs) { ['dir1', 'dir2'] }
+    subject { R10K::ModuleLoader::Puppetfile.new(basedir: '/test/basedir') }
+
+    it 'includes managed_directories' do
+      expect(subject.send(:determine_purge_exclusions, managed_dirs)).to match_array(managed_dirs)
+    end
+
+    context 'when belonging to an environment' do
+      let(:env_contents) { ['env1', 'env2' ] }
+      let(:env) { double(:environment, desired_contents: env_contents) }
+
+      subject { R10K::ModuleLoader::Puppetfile.new(basedir: '/test/basedir', environment: env) }
+
+      it "includes environment's desired_contents" do
+        expect(subject.send(:determine_purge_exclusions, managed_dirs)).to match_array(managed_dirs + env_contents)
+      end
+    end
+  end
+
+  describe '#managed_directories' do
+
+    let(:basedir) { '/test/basedir' }
+    subject { R10K::ModuleLoader::Puppetfile.new(basedir: basedir) }
+
+    before do
+      allow(subject).to receive(:puppetfile_content).and_return('')
+    end
+
+    it 'returns an array of paths that can be purged' do
+      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
+      subject.add_module('puppet/test_module', '1.2.3')
+      subject.load!
+
+      expect(subject.modules.length).to be 1
+      expect(subject.managed_directories).to match_array([subject.moduledir])
+    end
+
+    context "with a module with install_path == ''" do
+      it "basedir isn't in the list of paths to purge" do
+        module_opts = { install_path: '', git: 'git@example.com:puppet/test_module.git' }
+
+        allow(R10K::Module).to receive(:new).with('puppet/test_module', basedir, module_opts, anything).and_call_original
+        subject.add_module('puppet/test_module', module_opts)
+        subject.load!
+
+        expect(subject.modules.length).to be 1
+        expect(subject.managed_directories).to be_empty
+      end
+    end
+  end
+
+  describe 'evaluating a Puppetfile' do
+    def expect_wrapped_error(orig, pf_path, wrapped_error)
+      expect(orig).to be_a_kind_of(R10K::Error)
+      expect(orig.message).to eq("Failed to evaluate #{pf_path}")
+      expect(orig.original).to be_a_kind_of(wrapped_error)
+    end
+
+    subject { described_class.new(basedir: @path) }
+
+    it 'wraps and re-raises syntax errors' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'invalid-syntax')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect {
+        subject.load!
+      }.to raise_error do |e|
+        expect_wrapped_error(e, pf_path, SyntaxError)
+      end
+    end
+
+    it 'wraps and re-raises load errors' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'load-error')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect {
+        subject.load!
+      }.to raise_error do |e|
+        expect_wrapped_error(e, pf_path, LoadError)
+      end
+    end
+
+    it 'wraps and re-raises argument errors' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'argument-error')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect {
+        subject.load!
+      }.to raise_error do |e|
+        expect_wrapped_error(e, pf_path, ArgumentError)
+      end
+    end
+
+    it 'rejects Puppetfiles with duplicate module names' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'duplicate-module-error')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect {
+        subject.load!
+      }.to raise_error(R10K::Error, /Puppetfiles cannot contain duplicate module names/i)
+    end
+
+    it 'wraps and re-raises name errors' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'name-error')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect {
+        subject.load!
+      }.to raise_error do |e|
+        expect_wrapped_error(e, pf_path, NameError)
+      end
+    end
+
+    it 'accepts a forge module with a version' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect { subject.load! }.not_to raise_error
+    end
+
+    it 'accepts a forge module without a version' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-without-version')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect { subject.load! }.not_to raise_error
+    end
+
+    it 'creates a git module and applies the default branch sepcified in the Puppetfile' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'default-branch-override')
+      pf_path = File.join(@path, 'Puppetfile')
+      expect { subject.load! }.not_to raise_error
+      git_module = subject.modules[0]
+      expect(git_module.default_ref).to eq 'here_lies_the_default_branch'
+    end
+
+    it 'creates a git module and applies the provided default_branch_override' do
+      @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'default-branch-override')
+      pf_path = File.join(@path, 'Puppetfile')
+      default_branch_override = 'default_branch_override_name'
+      subject.default_branch_override = default_branch_override
+      expect { subject.load! }.not_to raise_error
+      git_module = subject.modules[0]
+      expect(git_module.default_override_ref).to eq default_branch_override
+      expect(git_module.default_ref).to eq 'here_lies_the_default_branch'
+    end
+  end
+end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -154,50 +154,50 @@ describe R10K::Puppetfile do
     # end
   end
 
-  describe "#purge_exclusions" do
-    let(:managed_dirs) { ['dir1', 'dir2'] }
+  # describe "#purge_exclusions" do
+  #   let(:managed_dirs) { ['dir1', 'dir2'] }
 
-    before(:each) do
-      allow(subject).to receive(:managed_directories).and_return(managed_dirs)
-    end
+  #   before(:each) do
+  #     allow(subject).to receive(:managed_directories).and_return(managed_dirs)
+  #   end
 
-    it "includes managed_directories" do
-      expect(subject.purge_exclusions).to match_array(managed_dirs)
-    end
+  #   it "includes managed_directories" do
+  #     expect(subject.purge_exclusions).to match_array(managed_dirs)
+  #   end
 
-    context "when belonging to an environment" do
-      let(:env_contents) { ['env1', 'env2' ] }
+  #   context "when belonging to an environment" do
+  #     let(:env_contents) { ['env1', 'env2' ] }
 
-      before(:each) do
-        mock_env = double(:environment, desired_contents: env_contents)
-        allow(subject).to receive(:environment).and_return(mock_env)
-      end
+  #     before(:each) do
+  #       mock_env = double(:environment, desired_contents: env_contents)
+  #       allow(subject).to receive(:environment).and_return(mock_env)
+  #     end
 
-      it "includes environment's desired_contents" do
-        expect(subject.purge_exclusions).to match_array(managed_dirs + env_contents)
-      end
-    end
-  end
+  #     it "includes environment's desired_contents" do
+  #       expect(subject.purge_exclusions).to match_array(managed_dirs + env_contents)
+  #     end
+  #   end
+  # end
 
-  describe '#managed_directories' do
-    it 'returns an array of paths that can be purged' do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
+  # describe '#managed_directories' do
+  #   it 'returns an array of paths that can be purged' do
+  #     allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
 
-      subject.add_module('puppet/test_module', '1.2.3')
-      expect(subject.managed_directories).to match_array(["/some/nonexistent/basedir/modules"])
-    end
+  #     subject.add_module('puppet/test_module', '1.2.3')
+  #     expect(subject.managed_directories).to match_array(["/some/nonexistent/basedir/modules"])
+  #   end
 
-    context 'with a module with install_path == \'\'' do
-      it 'basedir isn\'t in the list of paths to purge' do
-        module_opts = { install_path: '', git: 'git@example.com:puppet/test_module.git' }
+  #   context 'with a module with install_path == \'\'' do
+  #     it 'basedir isn\'t in the list of paths to purge' do
+  #       module_opts = { install_path: '', git: 'git@example.com:puppet/test_module.git' }
 
-        allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.basedir, module_opts, anything).and_call_original
+  #       allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.basedir, module_opts, anything).and_call_original
 
-        subject.add_module('puppet/test_module', module_opts)
-        expect(subject.managed_directories).to be_empty
-      end
-    end
-  end
+  #       subject.add_module('puppet/test_module', module_opts)
+  #       expect(subject.managed_directories).to be_empty
+  #     end
+  #   end
+  # end
 
   describe "evaluating a Puppetfile" do
     def expect_wrapped_error(orig, pf_path, wrapped_error)

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -67,230 +67,35 @@ describe R10K::Puppetfile do
     end
   end
 
-  describe "adding modules" do
-    it "should transform Forge modules with a string arg to have a version key" do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
-
-      expect { subject.add_module('puppet/test_module', '1.2.3') }.to change { subject.modules }
-      expect(subject.modules.collect(&:name)).to include('test_module')
-    end
-
-    it "should not accept Forge modules with a version comparison" do
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '< 1.2.0'), anything).and_call_original
-
-      expect {
-        subject.add_module('puppet/test_module', '< 1.2.0')
-      }.to raise_error(RuntimeError, /module puppet\/test_module.*doesn't have an implementation/i)
-
-      expect(subject.modules.collect(&:name)).not_to include('test_module')
-    end
-
-    it "should accept non-Forge modules with a hash arg" do
-      module_opts = { git: 'git@example.com:puppet/test_module.git' }
-
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, module_opts, anything).and_call_original
-
-      expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
-      expect(subject.modules.collect(&:name)).to include('test_module')
-    end
-
-    it "should accept non-Forge modules with a valid relative :install_path option" do
-      module_opts = {
-        install_path: 'vendor',
-        git: 'git@example.com:puppet/test_module.git',
-      }
-
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', File.join(subject.basedir, 'vendor'), module_opts, anything).and_call_original
-
-      expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
-      expect(subject.modules.collect(&:name)).to include('test_module')
-    end
-
-    it "should accept non-Forge modules with a valid absolute :install_path option" do
-      install_path = File.join(subject.basedir, 'vendor')
-
-      module_opts = {
-        install_path: install_path,
-        git: 'git@example.com:puppet/test_module.git',
-      }
-
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', install_path, module_opts, anything).and_call_original
-
-      expect { subject.add_module('puppet/test_module', module_opts) }.to change { subject.modules }
-      expect(subject.modules.collect(&:name)).to include('test_module')
-    end
-
-    it "should reject non-Forge modules with an invalid relative :install_path option" do
-      module_opts = {
-        install_path: '../../vendor',
-        git: 'git@example.com:puppet/test_module.git',
-      }
-
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', File.join(subject.basedir, 'vendor'), module_opts, anything).and_call_original
-
-      expect { subject.add_module('puppet/test_module', module_opts) }.to raise_error(R10K::Error, /cannot manage content.*is not within/i).and not_change { subject.modules }
-    end
-
-    it "should reject non-Forge modules with an invalid absolute :install_path option" do
-      module_opts = {
-        install_path: '/tmp/mydata/vendor',
-        git: 'git@example.com:puppet/test_module.git',
-      }
-
-      allow(R10K::Module).to receive(:new).with('puppet/test_module', File.join(subject.basedir, 'vendor'), module_opts, anything).and_call_original
-
-      expect { subject.add_module('puppet/test_module', module_opts) }.to raise_error(R10K::Error, /cannot manage content.*is not within/i).and not_change { subject.modules }
-    end
-
-    # it "should disable and not add modules that conflict with the environment" do
-    #   env = instance_double('R10K::Environment::Base')
-    #   mod = instance_double('R10K::Module::Base', name: 'conflict', origin: :puppetfile)
-    #   allow(mod).to receive(:origin=).and_return(nil)
-    #   allow(subject).to receive(:environment).and_return(env)
-    #   allow(env).to receive(:'module_conflicts?').with(mod).and_return(true)
-
-    #   allow(R10K::Module).to receive(:new).with('test', anything, anything, anything).and_return(mod)
-    #   expect { subject.add_module('test', {}) }.not_to change { subject.modules }
-    # end
-  end
-
-  # describe "#purge_exclusions" do
-  #   let(:managed_dirs) { ['dir1', 'dir2'] }
-
-  #   before(:each) do
-  #     allow(subject).to receive(:managed_directories).and_return(managed_dirs)
-  #   end
-
-  #   it "includes managed_directories" do
-  #     expect(subject.purge_exclusions).to match_array(managed_dirs)
-  #   end
-
-  #   context "when belonging to an environment" do
-  #     let(:env_contents) { ['env1', 'env2' ] }
-
-  #     before(:each) do
-  #       mock_env = double(:environment, desired_contents: env_contents)
-  #       allow(subject).to receive(:environment).and_return(mock_env)
-  #     end
-
-  #     it "includes environment's desired_contents" do
-  #       expect(subject.purge_exclusions).to match_array(managed_dirs + env_contents)
-  #     end
-  #   end
-  # end
-
-  # describe '#managed_directories' do
-  #   it 'returns an array of paths that can be purged' do
-  #     allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
-
-  #     subject.add_module('puppet/test_module', '1.2.3')
-  #     expect(subject.managed_directories).to match_array(["/some/nonexistent/basedir/modules"])
-  #   end
-
-  #   context 'with a module with install_path == \'\'' do
-  #     it 'basedir isn\'t in the list of paths to purge' do
-  #       module_opts = { install_path: '', git: 'git@example.com:puppet/test_module.git' }
-
-  #       allow(R10K::Module).to receive(:new).with('puppet/test_module', subject.basedir, module_opts, anything).and_call_original
-
-  #       subject.add_module('puppet/test_module', module_opts)
-  #       expect(subject.managed_directories).to be_empty
-  #     end
-  #   end
-  # end
-
-  describe "evaluating a Puppetfile" do
-    def expect_wrapped_error(orig, pf_path, wrapped_error)
-      expect(orig).to be_a_kind_of(R10K::Error)
-      expect(orig.message).to eq("Failed to evaluate #{pf_path}")
-      expect(orig.original).to be_a_kind_of(wrapped_error)
-    end
-
-    it "wraps and re-raises syntax errors" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'invalid-syntax')
-      pf_path = File.join(path, 'Puppetfile')
-      subject = described_class.new(path, {})
-      expect {
-        subject.load!
-      }.to raise_error do |e|
-        expect_wrapped_error(e, pf_path, SyntaxError)
-      end
-    end
-
-    it "wraps and re-raises load errors" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'load-error')
-      pf_path = File.join(path, 'Puppetfile')
-      subject = described_class.new(path, {})
-      expect {
-        subject.load!
-      }.to raise_error do |e|
-        expect_wrapped_error(e, pf_path, LoadError)
-      end
-    end
-
-    it "wraps and re-raises argument errors" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'argument-error')
-      pf_path = File.join(path, 'Puppetfile')
-      subject = described_class.new(path, {})
-      expect {
-        subject.load!
-      }.to raise_error do |e|
-        expect_wrapped_error(e, pf_path, ArgumentError)
-      end
-    end
-
-    it "rejects Puppetfiles with duplicate module names" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'duplicate-module-error')
-      pf_path = File.join(path, 'Puppetfile')
-      subject = described_class.new(path, {})
-      expect {
-        subject.load!
-      }.to raise_error(R10K::Error, /Puppetfiles cannot contain duplicate module names/i)
-    end
-
-    it "wraps and re-raises name errors" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'name-error')
-      pf_path = File.join(path, 'Puppetfile')
-      subject = described_class.new(path, {})
-      expect {
-        subject.load!
-      }.to raise_error do |e|
-        expect_wrapped_error(e, pf_path, NameError)
-      end
-    end
-
-    it "accepts a forge module with a version" do
+  describe "loading a Puppetfile" do
+    it "returns the loaded content" do
       path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
-      pf_path = File.join(path, 'Puppetfile')
       subject = described_class.new(path, {})
-      expect { subject.load! }.not_to raise_error
+
+      loaded_content = subject.load
+      expect(loaded_content).to be_an_instance_of(Hash)
+
+      has_some_data = loaded_content.values.none?(&:empty?)
+      expect(has_some_data).to be true
     end
 
-    it "accepts a forge module without a version" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-without-version')
-      pf_path = File.join(path, 'Puppetfile')
+    it "is idempotent" do
+      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
       subject = described_class.new(path, {})
-      expect { subject.load! }.not_to raise_error
+
+      expect(subject.loader).to receive(:load!).and_call_original.once
+
+      loaded_content1 = subject.load
+      expect(subject.loaded?).to be true
+      loaded_content2 = subject.load
+
+      expect(loaded_content2).to eq(loaded_content1)
     end
 
-    it "creates a git module and applies the default branch sepcified in the Puppetfile" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'default-branch-override')
-      pf_path = File.join(path, 'Puppetfile')
+    it "returns false if Puppetfile doesn't exist" do
+      path = '/rando/path/that/wont/exist'
       subject = described_class.new(path, {})
-      expect { subject.load! }.not_to raise_error
-      git_module = subject.modules[0]
-      expect(git_module.default_ref).to eq 'here_lies_the_default_branch'
-    end
-
-    it "creates a git module and applies the provided default_branch_override" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'default-branch-override')
-      pf_path = File.join(path, 'Puppetfile')
-      subject = described_class.new(path, {})
-      default_branch_override = 'default_branch_override_name'
-      expect { subject.load!(default_branch_override) }.not_to raise_error
-      git_module = subject.modules[0]
-      expect(git_module.default_override_ref).to eq default_branch_override
-      expect(git_module.default_ref).to eq "here_lies_the_default_branch"
+      expect(subject.load).to eq false
     end
   end
 

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -83,7 +83,7 @@ describe R10K::Puppetfile do
       path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
       subject = described_class.new(path, {})
 
-      expect(subject.loader).to receive(:load!).and_call_original.once
+      expect(subject.loader).to receive(:load).and_call_original.once
 
       loaded_content1 = subject.load
       expect(subject.loaded?).to be true

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -142,16 +142,16 @@ describe R10K::Puppetfile do
       expect { subject.add_module('puppet/test_module', module_opts) }.to raise_error(R10K::Error, /cannot manage content.*is not within/i).and not_change { subject.modules }
     end
 
-    it "should disable and not add modules that conflict with the environment" do
-      env = instance_double('R10K::Environment::Base')
-      mod = instance_double('R10K::Module::Base', name: 'conflict', origin: :puppetfile)
-      allow(mod).to receive(:origin=).and_return(nil)
-      allow(subject).to receive(:environment).and_return(env)
-      allow(env).to receive(:'module_conflicts?').with(mod).and_return(true)
+    # it "should disable and not add modules that conflict with the environment" do
+    #   env = instance_double('R10K::Environment::Base')
+    #   mod = instance_double('R10K::Module::Base', name: 'conflict', origin: :puppetfile)
+    #   allow(mod).to receive(:origin=).and_return(nil)
+    #   allow(subject).to receive(:environment).and_return(env)
+    #   allow(env).to receive(:'module_conflicts?').with(mod).and_return(true)
 
-      allow(R10K::Module).to receive(:new).with('test', anything, anything, anything).and_return(mod)
-      expect { subject.add_module('test', {}) }.not_to change { subject.modules }
-    end
+    #   allow(R10K::Module).to receive(:new).with('test', anything, anything, anything).and_return(mod)
+    #   expect { subject.add_module('test', {}) }.not_to change { subject.modules }
+    # end
   end
 
   describe "#purge_exclusions" do


### PR DESCRIPTION
This series of commits moves the logic for loading the module content from a Puppetfile and into a new concept called a ModuleLoader. The idea being to standardize the interface for loading modules, since there are multiple ways to load module specifications (eg, puppetfile, exec, yamldir).

This approach would allow Environments to no longer care _how_ modules were loaded but simply call `load` on any ModuleLoaders they are configured to use. The environment would then have a canonical list of all its environments (instead of deferring to the Puppetfile class when available) and be able to pass all of them to ContentSynchronizer at once (currently only Puppetfile content can be concurrent synced). As well as a list of managed directories, desired content, and purge exclusions for usage with the Cleaner util.

Refactoring the environment to use Module Loaders is a somewhat larger refactor and may break internal APIs. This changeset only refactors the Puppetfile to use the ModuleLoader under the hood. This should be a backwards compatible refactor save that `load` now returns the hash of loaded content information rather than `true` (we only check for it's truthiness - not a hard type check, so it remains backwards compatible for our uses). 


Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
