### PR TITLE
Revert "CRI: Allow latest versions on newer ruby"

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_dependency 'colored2',   '3.1.2'
-  s.add_dependency 'cri', '2.15.10' if RUBY_VERSION < '2.5.0'
-  s.add_dependency 'cri', '>= 2.15.10', '< 3' if RUBY_VERSION >= '2.5.0'
+  s.add_dependency 'cri', '2.15.10'
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
This reverts commit 6f4e5a4a3871bbc39b06fad96a8395f1354e84b5.

Gemspecs are evaluated at build time, so this will result in the
dependency restrictions being chosen based on the Ruby version of the
builder, not the system installing the gem.

