### PR TITLE
(maint) Raise when calling Puppetfile#load! if file is missing

### DIFF
--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -48,9 +48,9 @@ module R10K
         dsl.instance_eval(puppetfile_content(@puppetfile), @puppetfile)
 
         validate_no_duplicate_names(@modules)
-        @modules.freeze
+        @modules
 
-        managed_content = @modules.group_by(&:dirname).freeze
+        managed_content = @modules.group_by(&:dirname)
 
         @managed_directories = determine_managed_directories(managed_content)
         @desired_contents = determine_desired_contents(managed_content)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -106,7 +106,11 @@ class Puppetfile
     if self.loaded?
       return @loaded_content
     else
-      self.load!(default_branch_override)
+      if !File.readable?(@puppetfile_path)
+        logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile_path.inspect}
+      else
+        self.load!(default_branch_override)
+      end
     end
   end
 
@@ -115,10 +119,6 @@ class Puppetfile
   #   Deprecated, use R10K::ModuleLoader::Puppetfile directly and pass
   #   the default_branch_override as an option on initialization.
   def load!(default_branch_override = nil)
-    if !File.readable?(@puppetfile_path)
-      logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile_path.inspect}
-      return false
-    end
 
     if default_branch_override && (default_branch_override != @default_branch_override)
       logger.warn("Mismatch between passed and initialized default branch overrides, preferring passed value.")

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -68,34 +68,57 @@ describe R10K::Puppetfile do
   end
 
   describe "loading a Puppetfile" do
-    it "returns the loaded content" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
-      subject = described_class.new(path, {})
+    context 'using load' do
+      it "returns the loaded content" do
+        path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
+        subject = described_class.new(path, {})
 
-      loaded_content = subject.load
-      expect(loaded_content).to be_an_instance_of(Hash)
+        loaded_content = subject.load
+        expect(loaded_content).to be_an_instance_of(Hash)
 
-      has_some_data = loaded_content.values.none?(&:empty?)
-      expect(has_some_data).to be true
+        has_some_data = loaded_content.values.none?(&:empty?)
+        expect(has_some_data).to be true
+      end
+
+      it "is idempotent" do
+        path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
+        subject = described_class.new(path, {})
+
+        expect(subject.loader).to receive(:load).and_call_original.once
+
+        loaded_content1 = subject.load
+        expect(subject.loaded?).to be true
+        loaded_content2 = subject.load
+
+        expect(loaded_content2).to eq(loaded_content1)
+      end
+
+      it "returns nil if Puppetfile doesn't exist" do
+        path = '/rando/path/that/wont/exist'
+        subject = described_class.new(path, {})
+        expect(subject.load).to eq nil
+      end
     end
 
-    it "is idempotent" do
-      path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
-      subject = described_class.new(path, {})
+    context 'using load!' do
+      it "returns the loaded content" do
+        path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
+        subject = described_class.new(path, {})
 
-      expect(subject.loader).to receive(:load).and_call_original.once
+        loaded_content = subject.load!
+        expect(loaded_content).to be_an_instance_of(Hash)
 
-      loaded_content1 = subject.load
-      expect(subject.loaded?).to be true
-      loaded_content2 = subject.load
+        has_some_data = loaded_content.values.none?(&:empty?)
+        expect(has_some_data).to be true
+      end
 
-      expect(loaded_content2).to eq(loaded_content1)
-    end
-
-    it "returns false if Puppetfile doesn't exist" do
-      path = '/rando/path/that/wont/exist'
-      subject = described_class.new(path, {})
-      expect(subject.load).to eq false
+      it "raises if Puppetfile doesn't exist" do
+        path = '/rando/path/that/wont/exist'
+        subject = described_class.new(path, {})
+        expect {
+          subject.load!
+        }.to raise_error(/No such file or directory.*\/rando\/path\/.*/)
+      end
     end
   end
 


### PR DESCRIPTION
As part of a recent refactor the conditional behavior to check if a
Puppetfile existed was moved from `load` to `load!`. However, the
puppetfile actions only call `load!` and depend on its behavior of
raising for parts of their user experience.

This commit moves the check for Puppetfile existence back to `load` so
that it can be skipped by the puppetfile actions and they will properly
error for users when ran in a directory that does not contain a
Puppetfile.

It adds tests for the `load!` method that exercises its lack of
idempotence. It also removes the `freeze` from remaining internal module
loader objects as the method will still fail, but fails with a more user
friendly error (R10K::Error, "duplicate content") rather than
FreezeError.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
