### PR TITLE
Add support for Github App auth token

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -7,7 +7,7 @@ Unreleased
 - Always sync git cache on `ref: 'HEAD'` [#1182](https://github.com/puppetlabs/r10k/pull/1182)
 - (CODEMGMT-1421) Add skeleton for deploy_spec option [#1189](https://github.com/puppetlabs/r10k/pull/1189)
 - (RK-369) Make module deploys run the postrun command if any environments were updated. [#982](https://github.com/puppetlabs/r10k/issues/982)
-- Add support for Github App auth token. This allows r10k to authenticate under strict SSO/2FA guidelines that cannot utilize machine users for puppetserver deployment. [#1180](https://github.com/puppetlabs/r10k/pull/1180)
+- Add support for Github App auth token. This allows r10k to authenticate under strict SSO/2FA guidelines that cannot utilize machine users for code deployment. [#1180](https://github.com/puppetlabs/r10k/pull/1180)
 
 3.10.0
 ------

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -7,6 +7,7 @@ Unreleased
 - Always sync git cache on `ref: 'HEAD'` [#1182](https://github.com/puppetlabs/r10k/pull/1182)
 - (CODEMGMT-1421) Add skeleton for deploy_spec option [#1189](https://github.com/puppetlabs/r10k/pull/1189)
 - (RK-369) Make module deploys run the postrun command if any environments were updated. [#982](https://github.com/puppetlabs/r10k/issues/982)
+- Add support for Github App auth token. This allows r10k to authenticate under strict SSO/2FA guidelines that cannot utilize machine users for puppetserver deployment. [#1180](https://github.com/puppetlabs/r10k/pull/1180)
 
 3.10.0
 ------

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -243,7 +243,10 @@ module R10K
                       'puppet-conf': :self,
                       'private-key': :self,
                       'oauth-token': :self,
-                      'default-branch-override': :self)
+                      'default-branch-override': :self,
+                      'github-app-id': :self,
+                      'github-app-key': :self,
+                      'github-app-ttl': :self)
         end
       end
     end

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -122,7 +122,10 @@ module R10K
                       'puppet-path': :self,
                       'puppet-conf': :self,
                       'private-key': :self,
-                      'oauth-token': :self)
+                      'oauth-token': :self,
+                      'github-app-id': :self,
+                      'github-app-key': :self,
+                      'github-app-ttl': :self)
         end
       end
     end

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -121,7 +121,7 @@ module R10K
         end
 
         if token_path && (app_private_key_path || app_id)
-          raise R10K::Error, "Cannot specify both an SSH key and an SSL key or Github App id to use with this deploy."
+          raise R10K::Error, "Cannot specify both an OAuth token and an SSL key or Github App id to use with this deploy."
         end
 
         if app_id && ! app_private_key_path || app_private_key_path && ! app_id

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -116,8 +116,12 @@ module R10K
           raise R10K::Error, "Cannot specify both an SSH key and a token to use with this deploy."
         end
 
-        if sshkey_path && app_private_key_path || app_private_key_path && token_path || app_id && token_path || app_id && sshkey_path
-          raise R10K::Error, "Cannot specify both an SSH key and an SSL key or token to use with this deploy."
+        if sshkey_path && (app_private_key_path || app_id)
+          raise R10K::Error, "Cannot specify both an SSH key and an SSL key or Github App id to use with this deploy."
+        end
+
+        if token_path && (app_private_key_path || app_id)
+          raise R10K::Error, "Cannot specify both an SSH key and an SSL key or Github App id to use with this deploy."
         end
 
         if app_id && ! app_private_key_path || app_private_key_path && ! app_id

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -108,9 +108,24 @@ module R10K
       def add_credential_overrides(overrides)
         sshkey_path = @opts[:'private-key']
         token_path = @opts[:'oauth-token']
+        app_id = @opts[:'github-app-id']
+        app_private_key_path = @opts[:'github-app-key']
+        app_ttl = @opts[:'github-app-ttl']
 
         if sshkey_path && token_path
           raise R10K::Error, "Cannot specify both an SSH key and a token to use with this deploy."
+        end
+
+        if sshkey_path && app_private_key_path
+          raise R10K::Error, "Cannot specify both a SSH key and a SSL key to use with this deploy."
+        end
+
+        if app_id && token_path
+          raise R10K::Error, "Cannot specify both a Github App and a token to use with this deploy."
+        end
+
+        if app_id && ! app_private_key_path or app_private_key_path && ! app_id
+          raise R10K::Error, "Both id and private key are required with Github App to use with this deploy."
         end
 
         if sshkey_path
@@ -127,6 +142,18 @@ module R10K
           if repo_settings = overrides[:git][:repositories]
             repo_settings.each do |repo|
               repo[:oauth_token] = token_path
+            end
+          end
+        elsif app_id
+          overrides[:git] ||= {}
+          overrides[:git][:github_app_id] = app_id
+          overrides[:git][:github_app_key] = app_private_key_path
+          overrides[:git][:github_app_ttl] = app_ttl
+          if repo_settings = overrides[:git][:repositories]
+            repo_settings.each do |repo|
+              repo[:github_app_id] = app_id
+              repo[:github_app_key] = app_private_key_path
+              repo[:github_app_ttl] = app_ttl
             end
           end
         end

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -116,16 +116,12 @@ module R10K
           raise R10K::Error, "Cannot specify both an SSH key and a token to use with this deploy."
         end
 
-        if sshkey_path && app_private_key_path
-          raise R10K::Error, "Cannot specify both a SSH key and a SSL key to use with this deploy."
+        if sshkey_path && app_private_key_path || app_private_key_path && token_path || app_id && token_path || app_id && sshkey_path
+          raise R10K::Error, "Cannot specify both an SSH key and an SSL key or token to use with this deploy."
         end
 
-        if app_id && token_path
-          raise R10K::Error, "Cannot specify both a Github App and a token to use with this deploy."
-        end
-
-        if app_id && ! app_private_key_path or app_private_key_path && ! app_id
-          raise R10K::Error, "Both id and private key are required with Github App to use with this deploy."
+        if app_id && ! app_private_key_path || app_private_key_path && ! app_id
+          raise R10K::Error, "Must specify both id and SSL private key to use Github App for this deploy."
         end
 
         if sshkey_path

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -35,6 +35,9 @@ module R10K::CLI
         option nil, :'puppet-conf', 'Path to puppet.conf', argument: :required
         option nil, :'private-key', 'Path to SSH key to use when cloning. Only valid with rugged provider', argument: :required
         option nil, :'oauth-token', 'Path to OAuth token to use when cloning. Only valid with rugged provider', argument: :required
+        option nil, :'github-app-id', 'Github App id. Only valid with rugged provider', argument: :required
+        option nil, :'github-app-key', 'Github App private key. Only valid with rugged provider', argument: :required
+        option nil, :'github-app-ttl', 'Github App token expiration, in seconds. Only valid with rugged provider', default: "120", argument: :optional
 
         run do |opts, args, cmd|
           puts cmd.help(:verbose => opts[:verbose])

--- a/lib/r10k/git.rb
+++ b/lib/r10k/git.rb
@@ -135,6 +135,9 @@ module R10K
 
     def_setting_attr :private_key
     def_setting_attr :oauth_token
+    def_setting_attr :github_app_id
+    def_setting_attr :github_app_key
+    def_setting_attr :github_app_ttl
     def_setting_attr :proxy
     def_setting_attr :username
     def_setting_attr :repositories, {}

--- a/lib/r10k/git/rugged/credentials.rb
+++ b/lib/r10k/git/rugged/credentials.rb
@@ -1,6 +1,10 @@
 require 'r10k/git/rugged'
 require 'r10k/git/errors'
 require 'r10k/logging'
+require 'json'
+require 'jwt'
+require 'net/http'
+require 'openssl'
 
 # Generate credentials for secured remote connections.
 #
@@ -62,15 +66,29 @@ class R10K::Git::Rugged::Credentials
 
   def get_plaintext_credentials(url, username_from_url)
     per_repo_oauth_token = nil
+    per_repo_github_app_id = nil
+    per_repo_github_app_key = nil
+    per_repo_github_app_ttl = nil
+
     if per_repo_settings = R10K::Git.get_repo_settings(url)
       per_repo_oauth_token = per_repo_settings[:oauth_token]
+      per_repo_github_app_id = per_repo_settings[:github_app_id]
+      per_repo_github_app_key = per_repo_settings[:github_app_key]
+      per_repo_github_app_ttl = per_repo_settings[:github_app_ttl]
     end
+
+    app_id = per_repo_github_app_id || R10K::Git.settings[:github_app_id]
+    app_key = per_repo_github_app_key || R10K::Git.settings[:github_app_key]
+    app_ttl = per_repo_github_app_ttl || R10K::Git.settings[:github_app_ttl]
 
     if token_path = per_repo_oauth_token || R10K::Git.settings[:oauth_token]
       @oauth_token ||= extract_token(token_path, url)
 
       user = 'x-oauth-token'
       password = @oauth_token
+    elsif app_id && app_key && app_ttl
+      user = 'x-access-token'
+      password = github_app_token(app_id, app_key, app_ttl)
     else
       user = get_git_username(url, username_from_url)
       password = URI.parse(url).password || ''
@@ -124,5 +142,50 @@ class R10K::Git::Rugged::Credentials
     end
 
     user
+  end
+
+  def github_app_token(app_id, private_key, ttl)
+    raise R10K::Git::GitError, _('App id contains invalid characters.') unless app_id =~ /^\d+$/
+    raise R10K::Git::GitError, _('Token ttl contains invalid characters.') unless ttl =~ /^\d+$/
+    raise R10K::Git::GitError, _('App key is missing or unreadable') unless File.readable?(private_key)
+
+    begin
+      ssl_key = OpenSSL::PKey::RSA.new(File.read(private_key).strip)
+      ssl_key.private?
+    rescue OpenSSL::PKey::RSAError
+      raise R10K::Git::GitError, _('App key is not a valid SSL private key')
+    end
+
+    logger.debug2 _("Using Github App token from %{token_path} and id %{app_id}") % { token_path: private_key, app_id: app_id }
+
+    payload = { iat: Time.now.to_i, exp: Time.now.to_i + ttl.to_i, iss: app_id }
+    jwt = JWT.encode(payload, ssl_key, "RS256")
+
+    get = URI.parse("https://api.github.com/app/installations")
+    get_request = Net::HTTP::Get.new(get)
+    get_request["Authorization"] = "Bearer #{jwt}"
+    get_request["Accept"] = "application/vnd.github.v3+json"
+    get_req_options = { use_ssl: get.scheme == "https", }
+    get_response = Net::HTTP.start(get.hostname, get.port, get_req_options) do |http|
+      http.request(get_request)
+    end
+
+    access_tokens_url = JSON.parse(get_response.body)[0]['access_tokens_url']
+
+    post = URI.parse(access_tokens_url)
+    post_request = Net::HTTP::Post.new(post)
+    post_request["Authorization"] = "Bearer #{jwt}"
+    post_request["Accept"] = "application/vnd.github.v3+json"
+    post_req_options = { use_ssl: post.scheme == "https", }
+    post_response = Net::HTTP.start(post.hostname, post.port, post_req_options) do |http|
+      http.request(post_request)
+    end
+
+    token = JSON.parse(post_response.body)['token']
+
+    raise R10K::Git::GitError, _("Supplied OAuth token contains invalid characters.") unless valid_token?(token)
+
+    logger.debug2 _("token generated, expires at: %{expire}") % {expire: JSON.parse(post_response.body)['expires_at']}
+    token
   end
 end

--- a/lib/r10k/git/rugged/credentials.rb
+++ b/lib/r10k/git/rugged/credentials.rb
@@ -176,7 +176,7 @@ class R10K::Git::Rugged::Credentials
 
     unless (get_response.class < Net::HTTPSuccess)
       logger.debug2 _("Unexpected response code: #{get_response.code}\nResponse body: #{get_response.body}")
-      raise R10K::Git::GitError, _("Error using private key to generate access token #{access_token_url}")
+      raise R10K::Git::GitError, _("Error using private key to get Github App access token from url")
     end
 
     access_tokens_url = JSON.parse(get_response.body)[0]['access_tokens_url']
@@ -192,7 +192,7 @@ class R10K::Git::Rugged::Credentials
 
     unless (post_response.class < Net::HTTPSuccess)
       logger.debug2 _("Unexpected response code: #{post_response.code}\nResponse body: #{post_response.body}")
-      raise R10K::Git::GitError, _("Error using private key to generate access token #{access_token_url}")
+      raise R10K::Git::GitError, _("Error using private key to generate access token from #{access_token_url}")
     end
 
     token = JSON.parse(post_response.body)['token']

--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -56,6 +56,9 @@ module R10K
         with_setting(:proxy) { |value| R10K::Git.settings[:proxy] = value }
         with_setting(:repositories) { |value| R10K::Git.settings[:repositories] = value }
         with_setting(:oauth_token) { |value| R10K::Git.settings[:oauth_token] = value }
+        with_setting(:github_app_id) { |value| R10K::Git.settings[:github_app_id] = value }
+        with_setting(:github_app_key) { |value| R10K::Git.settings[:github_app_key] = value }
+        with_setting(:github_app_ttl) { |value| R10K::Git.settings[:github_app_ttl] = value }
       end
     end
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -42,6 +42,22 @@ module R10K
                     Only used by the 'rugged' Git provider."
         }),
 
+        Definition.new(:github_app_id, {
+          :desc => "The Github App id for Git SSL remotes.
+                    Only used by the 'rugged' Git provider."
+        }),
+
+        Definition.new(:github_app_key, {
+          :desc => "The Github App private key for Git SSL remotes.
+                    Only used by the 'rugged' Git provider."
+        }),
+
+        Definition.new(:github_app_ttl, {
+          :desc => "The ttl expiration for SSL tokens.
+                    Only used by the 'rugged' Git provider.",
+          :default => "120",
+        }),
+
         URIDefinition.new(:proxy, {
           :desc => "An optional proxy server to use when interacting with Git sources via HTTP(S).",
           :default => :inherit,
@@ -61,6 +77,24 @@ module R10K
 
             Definition.new(:oauth_token, {
               :desc => "The path to a token file for Git OAuth remotes.
+                        Only used by the 'rugged' Git provider.",
+              :default => :inherit
+            }),
+
+            Definition.new(:github_app_id, {
+              :desc => "The Github App id for Git SSL remotes.
+                        Only used by the 'rugged' Git provider.",
+              :default => :inherit
+            }),
+
+            Definition.new(:github_app_key, {
+              :desc => "The Github App private key for Git SSL remotes.
+                        Only used by the 'rugged' Git provider.",
+              :default => :inherit
+            }),
+
+            Definition.new(:github_app_ttl, {
+              :desc => "The ttl expiration for Git SSL tokens.
                         Only used by the 'rugged' Git provider.",
               :default => :inherit
             }),

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'fast_gettext', '~> 1.1.0'
   s.add_dependency 'gettext', ['>= 3.0.2', '< 3.3.0']
 
+  s.add_dependency 'jwt', '~> 2.2.3'
+
   s.add_development_dependency 'rspec', '~> 3.1'
 
   s.add_development_dependency 'rake'

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -47,6 +47,18 @@ describe R10K::Action::Deploy::Environment do
       described_class.new({ 'oauth-token': '/nonexistent' }, [], {})
     end
 
+    it 'can accept an app id option' do
+      described_class.new({ 'github-app-id': '/nonexistent' }, [], {})
+    end
+
+    it 'can accept a ttl option' do
+      described_class.new({ 'github-app-ttl': '/nonexistent' }, [], {})
+    end
+
+    it 'can accept a ssl private key option' do
+      described_class.new({ 'github-app-key': '/nonexistent' }, [], {})
+    end
+
     describe "initializing errors" do
       let (:settings) { { deploy: { purge_levels: [:environment],
                                     purge_whitelist: ['coolfile', 'coolfile2'],

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -41,6 +41,18 @@ describe R10K::Action::Deploy::Module do
     it 'can accept a token option' do
       described_class.new({ 'oauth-token': '/nonexistent' }, [], {})
     end
+
+    it 'can accept an app id option' do
+      described_class.new({ 'github-app-id': '/nonexistent' }, [], {})
+    end
+
+    it 'can accept a ttl option' do
+      described_class.new({ 'github-app-ttl': '/nonexistent' }, [], {})
+    end
+
+    it 'can accept a ssl private key option' do
+      described_class.new({ 'github-app-key': '/nonexistent' }, [], {})
+    end
   end
 
   describe "with no-force" do
@@ -174,6 +186,33 @@ describe R10K::Action::Deploy::Module do
 
     it 'sets token_path' do
       expect(subject.instance_variable_get(:@oauth_token)).to eq('/nonexistent')
+    end
+  end
+
+  describe 'with github-app-id' do
+
+    subject { described_class.new({ config: '/some/nonexistent/path', 'github-app-id': '/nonexistent' }, [], {}) }
+
+    it 'sets github-app-id' do
+      expect(subject.instance_variable_get(:@github_app_id)).to eq('/nonexistent')
+    end
+  end
+
+  describe 'with github-app-key' do
+
+    subject { described_class.new({ config: '/some/nonexistent/path', 'github-app-key': '/nonexistent' }, [], {}) }
+
+    it 'sets github-app-key' do
+      expect(subject.instance_variable_get(:@github_app_key)).to eq('/nonexistent')
+    end
+  end
+
+  describe 'with github-app-ttl' do
+
+    subject { described_class.new({ config: '/some/nonexistent/path', 'github-app-ttl': '/nonexistent' }, [], {}) }
+
+    it 'sets github-app-ttl' do
+      expect(subject.instance_variable_get(:@github_app_ttl)).to eq('/nonexistent')
     end
   end
 

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -165,7 +165,7 @@ describe R10K::Action::Runner do
       runner.call
     end
 
-    it "does not modify the loglevel if :logle1vel is not provided" do
+    it "does not modify the loglevel if :loglevel is not provided" do
       expect(R10K::Logging).to_not receive(:level=)
       runner.call
     end

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -178,7 +178,7 @@ describe R10K::Action::Runner do
         %w[args yes],
         action_class
       )
-      expect{ runner.call }.to raise_error(R10K::Error, /Both id and private key are required/)
+      expect{ runner.call }.to raise_error(R10K::Error, /Must specify both id and SSL private key/)
     end
 
     it 'errors if ssl key is passed without app id' do
@@ -187,21 +187,39 @@ describe R10K::Action::Runner do
         %w[args yes],
         action_class
       )
-      expect{ runner.call }.to raise_error(R10K::Error, /Both id and private key are required/)
+      expect{ runner.call }.to raise_error(R10K::Error, /Must specify both id and SSL private key/)
     end
 
-    it 'errors if both token and app id paths are passed' do
+    it 'errors if both app id and token paths are passed' do
       runner = described_class.new(
         { 'github-app-id': '/nonexistent', 'oauth-token': '/also/fake' },
         %w[args yes],
         action_class
       )
-      expect{ runner.call }.to raise_error(R10K::Error, /both a Github App and a token/)
+      expect{ runner.call }.to raise_error(R10K::Error, /Cannot specify both/)
     end
 
-    it 'errors if both token and ssh key paths are passed' do
+    it 'errors if both ssl key and token paths are passed' do
+      runner = described_class.new(
+        { 'github-app-key': '/nonexistent', 'oauth-token': '/also/fake' },
+        %w[args yes],
+        action_class
+      )
+      expect{ runner.call }.to raise_error(R10K::Error, /Cannot specify both/)
+    end
+
+    it 'errors if both ssl key and ssh key paths are passed' do
       runner = described_class.new(
         { 'github-app-key': '/nonexistent', 'private-key': '/also/fake' },
+        %w[args yes],
+        action_class
+      )
+      expect{ runner.call }.to raise_error(R10K::Error, /Cannot specify both/)
+    end
+
+    it 'errors if both app id and ssh key are passed' do
+      runner = described_class.new(
+        { 'github-app-id': '/nonexistent', 'private-key': '/also/fake' },
         %w[args yes],
         action_class
       )

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -237,6 +237,18 @@ describe R10K::Action::Runner do
       expect(runner.instance.settings[:git][:github_app_key]).to eq('/my/ssl/key')
       expect(runner.instance.settings[:git][:github_app_ttl]).to eq('600')
     end
+
+    it 'saves the parameters in settings hash without ttl and uses its default value' do
+      runner = described_class.new(
+        { 'github-app-id': '123456', 'github-app-key': '/my/ssl/key', },
+        %w[args yes],
+        action_class
+      )
+      runner.call
+      expect(runner.instance.settings[:git][:github_app_id]).to eq('123456')
+      expect(runner.instance.settings[:git][:github_app_key]).to eq('/my/ssl/key')
+      expect(runner.instance.settings[:git][:github_app_ttl]).to eq('120')
+    end
   end
 
   describe "configuring git credentials" do

--- a/spec/unit/git/rugged/credentials_spec.rb
+++ b/spec/unit/git/rugged/credentials_spec.rb
@@ -90,7 +90,7 @@ describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? 
     end
     it 'errors if private file does not exist' do
       R10K::Git.settings[:github_app_key] = "/missing/token/file"
-      expect(File).to receive(:readable?).with("/missing/token/file").and_return false
+      expect(File).to receive(:readable?).with(R10K::Git.settings[:github_app_key]).and_return false
       expect {
         subject.github_app_token("123456", R10K::Git.settings[:github_app_key], "300")
       }.to raise_error(R10K::Git::GitError, /App key is missing or unreadable/)

--- a/spec/unit/git/rugged/credentials_spec.rb
+++ b/spec/unit/git/rugged/credentials_spec.rb
@@ -81,13 +81,11 @@ describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? 
 
   describe "generating github app tokens" do
     it 'errors if app id has invalid characters' do
-      R10K::Git.settings[:github_app_id] = "123A567890"
-      expect { subject.github_app_token(nil, "fake", "300")
+      expect { subject.github_app_token("123A567890", "fake", "300")
       }.to raise_error(R10K::Git::GitError, /App id contains invalid characters/)
     end
     it 'errors if app ttl has invalid characters' do
-      R10K::Git.settings[:github_app_ttl] = "abc"
-      expect { subject.github_app_token("123456", "fake", nil)
+      expect { subject.github_app_token("123456", "fake", "abc")
       }.to raise_error(R10K::Git::GitError, /Token ttl contains invalid characters/)
     end
     it 'errors if private file does not exist' do
@@ -97,7 +95,7 @@ describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? 
         subject.github_app_token("123456", R10K::Git.settings[:github_app_key], "300")
       }.to raise_error(R10K::Git::GitError, /App key is missing or unreadable/)
     end
-    it 'errors if private file exists but is not a valid SSL private key' do
+    it 'errors if file is not a valid SSL key' do
       token_file = Tempfile.new('token')
       token_file.write('my_token')
       token_file.close
@@ -105,7 +103,8 @@ describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? 
       expect(File).to receive(:readable?).with(token_file.path).and_return true
       expect {
         subject.github_app_token("123456", R10K::Git.settings[:github_app_key], "300")
-      }.to raise_error(R10K::Git::GitError, /App key is not a valid SSL private key/)
+      }.to raise_error(R10K::Git::GitError, /App key is not a valid SSL key/)
+      token_file.unlink
     end
   end
 

--- a/spec/unit/git/rugged/credentials_spec.rb
+++ b/spec/unit/git/rugged/credentials_spec.rb
@@ -86,7 +86,7 @@ describe R10K::Git::Rugged::Credentials, :unless => R10K::Util::Platform.jruby? 
     end
     it 'errors if app ttl has invalid characters' do
       expect { subject.github_app_token("123456", "fake", "abc")
-      }.to raise_error(R10K::Git::GitError, /Token ttl contains invalid characters/)
+      }.to raise_error(R10K::Git::GitError, /Github App token ttl contains/)
     end
     it 'errors if private file does not exist' do
       R10K::Git.settings[:github_app_key] = "/missing/token/file"


### PR DESCRIPTION
This authentication benefits large organizations with strict SSO/2FA
guidelines that cannot utilize machine users for puppetserver
deployment.

Here are some of the advantages with Github App vs OAuth or SSH:

* The rate limit of server-to-server requests scales with user + repo count
* No seat consumption with Github App vs machine user. Enforcing SSO/2FA on
  the organization restricts machine user capabilities
* No need to manage unique ssh keys per repository for deployment, which
  can grow upward into the thousands with multiple puppetservers

It has three parameters, one of which is optional with a default
value:

github-app-id: Github App Identifier
github-app-key: SSL private key
github-app-ttl: Token time-to-live in seconds (optional, default: 120)

It generates a new token for every repo when calling `environment`
subcommand.

The jwt gem was added to the gemspec config in order to create the
json web tokens requests.