### PR TITLE
(RK-369) Run postrun command for module deploys

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - (CODEMGMT-1421) Add skeleton for deploy_spec option [#1189](https://github.com/puppetlabs/r10k/pull/1189)
+- (RK-369) Make module deploys run the postrun command if any environments were updated. [#1190](https://github.com/puppetlabs/r10k/pull/1190)
 
 3.10.0
 ------

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -188,7 +188,7 @@ module R10K
         }),
 
         Definition.new(:postrun, {
-          :desc => "The command r10k should run after deploying environments.",
+          :desc => "The command r10k should run after deploying environments or modules.",
           :validate => lambda do |value|
             if !value.is_a?(Array)
               raise ArgumentError, "The postrun setting should be an array of strings, not a #{value.class}"


### PR DESCRIPTION
This commit updates the `deploy module` command to run the configured
`postrun` command that is normally run after an environment deploy. It
will only run the command if any of the requested environments were
actually modified, i.e. if they contained any of the modules we asked to
deploy. Similarly, if the command contains the `$modifiedenvs` variable,
it will be populated only with environments that actually had modules
deployed. This mirrors how we run `puppet generate types` for module
deploys when that setting is enabled.

Still needs tests, they're a little involved, but would appreciate thoughts on the approach and functionality!

Associated issue: https://github.com/puppetlabs/r10k/issues/982