### PR TITLE
(maint) Simplify forge module implementation identification

### DIFF
--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -96,7 +96,7 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   def load_modules(module_hash)
     module_hash.each do |name, args|
       if !args.is_a?(Hash)
-        args = { version: args }
+        args = { type: 'forge', version: args }
       end
 
       add_module(name, args)

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -13,16 +13,7 @@ class R10K::Module::Forge < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    args[:type].to_s == 'forge' ||
-      (!!
-       ((args.keys & %i{git svn type}).empty? &&
-        args.has_key?(:version) &&
-        name.match(%r[\w+[/-]\w+]) &&
-        valid_version?(args[:version])))
-  end
-
-  def self.valid_version?(expected_version)
-    expected_version == :latest || expected_version.nil? || PuppetForge::Util.version_valid?(expected_version)
+    args[:type].to_s == 'forge'
   end
 
   def self.statically_defined_version(name, args)
@@ -54,9 +45,18 @@ class R10K::Module::Forge < R10K::Module::Base
       :type    => ::R10K::Util::Setopts::Ignore,
     }, :raise_on_unhandled => false)
 
+    # Validate version and raise on issue. Title is validated by base class.
+    unless valid_version?(@expected_version)
+      raise ArgumentError, _("Module version %{ver} is not a valid Forge module version") % {ver: @expected_version}
+    end
+
     @expected_version ||= current_version || :latest
 
     @v3_module = PuppetForge::V3::Module.new(:slug => @title)
+  end
+
+  def valid_version?(version)
+    version == :latest || version.nil? || PuppetForge::Util.version_valid?(version)
   end
 
   # @param [Hash] opts Deprecated

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -9,8 +9,6 @@ class R10K::Module::Git < R10K::Module::Base
 
   def self.implement?(name, args)
     args.has_key?(:git) || args[:type].to_s == 'git'
-  rescue
-    false
   end
 
   # Will be called if self.implement? above returns true. Will return

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -8,7 +8,7 @@ class R10K::Module::Local < R10K::Module::Base
   R10K::Module.register(self)
 
   def self.implement?(name, args)
-    args.is_a?(Hash) && (args[:local] || args[:type].to_s == 'local')
+    args[:local] || args[:type].to_s == 'local'
   end
 
   def self.statically_defined_version(*)

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -187,8 +187,10 @@ module R10K
       end
 
       def parse_module_definition(name, info)
+        # The only valid (deprecated) way a module can be defined with a
+        # non-hash info is if it is a Forge module.
         if !info.is_a?(Hash)
-          info = { version: info }
+          info = { type: 'forge', version: info }
         end
 
         info[:overrides] = @overrides

--- a/lib/r10k/module_loader/puppetfile/dsl.rb
+++ b/lib/r10k/module_loader/puppetfile/dsl.rb
@@ -15,7 +15,7 @@ module R10K
           if args.is_a?(Hash)
             opts = args
           else
-            opts = { version: args }
+            opts = { type: 'forge', version: args }
           end
 
           if @metadata_only

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -33,21 +33,17 @@ describe R10K::Module::Forge do
 
   describe "implementing the Puppetfile spec" do
     it "should implement 'branan/eight_hundred', '8.0.0'" do
-      expect(described_class).to be_implement('branan/eight_hundred', { version: '8.0.0' })
+      expect(described_class).to be_implement('branan/eight_hundred', { type: 'forge', version: '8.0.0' })
     end
 
     it "should implement 'branan-eight_hundred', '8.0.0'" do
-      expect(described_class).to be_implement('branan-eight_hundred', { version: '8.0.0' })
-    end
-
-    it "should fail with an invalid title" do
-      expect(described_class).to_not be_implement('branan!eight_hundred', { version: '8.0.0' })
+      expect(described_class).to be_implement('branan-eight_hundred', { type: 'forge', version: '8.0.0' })
     end
   end
 
   describe "implementing the standard options interface" do
     it "should implement {type: forge}" do
-      expect(described_class).to be_implement('branan-eight_hundred', {type: 'forge', version: '8.0.0', source: 'not implemented'})
+      expect(described_class).to be_implement('branan-eight_hundred', { type: 'forge', version: '8.0.0', source: 'not implemented' })
     end
   end
 
@@ -68,6 +64,12 @@ describe R10K::Module::Forge do
 
     it "sets the title" do
       expect(subject.title).to eq 'branan-eight_hundred'
+    end
+  end
+
+  describe "invalid attributes" do
+    it "errors on invalid versions" do
+      expect { described_class.new('branan/eight_hundred', '/moduledir', { version: '_8.0.0_' }) }.to raise_error ArgumentError, /version/
     end
   end
 

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -94,7 +94,7 @@ describe R10K::ModuleLoader::Puppetfile do
 
       expect {
         subject.add_module('puppet/test_module', '< 1.2.0')
-      }.to raise_error(RuntimeError, /module puppet\/test_module.*doesn't have an implementation/i)
+      }.to raise_error(ArgumentError, /module version .* is not a valid forge module version/i)
 
       expect(subject.modules.collect(&:name)).not_to include('test_module')
     end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -31,12 +31,11 @@ describe R10K::Module do
       'bar-quux',
     ].each do |scenario|
       it "accepts a name matching #{scenario} and version nil" do
-        obj = R10K::Module.new(scenario, '/modulepath', { version: nil })
+        obj = R10K::Module.new(scenario, '/modulepath', { type: 'forge', version: nil })
         expect(obj).to be_a_kind_of(R10K::Module::Forge)
       end
     end
-    [ {version: '8.0.0'},
-      {type: 'forge', version: '8.0.0'},
+    [ {type: 'forge', version: '8.0.0'},
     ].each do |scenario|
       it "accepts a name matching bar-quux and args #{scenario.inspect}" do
         obj = R10K::Module.new('bar-quux', '/modulepath', scenario)
@@ -65,7 +64,7 @@ describe R10K::Module do
       end
 
       it 'sets the expected version to what is found in the metadata' do
-        obj = R10K::Module.new(@title, @dirname, {version: nil})
+        obj = R10K::Module.new(@title, @dirname, {type: 'forge', version: nil})
         expect(obj.send(:instance_variable_get, :'@expected_version')).to eq('1.2.0')
       end
     end
@@ -82,7 +81,6 @@ describe R10K::Module do
       ['name', {type: 'git', source: 'git url'}],
       ['name', {svn: 'svn url'}],
       ['name', {type: 'svn', source: 'svn url'}],
-      ['namespace-name', {version: '8.0.0'}],
       ['namespace-name', {type: 'forge', version: '8.0.0'}]
     ].each do |(name, options)|
       it 'can handle the default_branch_override option' do


### PR DESCRIPTION
Anywhere except the Puppetfile, a module input must specify {type: forge} to indicate a Forge module. In the Puppetfile, we convert a scalar version arg to a hash already, before passing it to R10K::Module.new(). So, let's simplify the implementation selection logic.

In the Puppetfile, specify both version: and type: for scalar module args, which by convention we know to be Forge modules.

End result: internally, modules args should ALWAYS be of type Hash. Puppetfile module specifications, which permit a String form of args, now convert found string args to hashes on intake.