### PR TITLE
(RK-135) Improve error message when no published mod versions exist

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,7 @@ CHANGELOG
 
 Unreleased
 
+- Attempting to download the latest version for a module that has no Forge releases will now issue a meaningful error.
 - Added an interface to R10K::Source::Base named `reload!` for updating the environments list for a given deployment; `reload!` is called before deployment purges to make r10k deploy pools more threadsafe. [#1172](https://github.com/puppetlabs/r10k/pull/1172)
 ----------
 

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_specify_deleted_forge_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_specify_deleted_forge_module.rb
@@ -10,7 +10,7 @@ last_commit = git_last_commit(master, git_environments_path)
 r10k_fqp = get_r10k_fqp(master)
 
 #Verification
-error_notification_regex = /Does 'puppetlabs-regret' have at least one published release?/
+error_notification_regex = /The module puppetlabs-regret does not appear to have any published releases/
 
 #File
 puppet_file = <<-PUPPETFILE
@@ -40,12 +40,6 @@ git_add_commit_push(master, 'production', 'Add module.', git_environments_path)
 
 #Tests
 step "Deploy production environment via r10k with specified module deleted"
-on(master, "#{r10k_fqp} deploy environment -p -v", :acceptable_exit_codes => 1) do |result|
-  if get_puppet_version(master) < 4.0
-    assert_match(error_notification_regex, result.stderr, 'Unexpected error was detected!')
-  else
-    expect_failure('expected to fail due to RK-135') do
-      assert_match(error_notification_regex, result.stderr, 'Unexpected error was detected!')
-    end
-  end
+on(master, "#{r10k_fqp} deploy environment -p -v --trace", :acceptable_exit_codes => 1) do |result|
+  assert_match(error_notification_regex, result.stderr, 'Unexpected error was detected!')
 end

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -83,7 +83,11 @@ class R10K::Module::Forge < R10K::Module::Base
   def expected_version
     if @expected_version == :latest
       begin
-        @expected_version = @v3_module.current_release.version
+        if @v3_module.current_release
+          @expected_version = @v3_module.current_release.version
+        else
+          raise PuppetForge::ReleaseNotFound, _("The module %{title} does not appear to have any published releases, cannot determine latest version.") % { title: @title }
+        end
       rescue Faraday::ResourceNotFound => e
         raise PuppetForge::ReleaseNotFound, _("The module %{title} does not exist on %{url}.") % {title: @title, url: PuppetForge::V3::Release.conn.url_prefix}, e.backtrace
       end

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -104,8 +104,15 @@ describe R10K::Module::Forge do
 
     it "uses the latest version from the forge when the version is :latest" do
       subject = described_class.new('branan/eight_hundred', fixture_modulepath, { version: :latest })
-      expect(subject.v3_module).to receive_message_chain(:current_release, :version).and_return('8.8.8')
+      release = double("Module Release", version: '8.8.8')
+      expect(subject.v3_module).to receive(:current_release).and_return(release).twice
       expect(subject.expected_version).to eq '8.8.8'
+    end
+
+    it "throws when there are no available versions" do
+      subject = described_class.new('branan/eight_hundred', fixture_modulepath, { version: :latest })
+      expect(subject.v3_module).to receive(:current_release).and_return(nil)
+      expect { subject.expected_version }.to raise_error(PuppetForge::ReleaseNotFound)
     end
   end
 


### PR DESCRIPTION
This previously would throw an undefined method error when
`current_release` was nil. Now, we check for that case and raise
something that will be meaningful to the user.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
