### PR TITLE
Remove username and password in remote url for cache directory name

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -6,6 +6,7 @@ Unreleased
 - Add `authorization_token` setting to allow authentication to a custom Forge server. [#1181](https://github.com/puppetlabs/r10k/pull/1181)
 - (RK-135) Attempting to download the latest version for a module that has no Forge releases will now issue a meaningful error. [#1177](https://github.com/puppetlabs/r10k/pull/1177)
 - Added an interface to R10K::Source::Base named `reload!` for updating the environments list for a given deployment; `reload!` is called before deployment purges to make r10k deploy pools more threadsafe. [#1172](https://github.com/puppetlabs/r10k/pull/1172)
+- Remove username and password from remote url in cache directory name [#1186](https://github.com/puppetlabs/r10k/pull/1186)
 ----------
 
 3.9.3

--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -111,6 +111,6 @@ class R10K::Git::Cache
 
   # Reformat the remote name into something that can be used as a directory
   def sanitized_dirname
-    @sanitized_dirname ||= @remote.gsub(/[^@\w\.-]/, '-')
+    @sanitized_dirname ||= @remote.gsub(/(\w+:\/\/)(.*)(@)/, '\1').gsub(/[^@\w\.-]/, '-')
   end
 end

--- a/spec/unit/git/cache_spec.rb
+++ b/spec/unit/git/cache_spec.rb
@@ -62,4 +62,18 @@ describe R10K::Git::Cache do
       subject.cached?
     end
   end
+
+  describe "dirname sanitization" do
+    it 'sanitizes cache directory name' do
+      expect(subject.sanitized_dirname).to eq('git---some-git-remote')
+    end
+
+    context 'with username and password' do
+      subject { subclass.new('https://"user:pa$$w0rd:@some/git/remote') }
+
+      it 'sanitizes cache directory name' do
+        expect(subject.sanitized_dirname).to eq('https---some-git-remote')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, module remote url has some characters replaced to with `-` so it can be used as cache directory name on disk. However, when Puppetfile has module urls with authentication data in format of `protocol://username:password@host`, password will be leaked in cache directory name. 

I've added replace action for username or username and password parts for the cache directory to avoid leaking credentials on filesystem. Using regex  as some popular urls from eg. gitlab are not parsable with `URI.parse`.


```
- (JIRA ticket) Remove username and password from remote url for cache directory name. [Issue or PR #](link to issue or PR)
```
