### PR TITLE
(PF-2437) Allow r10k to authenticate to the Forge

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - (CODEMGMT-1454) Ensure missing repo caches are re-synced [#1210](https://github.com/puppetlabs/r10k/pull/1210)
+- (PF-2437) Allow token authentication to be used with the Forge. [#1192](https://github.com/puppetlabs/r10k/pull/1192)
 
 3.11.0
 ------

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -167,9 +167,8 @@ This defaults to 'https://forgeapi.puppetlabs.com'
 
 #### authorization_token
 
-The 'authorization_token' setting allows you to provide a token for authenticating to a
-custom Forge server. When set, 'baseurl' must also be set.
-You will need to prepend your token with 'Bearer ' if using Artifactory as your Forge server.
+The 'authorization_token' setting allows you to provide a token for authenticating to a Forge server.
+You will need to prepend your token with 'Bearer ' to authenticate to the Forge or when using your own Artifactory server.
 
 ```yaml
 forge:

--- a/lib/r10k/initializers.rb
+++ b/lib/r10k/initializers.rb
@@ -66,13 +66,7 @@ module R10K
       def call
         with_setting(:baseurl) { |value| PuppetForge.host = value }
         with_setting(:proxy) { |value| PuppetForge::Connection.proxy = value }
-        with_setting(:authorization_token) { |value|
-          if @settings[:baseurl]
-            PuppetForge::Connection.authorization = value
-          else
-            raise R10K::Error, "Cannot specify a Forge authorization token without configuring a custom baseurl."
-          end
-        }
+        with_setting(:authorization_token) { |value| PuppetForge::Connection.authorization = value }
       end
     end
   end

--- a/spec/unit/action/runner_spec.rb
+++ b/spec/unit/action/runner_spec.rb
@@ -310,14 +310,6 @@ describe R10K::Action::Runner do
         runner.setup_settings
         runner.setup_authorization
       end
-
-      it 'errors if no custom forge URL is set' do
-        options = { config: "spec/fixtures/unit/action/r10k_forge_auth_no_url.yaml" }
-        runner = described_class.new(options, %w[args yes], action_class)
-        expect(PuppetForge::Connection).not_to receive(:authorization=).with('faketoken')
-
-        expect { runner.setup_settings }.to raise_error(R10K::Error, /Cannot specify a Forge auth/)
-      end
     end
 
     context "license auth" do


### PR DESCRIPTION
In the near future, the Forge will be adding support for authenticated
module downloads. This extends support for token based authentication to
that use case.