### PR TITLE
(maint) Fix broken acceptance test

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -15,7 +15,7 @@ jobs:
           - {os: ubuntu-18.04, ruby: 2.5}
           - {os: ubuntu-18.04, ruby: 2.6}
           - {os: ubuntu-18.04, ruby: 2.7}
-          - {os: ubuntu-18.04, ruby: jruby-9.2.9.0}
+          - {os: ubuntu-18.04, ruby: jruby-9.2.10.0}
           - {os: windows-2016, ruby: 2.5}
           - {os: windows-2016, ruby: 2.6}
           - {os: windows-2016, ruby: 2.7}

--- a/integration/Rakefile
+++ b/integration/Rakefile
@@ -65,7 +65,7 @@ rototiller_task :beaker_hostgenerator do |t|
     end
 
     # This is a hack :(
-    t.add_flag(:name => '', :default => 'centos6-64mdca-64.fa', :override_env => 'TEST_TARGET')
+    t.add_flag(:name => '', :default => 'centos7-64mdca-64.fa', :override_env => 'TEST_TARGET')
 
     t.add_flag(:name => '--global-config', :default => '{forge_host=forge-aio01-petest.puppetlabs.com}', :override_env => 'BHG_GLOBAL_CONFIG')
   end


### PR DESCRIPTION
Previously, the single_env_purge_unmanaged_modules test said that
it was testing that agent runs would fail because the motd module
had been successfully purged.

However, it was actually testing that a) the purge command failed and
b) the agent run succeeded but the assertion failed, not because of
anything that happened on SUT, but because it was testing the output
against the regex /Blah/ which should not appear in normal agent output.
The test then claimed that the failure was part of CODEMGMT-78, which
was a feature improvement to `r10k puppetfile` to respect `--moduledir`
and `--puppetfile` flags. However, that feature was implemented in 2016
and the test has continued to "pass" because of a failing purge command
because the test never actually attempted to use either the moduledir
or puppetfile flags.

This patch updates the purge invocation to actually use moduledir and
puppetfile flags, updates the expectation on the purge invocation to
be successful. It also updates the expectation on agent runs to be
unsuccessful but removes the duplicitous expectation on output matching
/Blah/.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
