### PR TITLE
(#1173) Allow default_branch_override argument for all module types

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,13 @@ CHANGELOG
 Unreleased
 ----------
 
+3.9.3
+-----
+
+- Fixes a regression when using `--default_branch_override` with Puppetfiles containing Forge modules. [#1173](https://github.com/puppetlabs/r10k/issues/1173)
+
 3.9.2
+-----
 
 - Makes the third parameter to R10K::Actions optional, restoring backwards compatability broken in 3.9.1.
 

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -50,7 +50,7 @@ class R10K::Module::Forge < R10K::Module::Base
       :version => :expected_version,
       :source  => ::R10K::Util::Setopts::Ignore,
       :type    => ::R10K::Util::Setopts::Ignore,
-    })
+    }, :raise_on_unhandled => false)
 
     @expected_version ||= current_version || :latest
 

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -52,7 +52,7 @@ class R10K::Module::Git < R10K::Module::Base
       :git                     => :remote,
       :default_branch          => :default_ref,
       :default_branch_override => :default_override_ref,
-    })
+    }, :raise_on_unhandled => false)
 
     force = @overrides.dig(:modules, :force)
     @force = force == false ? false : true

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -50,7 +50,7 @@ class R10K::Module::SVN < R10K::Module::Base
       :revision => :expected_revision,
       :username => :self,
       :password => :self
-    })
+    }, :raise_on_unhandled => false)
 
     @working_dir = R10K::SVN::WorkingDir.new(@path, :username => @username, :password => @password)
   end

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '3.9.2'
+  VERSION = '3.9.3'
 end

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -119,14 +119,6 @@ describe R10K::Module::Git do
       allow(mock_repo).to receive(:head).and_return('abc123')
     end
 
-    context "when option is unrecognized" do
-      let(:opts) { { unrecognized: true } }
-
-      it "raises an error" do
-        expect { test_module(opts) }.to raise_error(ArgumentError, /cannot handle option 'unrecognized'/)
-      end
-    end
-
     describe "desired ref" do
       context "when no desired ref is given" do
         it "defaults to master" do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -76,4 +76,21 @@ describe R10K::Module do
       R10K::Module.new('bar!quux', '/modulepath', {version: ["NOPE NOPE NOPE NOPE!"]})
     }.to raise_error RuntimeError, /doesn't have an implementation/
   end
+
+  describe 'when a user passes a `default_branch_override`' do
+    [ ['name', {git: 'git url'}],
+      ['name', {type: 'git', source: 'git url'}],
+      ['name', {svn: 'svn url'}],
+      ['name', {type: 'svn', source: 'svn url'}],
+      ['namespace-name', {version: '8.0.0'}],
+      ['namespace-name', {type: 'forge', version: '8.0.0'}]
+    ].each do |(name, options)|
+      it 'can handle the default_branch_override option' do
+        expect {
+          obj = R10K::Module.new(name, '/modulepath', options.merge({default_branch_override: 'foo'}))
+          expect(obj).to be_a_kind_of(R10K::Module::Base)
+        }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
In 1ff9995, we moved the setting of the `default_branch_override` from
all module declarations that were Hashes (ie, not Puppetfile declared
Forge modules) to all modules. This broke Forge modules for users who
pass the `default_branch_override` flag.

It should be noted that code-wise, users who set the
`default_branch_override` flag when deploying YAML based environments
(which always use Hash based module declarations) or had SVN modules in
their Puppetfile (also Hash based) would have failed. However, those
scenarios are either not supported (in the case of YAML based envs) or
essentially unused (in the case of SVN).

Other options to fix this regretion include:
  * Have the caller of Module.new first determine if the module will be
  a Git module and then conditionally add the option, or
  * Have the caller of Module.new set the default_branch_override after
  creating the module, if the module responds to the setter

Both of these options involve the caller having to introspect enough
about the type of module being created that it destroys what value we
get from the Module.new facade. Consequently, this patch takes the
approach to loosen Module argument strictness, allowing potentially
unused options to passed to any module.