### PR TITLE
Always sync git module on ref HEAD

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- Always sync git cache on `ref: 'HEAD'` [#1182](https://github.com/puppetlabs/r10k/pull/1182)
+
 3.10.0
 ------
 

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -130,7 +130,8 @@ with a git commit, branch reference, or a tag.
 When a module is installed using `:tag` or `:commit`, r10k assumes that the
 given object is a tag or commit and can do some optimizations around fetching
 the object. If the tag or commit is already available r10k will skip network
-operations when updating the repo, which can speed up install times.
+operations when updating the repo, which can speed up install times. When
+`:commit` is set to track `HEAD`, it will synchronize the module on each run.
 
 Module versions can also be specified using `:branch` to track a specific
 branch reference.

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -131,7 +131,7 @@ When a module is installed using `:tag` or `:commit`, r10k assumes that the
 given object is a tag or commit and can do some optimizations around fetching
 the object. If the tag or commit is already available r10k will skip network
 operations when updating the repo, which can speed up install times. When
-`:commit` is set to track `HEAD`, it will synchronize the module on each run.
+`:ref` is set to track `HEAD`, it will synchronize the module on each run.
 
 Module versions can also be specified using `:branch` to track a specific
 branch reference.

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -93,6 +93,7 @@ class R10K::Git::StatefulRepository
   # @api private
   def sync_cache?(ref)
     return true if !@cache.exist?
+    return true if ref == 'HEAD'
     return true if !([:commit, :tag].include? @cache.ref_type(ref))
     return false
   end

--- a/spec/unit/git/stateful_repository_spec.rb
+++ b/spec/unit/git/stateful_repository_spec.rb
@@ -19,6 +19,11 @@ describe R10K::Git::StatefulRepository do
       expect(subject.sync_cache?(ref)).to eq true
     end
 
+    it "is true if the ref is HEAD" do
+      expect(cache).to receive(:exist?).and_return true
+      expect(subject.sync_cache?('HEAD')).to eq true
+    end
+
     it "is true if the ref is unresolvable" do
       expect(cache).to receive(:exist?).and_return true
       expect(cache).to receive(:ref_type).with('0.9.x').and_return(:unknown)


### PR DESCRIPTION
This PR solves Jira ticket [RK-323](https://tickets.puppetlabs.com/projects/RK/issues/RK-323) for which no GH was made yet.

It allows you to always checkout the latest available version of a Git-type module in Puppetfile by setting `:ref` to `:latest`. Basically what it does is force a sync of the cache and update the desired checkout to `HEAD` while resolving to a specific commit.