### PR TITLE
(CODEMGMT-1448) Update git before purging deployment environments

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -2,6 +2,8 @@ CHANGELOG
 =========
 
 Unreleased
+
+- Added an interface to R10K::Source::Base named `reload!` for updating the environments list for a given deployment; `reload!` is called before deployment purges to make r10k deploy pools more threadsafe. [#1172](https://github.com/puppetlabs/r10k/pull/1172)
 ----------
 
 3.9.2

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -116,6 +116,9 @@ module R10K
 
           if @settings.dig(:overrides, :purging, :purge_levels).include?(:deployment)
             logger.debug("Purging unmanaged environments for deployment...")
+            deployment.sources.each do |source|
+              source.reload!
+            end
             deployment.purge!
           end
         ensure

--- a/lib/r10k/source/base.rb
+++ b/lib/r10k/source/base.rb
@@ -63,6 +63,16 @@ class R10K::Source::Base
 
   end
 
+  # Perform actions to reload environments after the `preload!`. Similar
+  # to preload!, and likely to include network queries and rerunning
+  # environment generation.
+  #
+  # @api public
+  # @abstract
+  # @return [void]
+  def reload!
+  end
+
   # Enumerate the environments associated with this SVN source.
   #
   # @api public

--- a/lib/r10k/source/git.rb
+++ b/lib/r10k/source/git.rb
@@ -93,6 +93,11 @@ class R10K::Source::Git < R10K::Source::Base
     end
   end
 
+  def reload!
+    @cache.sync!
+    @environments = generate_environments()
+  end
+
   def generate_environments
     envs = []
     branch_names.each do |bn|

--- a/lib/r10k/source/svn.rb
+++ b/lib/r10k/source/svn.rb
@@ -65,6 +65,10 @@ class R10K::Source::SVN < R10K::Source::Base
     @ignore_branch_prefixes = options[:ignore_branch_prefixes]
   end
 
+  def reload!
+    @environments = generate_environments()
+  end
+
   # Enumerate the environments associated with this SVN source.
   #
   # @return [Array<R10K::Environment::SVN>] An array of environments created

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -265,6 +265,15 @@ describe R10K::Action::Deploy::Environment do
       describe "deployment purge level" do
         let(:purge_levels) { [:deployment] }
 
+
+        it "updates the source's cache before it purges environments" do
+          deployment.sources.each do |source|
+            expect(source).to receive(:reload!).ordered
+          end
+          expect(deployment).to receive(:purge!).ordered
+          subject.call
+        end
+
         it "only logs about purging deployment" do
           expect(subject).to receive(:visit_environment).and_wrap_original do |original, env, &block|
             expect(env.logger).to_not receive(:debug).with(/purging unmanaged puppetfile content/i)


### PR DESCRIPTION
When using deploy pools of r10k, new branches can be created during
deployment that won't be in the current cache; during a deployment
purge, this would end up deleting an in-process, simultaneous
deployment of another branch. This change syncs the git repo just
before purge to minimize any chance of deleting separate and
simultaneous r10k deployments.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
