### PR TITLE
(CODEMGMT-1110) Allow specifying a forge token in config

### DIFF
--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -67,14 +67,15 @@ module R10K
         exit(8)
       end
 
+      # Set up authorization from license file if it wasn't
+      # already set via the config
       def setup_authorization
-        if @settings.dig(:forge, :authorization_token)
-          PuppetForge::Connection.authorization = @settings[:forge][:authorization_token]
-        else
+        if PuppetForge::Connection.authorization.nil?
           begin
             license = R10K::Util::License.load
 
             if license.respond_to?(:authorization_token)
+              logger.debug "Using token from license to connect to the Forge."
               PuppetForge::Connection.authorization = license.authorization_token
             end
           rescue R10K::Error => e

--- a/lib/r10k/action/runner.rb
+++ b/lib/r10k/action/runner.rb
@@ -68,14 +68,18 @@ module R10K
       end
 
       def setup_authorization
-        begin
-          license = R10K::Util::License.load
+        if @settings.dig(:forge, :authorization_token)
+          PuppetForge::Connection.authorization = @settings[:forge][:authorization_token]
+        else
+          begin
+            license = R10K::Util::License.load
 
-          if license.respond_to?(:authorization_token)
-            PuppetForge::Connection.authorization = license.authorization_token
+            if license.respond_to?(:authorization_token)
+              PuppetForge::Connection.authorization = license.authorization_token
+            end
+          rescue R10K::Error => e
+            logger.warn e.message
           end
-        rescue R10K::Error => e
-          logger.warn e.message
         end
       end
 

--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -63,6 +63,13 @@ module R10K
       def call
         with_setting(:baseurl) { |value| PuppetForge.host = value }
         with_setting(:proxy) { |value| PuppetForge::Connection.proxy = value }
+        with_setting(:authorization_token) { |value|
+          if @settings[:baseurl]
+            PuppetForge::Connection.authorization = value
+          else
+            raise R10K::Error, "Cannot specify a Forge authorization token without configuring a custom baseurl."
+          end
+        }
       end
     end
   end

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -92,6 +92,9 @@ module R10K
         URIDefinition.new(:baseurl, {
           :desc => "The URL to the Puppet Forge to use for downloading modules."
         }),
+        Definition.new(:authorization_token, {
+          :desc => "The token for Puppet Forge authorization. Leave blank for unauthorized or license-based connections."
+        })
       ])
     end
 

--- a/spec/fixtures/unit/action/r10k_forge_auth.yaml
+++ b/spec/fixtures/unit/action/r10k_forge_auth.yaml
@@ -1,0 +1,3 @@
+---
+forge:
+  authorization_token: 'faketoken'

--- a/spec/fixtures/unit/action/r10k_forge_auth_no_url.yaml
+++ b/spec/fixtures/unit/action/r10k_forge_auth_no_url.yaml
@@ -1,4 +1,3 @@
 ---
 forge:
-  baseurl: 'http://private-forge.com'
   authorization_token: 'faketoken'

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -218,42 +218,56 @@ describe R10K::Action::Runner do
   end
 
   describe "configuration authorization" do
-    context "when license is not present" do
-      before(:each) do
-        expect(R10K::Util::License).to receive(:load).and_return(nil)
-      end
+    context "settings auth" do
+      let(:options) { { config: "spec/fixtures/unit/action/r10k_forge_auth.yaml" } }
 
-      it "does not set authorization header on connection class" do
-        expect(PuppetForge::Connection).not_to receive(:authorization=)
+      it "sets the configured token as the forge authorization header" do
+        runner = described_class.new(options, %w[args yes], action_class)
+        expect(PuppetForge::Connection).to receive(:authorization=).with('faketoken')
+        expect(R10K::Util::License).not_to receive(:load)
+        runner.setup_settings
         runner.setup_authorization
       end
     end
 
-    context "when license is present but invalid" do
-      before(:each) do
-        expect(R10K::Util::License).to receive(:load).and_raise(R10K::Error.new('invalid license'))
+    context "license auth" do
+      context "when license is not present" do
+        before(:each) do
+          expect(R10K::Util::License).to receive(:load).and_return(nil)
+        end
+
+        it "does not set authorization header on connection class" do
+          expect(PuppetForge::Connection).not_to receive(:authorization=)
+          runner.setup_authorization
+        end
       end
 
-      it "issues warning to logger" do
-        expect(runner.logger).to receive(:warn).with(/invalid license/)
-        runner.setup_authorization
+      context "when license is present but invalid" do
+        before(:each) do
+          expect(R10K::Util::License).to receive(:load).and_raise(R10K::Error.new('invalid license'))
+        end
+
+        it "issues warning to logger" do
+          expect(runner.logger).to receive(:warn).with(/invalid license/)
+          runner.setup_authorization
+        end
+
+        it "does not set authorization header on connection class" do
+          expect(PuppetForge::Connection).not_to receive(:authorization=)
+          runner.setup_authorization
+        end
       end
 
-      it "does not set authorization header on connection class" do
-        expect(PuppetForge::Connection).not_to receive(:authorization=)
-        runner.setup_authorization
-      end
-    end
+      context "when license is present and valid" do
+        before(:each) do
+          mock_license = double('pe-license', :authorization_token => 'test token')
+          expect(R10K::Util::License).to receive(:load).and_return(mock_license)
+        end
 
-    context "when license is present and valid" do
-      before(:each) do
-        mock_license = double('pe-license', :authorization_token => 'test token')
-        expect(R10K::Util::License).to receive(:load).and_return(mock_license)
-      end
-
-      it "sets authorization header on connection class" do
-        expect(PuppetForge::Connection).to receive(:authorization=).with('test token')
-        runner.setup_authorization
+        it "sets authorization header on connection class" do
+          expect(PuppetForge::Connection).to receive(:authorization=).with('test token')
+          runner.setup_authorization
+        end
       end
     end
   end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -250,8 +250,12 @@ describe R10K::Settings do
 
     describe "forge settings" do
       it "passes settings through to the forge settings" do
-        output = subject.evaluate("forge" => {"baseurl" => "https://forge.tessier-ashpool.freeside", "proxy" => "https://proxy.tessier-ashpool.freesize:3128"})
-        expect(output[:forge]).to eq(:baseurl => "https://forge.tessier-ashpool.freeside", :proxy => "https://proxy.tessier-ashpool.freesize:3128")
+        output = subject.evaluate("forge" => {"baseurl" => "https://forge.tessier-ashpool.freeside",
+                                              "proxy" => "https://proxy.tessier-ashpool.freesize:3128",
+                                              "authorization_token" => "faketoken"})
+        expect(output[:forge]).to eq(:baseurl => "https://forge.tessier-ashpool.freeside",
+                                     :proxy => "https://proxy.tessier-ashpool.freesize:3128",
+                                     :authorization_token => "faketoken")
       end
     end
   end


### PR DESCRIPTION
This commit adds a new config value to the `forge` section,
`authorization_token`, that can be used to supply a token to be used to
contact a private Puppet Forge instance. It will supersede the token
from the PE license, if that exists.

This mirrors what we do in Puppet: [setting](https://github.com/puppetlabs/puppet/blob/2f14ddd269c26cba36771d9b3464c2c29422e46a/lib/puppet/defaults.rb#L774-L776). But open to suggestions, e.g. if we want this to be a file path like it is for the OAuth token, instead.
