### PR TITLE
(maint) Update acceptance tests for missing environments

### DIFF
--- a/integration/Rakefile
+++ b/integration/Rakefile
@@ -1,4 +1,5 @@
 require 'rototiller'
+require 'fileutils'
 
 namespace :ci do
   namespace :test do
@@ -59,6 +60,7 @@ end
 desc 'Generate a host configuration used by Beaker'
 rototiller_task :beaker_hostgenerator do |t|
   if ENV['BEAKER_HOST'].nil?
+    FileUtils.mkdir_p 'configs'
     t.add_command do |c|
       c.name = 'beaker-hostgenerator'
       c.argument = '> configs/generated'

--- a/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
@@ -24,7 +24,7 @@ stage_env_notify_message = 'This is a different message'
 stage_env_notify_message_regex = /#{stage_env_notify_message}/
 
 #Verification for "test" Environment
-test_env_error_message_regex = /Error:.*Could not.*environment '?test'?/
+test_env_message_regex = /Environment 'test' not found on server/
 
 #Verification for "temp" Environment
 test_env_notify_message_regex = /I am in the temp environment/
@@ -157,7 +157,7 @@ agents.each do |agent|
   end
 
   step 'Attempt to Run Puppet Agent Against "test" Environment'
-  on(agent, puppet('agent', '--test', '--environment test'), :acceptable_exit_codes => 1) do |result|
-    assert_match(test_env_error_message_regex, result.stderr, 'Expected error was not detected!')
+  on(agent, puppet('agent', '--test', '--environment test'), :acceptable_exit_codes => 2) do |result|
+    assert_match(test_env_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
@@ -15,7 +15,7 @@ initial_env_names = ['production', 'stage']
 
 #Verification
 notify_message_regex = /I am in the production environment/
-stage_env_error_message_regex = /Error:.*Could not.*environment '?stage'?/
+stage_env_message_regex = /Environment 'stage' not found on server/
 
 #Manifest
 site_pp_path = File.join(git_environments_path, 'manifests', 'site.pp')
@@ -83,8 +83,8 @@ agents.each do |agent|
   end
 
   step 'Attempt to Run Puppet Agent Against "stage" Environment'
-  on(agent, puppet('agent', '--test', '--environment stage'), :acceptable_exit_codes => 1) do |result|
-    assert_match(stage_env_error_message_regex, result.stderr, 'Expected error was not detected!')
+  on(agent, puppet('agent', '--test', '--environment stage'), :acceptable_exit_codes => 2) do |result|
+    assert_match(stage_env_message_regex, result.stdout, 'Expected message not found!')
   end
 end
 

--- a/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
@@ -22,7 +22,7 @@ site_pp = create_site_pp(master_certname, '  include helloworld')
 notify_message_prod_env_regex = /I am in the production environment/
 notify_message_test_env_regex = /I am in the test environment/
 removal_message_test_env_regex = /Removing unmanaged path.*test/
-error_message_regex = /Could not retrieve (catalog from remote server|information from environment test)/
+missing_message_regex = /Environment 'test' not found on server/
 
 #Teardown
 teardown do
@@ -72,7 +72,7 @@ end
 
 agents.each do |agent|
   step 'Run Puppet Agent Against "test" Environment'
-  on(agent, puppet('agent', '--test', '--environment test'), :acceptable_exit_codes => 1) do |result|
-    assert_match(error_message_regex, result.stderr, 'Expected message not found!')
+  on(agent, puppet('agent', '--test', '--environment test'), :acceptable_exit_codes => 2) do |result|
+    assert_match(missing_message_regex, result.stdout, 'Expected message not found!')
   end
 end


### PR DESCRIPTION
This commit updates the expected behavior when running puppet against
environments that don't exist. Previously, puppet runs would fail if the
requested environment wasn't found, but recent changes in puppet (PUP-10539)
changed this behavior to fall back to the environment specified by the server.