### PR TITLE
CRI: Allow latest versions on newer ruby

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_dependency 'colored2',   '3.1.2'
-  s.add_dependency 'cri', '2.15.10'
+  s.add_dependency 'cri', '2.15.10' if RUBY_VERSION < '2.5.0'
+  s.add_dependency 'cri', '>= 2.15.10', '< 3' if RUBY_VERSION >= '2.5.0'
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
People with a more modern operating system/ruby version might already
have a newer CRI version. Given that Ruby 2.4 is dead since years I
think it's a good idea to support newer versions.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
