### PR TITLE
(maint) Remove rspec testing from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,7 @@ before_install: gem install bundler -v '< 2' --no-document
 matrix:
   include:
     - stage: r10k tests
-      rvm: 2.7.0
-    - stage: r10k tests
-      rvm: 2.6.5
-    - stage: r10k tests
-      rvm: 2.5.0
-    - stage: r10k tests
-      rvm: 2.4.0
-    - stage: r10k tests
       rvm: 2.3.0
-    - stage: r10k tests
-      rvm: jruby
     - stage: r10k container tests
       dist: focal
       language: ruby


### PR DESCRIPTION
We run these tests in GH Actions now, so we don't need to duplicate them
in Travis.
