### PR TITLE
(CODEMGMT-1415) Allow assuming modules are unchanged between deploys

### DIFF
--- a/doc/dynamic-environments/usage.mkd
+++ b/doc/dynamic-environments/usage.mkd
@@ -62,6 +62,32 @@ useful if you want to make sure that a given environment is fully up to date.
 
 - - -
 
+There is also a middle ground between updating all modules and updating no modules.
+It is often desirable to update the environment and then update only those modules
+whose definitions have changed in the Puppetfile, or whose content _could_ have
+changed since the last deployment (eg, Forge modules with their version set to
+`:latest` or Git modules who point to a `branch` ref).
+
+This can be achieved by assuming content is unchanged locally on disk. This is the
+opposite of what one would assume during a module development cycle, when a user
+might be making local edits to test code changes. However, in production, access
+to puppet code is usually locked down, and updates are deployed through automated
+invocations of R10K.
+
+In these cases, deploys where most modules are unchanged and reference exact
+versions (ie, not `:latest` or a branch as mentioned above), this invocation
+may shorten deployment times dozens of seconds if not minutes depending on how
+many modules meet the above criteria (approximately 1 minute for every 400 modules).
+
+To take advantage of this, set as many modules as possible in the Puppetfile to
+explicit, static version. These are released Forge versions, or Git modules using
+the `:tag`, or `:commit` keys. Git `:ref`s containing only the full 40 character
+commit SHA will also be treated as static versions. Then invoke a deploy with:
+
+    r10k deploy environment production --modules --assume-unchanged
+
+- - -
+
 Update a single environment and specify a default branch override:
 
     r10k deploy environment my_working_environment --modules --default-branch-override default_branch_override

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -41,7 +41,8 @@ module R10K
                 requested_environments: @argv.map { |arg| arg.gsub(/\W/,'_') },
                 default_branch_override: @default_branch_override,
                 generate_types: @generate_types || settings.dig(:deploy, :generate_types) || false,
-                preload_environments: true
+                preload_environments: true,
+                assume_unchanged: @assume_unchanged
               },
               modules: {
                 exclude_spec: settings.dig(:deploy, :exclude_spec),
@@ -238,6 +239,7 @@ module R10K
           super.merge(puppetfile: :modules,
                       modules: :self,
                       cachedir: :self,
+                      'assume-unchanged': :self,
                       'no-force': :self,
                       'exclude-spec': :self,
                       'generate-types': :self,

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -47,6 +47,7 @@ module R10K
                 exclude_spec: settings.dig(:deploy, :exclude_spec),
                 requested_modules: [],
                 deploy_modules: @modules,
+                pool_size: @settings[:pool_size] || 4,
                 force: !@no_force, # force here is used to make it easier to reason about
               },
               purging: {

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -39,6 +39,7 @@ module R10K
               },
               modules: {
                 exclude_spec: settings.dig(:deploy, :exclude_spec),
+                pool_size: @settings[:pool_size] || 4,
                 requested_modules: @argv.map.to_a,
                 # force here is used to make it easier to reason about
                 force: !@no_force

--- a/lib/r10k/action/puppetfile/check.rb
+++ b/lib/r10k/action/puppetfile/check.rb
@@ -14,7 +14,7 @@ module R10K
 
           loader = R10K::ModuleLoader::Puppetfile.new(**options)
           begin
-            loader.load
+            loader.load!
             $stderr.puts _("Syntax OK")
             true
           rescue => e

--- a/lib/r10k/action/puppetfile/check.rb
+++ b/lib/r10k/action/puppetfile/check.rb
@@ -1,6 +1,6 @@
-require 'r10k/puppetfile'
 require 'r10k/action/base'
 require 'r10k/errors/formatting'
+require 'r10k/module_loader/puppetfile'
 
 module R10K
   module Action
@@ -8,11 +8,13 @@ module R10K
       class Check < R10K::Action::Base
 
         def call
-          pf = R10K::Puppetfile.new(@root,
-                                    {moduledir: @moduledir,
-                                     puppetfile_path: @puppetfile})
+          options = { basedir: @root }
+          options[:moduledir] = @moduledir if @moduledir
+          options[:puppetfile] = @puppetfile if @puppetfile
+
+          loader = R10K::ModuleLoader::Puppetfile.new(**options)
           begin
-            pf.load!
+            loader.load
             $stderr.puts _("Syntax OK")
             true
           rescue => e

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -16,7 +16,7 @@ module R10K
             options[:puppetfile] = @puppetfile if @puppetfile
 
             loader = R10K::ModuleLoader::Puppetfile.new(**options)
-            loaded_content = loader.load
+            loaded_content = loader.load!
 
             pool_size = @settings[:pool_size] || 4
             modules   = loaded_content[:modules]

--- a/lib/r10k/action/puppetfile/purge.rb
+++ b/lib/r10k/action/puppetfile/purge.rb
@@ -15,7 +15,7 @@ module R10K
           options[:puppetfile] = @puppetfile if @puppetfile
 
           loader = R10K::ModuleLoader::Puppetfile.new(**options)
-          loaded_content = loader.load
+          loaded_content = loader.load!
           R10K::Util::Cleaner.new(loaded_content[:managed_directories],
                                   loaded_content[:desired_contents],
                                   loaded_content[:purge_exclusions]).purge!

--- a/lib/r10k/cli/deploy.rb
+++ b/lib/r10k/cli/deploy.rb
@@ -69,6 +69,7 @@ scheduled. On subsequent deployments, Puppetfile deployment will default to off.
 
           flag :p, :puppetfile, 'Deploy modules (deprecated, use -m)'
           flag :m, :modules, 'Deploy modules'
+          flag nil, :'assume-unchanged', 'Assume previously deployed modules are unchanged'
           option nil, :'default-branch-override', 'Specify a branchname to override the default branch in the puppetfile',
                  argument: :required
 

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -1,5 +1,4 @@
 require 'r10k/cli'
-require 'r10k/puppetfile'
 require 'r10k/action/puppetfile'
 
 require 'cri'

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -34,6 +34,10 @@ class R10K::Environment::Base
   #   @return [String] The puppetfile name (relative)
   attr_reader :puppetfile_name
 
+  attr_reader :managed_directories, :purge_exclusions, :desired_contents
+
+  attr_reader :loader
+
   # Initialize the given environment.
   #
   # @param name [String] The unique name describing this environment.
@@ -57,6 +61,14 @@ class R10K::Environment::Base
                                          force: @overrides.dig(:modules, :force),
                                          puppetfile_name: @puppetfile_name})
     @puppetfile.environment = self
+
+    loader_options = { basedir: @full_path, overrides: @overrides, environment: self }
+    loader_options[:puppetfile] = @puppetfile_name if @puppetfile_name
+    @loader = R10K::ModuleLoader::Puppetfile.new(**loader_options)
+
+    @managed_directories = [ @full_path ]
+    @desired_contents = []
+    @purge_exclusions = []
   end
 
   # Synchronize the given environment.
@@ -124,15 +136,22 @@ class R10K::Environment::Base
   end
 
   def deploy
-    puppetfile.load(@overrides.dig(:environments, :default_branch_override))
+    loaded_content = @loader.load
+    @modules = loaded_content[:modules]
 
-    puppetfile.sync
+    if ! @modules.empty?
+      pool_size = @overrides.dig(:modules, :pool_size)
+      R10K::ContentSynchronizer.concurrent_sync(loaded_content[:modules], pool_size, logger)
+    end
+
+    @purge_exclusions = determine_purge_exclusions(loaded_content[:managed_directories],
+                                                   loaded_content[:desired_contents])
 
     if (@overrides.dig(:purging, :purge_levels) || []).include?(:puppetfile)
       logger.debug("Purging unmanaged Puppetfile content for environment '#{dirname}'...")
-      R10K::Util::Cleaner.new(puppetfile.managed_directories,
-                              puppetfile.desired_contents,
-                              puppetfile.purge_exclusions).purge!
+      R10K::Util::Cleaner.new(loaded_content[:managed_directories],
+                              loaded_content[:desired_contents],
+                              loaded_content[:purge_exclusions]).purge!
     end
   end
 
@@ -140,12 +159,14 @@ class R10K::Environment::Base
     user_whitelist.collect { |pattern| File.join(@full_path, pattern) }
   end
 
-  def purge_exclusions
+  def determine_purge_exclusions(pf_managed_dirs     = @puppetfile.managed_directories,
+                                 pf_desired_contents = @puppetfile.desired_contents)
+
     list = [File.join(@full_path, '.r10k-deploy.json')].to_set
 
-    list += @puppetfile.managed_directories
+    list += pf_managed_dirs
 
-    list += @puppetfile.desired_contents.flat_map do |item|
+    list += pf_desired_contents.flat_map do |item|
       desired_tree = []
 
       if File.directory?(item)

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -23,6 +23,7 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   def initialize(name, basedir, dirname, options = {})
     super
 
+    @all_modules = nil
     @managed_content = {}
     @modules = []
     @moduledir = case options[:moduledir]
@@ -43,10 +44,8 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   #     - The r10k environment object
   #     - A Puppetfile in the environment's content
   def modules
-    return @modules if puppetfile.nil?
-
-    puppetfile.load unless puppetfile.loaded?
-    @modules + puppetfile.modules
+    puppetfile_modules = super()
+    @all_modules ||= @modules + puppetfile_modules
   end
 
   def module_conflicts?(mod_b)

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -44,8 +44,12 @@ class R10K::Environment::WithModules < R10K::Environment::Base
   #     - The r10k environment object
   #     - A Puppetfile in the environment's content
   def modules
-    puppetfile_modules = super()
-    @all_modules ||= @modules + puppetfile_modules
+    if @all_modules.nil?
+      puppetfile_modules = super()
+      @all_modules = @modules + puppetfile_modules
+    end
+
+    @all_modules
   end
 
   def module_conflicts?(mod_b)

--- a/lib/r10k/environment/with_modules.rb
+++ b/lib/r10k/environment/with_modules.rb
@@ -126,13 +126,6 @@ class R10K::Environment::WithModules < R10K::Environment::Base
 
   include R10K::Util::Purgeable
 
-  # Returns an array of the full paths that can be purged.
-  # @note This implements a required method for the Purgeable mixin
-  # @return [Array<String>]
-  def managed_directories
-    [@full_path]
-  end
-
   # Returns an array of the full paths of filenames that should exist. Files
   # inside managed_directories that are not listed in desired_contents will
   # be purged.

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -1,8 +1,11 @@
 require 'r10k/module'
+require 'r10k/logging'
 require 'puppet_forge'
 
 # This class defines a common interface for module implementations.
 class R10K::Module::Base
+
+  include R10K::Logging
 
   # @!attribute [r] title
   #   @return [String] The forward slash separated owner and name of the module
@@ -47,7 +50,7 @@ class R10K::Module::Base
 
   # @param title [String]
   # @param dirname [String]
-  # @param args [Array]
+  # @param args [Hash]
   def initialize(title, dirname, args, environment=nil)
     @title   = PuppetForge::V3.normalize_name(title)
     @dirname = dirname

--- a/lib/r10k/module/definition.rb
+++ b/lib/r10k/module/definition.rb
@@ -1,0 +1,62 @@
+require 'r10k/module'
+
+class R10K::Module::Definition < R10K::Module::Base
+
+  attr_reader :version
+
+  def initialize(name, dirname:, args:, implementation:, environment: nil)
+    @original_name  = name
+    @original_args  = args.dup
+    @implementation = implementation
+    @version        = implementation.statically_defined_version(name, args)
+
+    super(name, dirname, args, environment)
+  end
+
+  def to_implementation
+    mod = @implementation.new(@title, @dirname, @original_args, @environment)
+
+    mod.origin = origin
+    mod.spec_deletable = spec_deletable
+
+    mod
+  end
+
+  # syncing is a noop for module definitions
+  def sync(args = {})
+    logger.debug1(_("Not updating module %{name}, assuming content unchanged") % {name: name})
+  end
+
+  def status
+    :insync
+  end
+
+  def properties
+    type = nil
+
+    if @args[:type]
+      type = @args[:type]
+    elsif @args[:ref] || @args[:commit] || @args[:branch] || @args[:tag]
+      type = 'git'
+    elsif @args[:svn]
+      # This logic is clear and included for completeness sake, though at
+      # this time module definitions do not support SVN versions.
+      type = 'svn'
+    else
+      type = 'forge'
+    end
+
+    {
+      expected: version,
+      # We can't get the value for `actual` here because that requires the
+      # implementation (and potentially expensive operations by the
+      # implementation). Some consumers will check this value, if it exists
+      # and if not, fall back to the expected version. That is the correct
+      # behavior when assuming modules are unchanged, and why `actual` is set
+      # to `nil` here.
+      actual: nil,
+      type: type
+    }
+  end
+end
+

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -25,6 +25,10 @@ class R10K::Module::Forge < R10K::Module::Base
     expected_version == :latest || expected_version.nil? || PuppetForge::Util.version_valid?(expected_version)
   end
 
+  def self.statically_defined_version(name, args)
+    args[:version] if args[:version].is_a?(String)
+  end
+
   # @!attribute [r] metadata
   #   @api private
   #   @return [PuppetForge::Metadata]
@@ -34,8 +38,6 @@ class R10K::Module::Forge < R10K::Module::Base
   #   @api private
   #   @return [PuppetForge::V3::Module] The Puppet Forge module metadata
   attr_reader :v3_module
-
-  include R10K::Logging
 
   include R10K::Util::Setopts
 

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -13,6 +13,21 @@ class R10K::Module::Git < R10K::Module::Base
     false
   end
 
+  # Will be called if self.implement? above returns true. Will return
+  # the version info, if version is statically defined in the modules
+  # declaration.
+  def self.statically_defined_version(name, args)
+    if !args[:type] && (args[:ref] || args[:tag] || args[:commit])
+      if args[:ref] && args[:ref].to_s.match(/[0-9a-f]{40}/)
+        args[:ref]
+      else
+        args[:tag] || args[:commit]
+      end
+    elsif args[:type].to_s == 'git' && args[:version] && args[:version].to_s.match(/[0-9a-f]{40}/)
+      args[:version]
+    end
+  end
+
   # @!attribute [r] repo
   #   @api private
   #   @return [R10K::Git::StatefulRepository]

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -1,5 +1,4 @@
 require 'r10k/module'
-require 'r10k/logging'
 
 # A dummy module type that can be used to "protect" Puppet modules that exist
 # inside of the Puppetfile "moduledir" location. Local modules will not be
@@ -11,8 +10,6 @@ class R10K::Module::Local < R10K::Module::Base
   def self.implement?(name, args)
     args.is_a?(Hash) && (args[:local] || args[:type].to_s == 'local')
   end
-
-  include R10K::Logging
 
   def version
     "0.0.0"

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -10,6 +10,10 @@ class R10K::Module::SVN < R10K::Module::Base
     args.has_key?(:svn) || args[:type].to_s == 'svn'
   end
 
+  def self.statically_defined_version(name, args)
+    nil
+  end
+
   # @!attribute [r] expected_revision
   #   @return [String] The SVN revision that the repo should have checked out
   attr_reader :expected_revision

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -51,6 +51,20 @@ module R10K
       end
 
       def load
+        if !File.readable?(@puppetfile_path)
+          logger.debug _("Puppetfile %{path} missing or unreadable") % {path: @puppetfile_path.inspect}
+          {
+            modules: [],
+            managed_directories: [],
+            desired_contents: [],
+            purge_exclusions: []
+          }
+        else
+          self.load!
+        end
+      end
+
+      def load!
         dsl = R10K::ModuleLoader::Puppetfile::DSL.new(self)
         dsl.instance_eval(puppetfile_content(@puppetfile_path), @puppetfile_path)
 

--- a/lib/r10k/module_loader/puppetfile/dsl.rb
+++ b/lib/r10k/module_loader/puppetfile/dsl.rb
@@ -6,8 +6,9 @@ module R10K
         #
         # @api private
 
-        def initialize(librarian)
-          @librarian = librarian
+        def initialize(librarian, metadata_only: false)
+          @librarian     = librarian
+          @metadata_only = metadata_only
         end
 
         def mod(name, args = nil)
@@ -17,7 +18,11 @@ module R10K
             opts = { version: args }
           end
 
-          @librarian.add_module(name, opts)
+          if @metadata_only
+            @librarian.add_module_metadata(name, opts)
+          else
+            @librarian.add_module(name, opts)
+          end
         end
 
         def forge(location)

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -120,7 +120,7 @@ class Puppetfile
       @loader.default_branch_override = default_branch_override
     end
 
-    @loaded_content = @loader.load
+    @loaded_content = @loader.load!
     @loaded = true
 
     @loaded_content

--- a/spec/fixtures/unit/puppetfile/various-modules/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/various-modules/Puppetfile
@@ -1,0 +1,9 @@
+mod 'puppetlabs/apt', '2.1.1'
+mod 'puppetlabs/stdlib', :latest
+mod 'puppetlabs/concat'
+mod 'puppetlabs/rpm', '2.1.1-pre1'
+mod 'foo', git: 'this/remote', branch: 'main'
+mod 'bar', git: 'this/remote', tag: 'v1.2.3'
+mod 'baz', git: 'this/remote', commit: '123abc456'
+mod 'fizz', git: 'this/remote', ref: '1234567890abcdef1234567890abcdef12345678'
+mod 'buzz', git: 'this/remote', ref: 'refs/heads/main'

--- a/spec/fixtures/unit/puppetfile/various-modules/Puppetfile.new
+++ b/spec/fixtures/unit/puppetfile/various-modules/Puppetfile.new
@@ -1,0 +1,9 @@
+mod 'puppetlabs/apt', '3.0.0'
+mod 'puppetlabs/stdlib', :latest
+mod 'puppetlabs/concat'
+mod 'puppetlabs/rpm', '2.1.1-pre1'
+mod 'foo', git: 'this/remote', branch: 'main'
+mod 'bar', git: 'this/remote', tag: 'v1.2.3'
+mod 'baz', git: 'this/remote', commit: '123abc456'
+mod 'fizz', git: 'this/remote', ref: '1234567890abcdef1234567890abcdef12345678'
+mod 'buzz', git: 'this/remote', ref: 'refs/heads/main'

--- a/spec/r10k-mocks/mock_env.rb
+++ b/spec/r10k-mocks/mock_env.rb
@@ -1,6 +1,9 @@
 require 'r10k/environment'
+require 'r10k/util/purgeable'
 
 class R10K::Environment::Mock < R10K::Environment::Base
+  include R10K::Util::Purgeable
+
   def sync
     "synced"
   end

--- a/spec/r10k-mocks/mock_source.rb
+++ b/spec/r10k-mocks/mock_source.rb
@@ -5,9 +5,13 @@ class R10K::Source::Mock < R10K::Source::Base
   R10K::Source.register(:mock, self)
 
   def environments
-    corrected_environment_names = @options[:environments].map do |env|
-      R10K::Environment::Name.new(env, :prefix => @prefix, :invalid => 'correct_and_warn')
+    if @_environments.nil?
+      corrected_environment_names = @options[:environments].map do |env|
+        R10K::Environment::Name.new(env, :prefix => @prefix, :invalid => 'correct_and_warn')
+      end
+      @_environments = corrected_environment_names.map { |env| R10K::Environment::Mock.new(env.name, @basedir, env.dirname, { overrides: @options[:overrides] }) }
     end
-    corrected_environment_names.map { |env| R10K::Environment::Mock.new(env.name, @basedir, env.dirname, { overrides: @options[:overrides] }) }
+
+    @_environments
   end
 end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -546,7 +546,6 @@ describe R10K::Action::Deploy::Environment do
                       })
     end
     let(:mock_forge_module_1) { double(:name => "their_shiny_module", :properties => { :expected => "2.0.0" }) }
-    let(:mock_puppetfile) { instance_double("R10K::Puppetfile", :modules => [mock_git_module_1, mock_git_module_2, mock_forge_module_1]) }
 
     before(:all) do
       @tmp_path = "./tmp-r10k-test-dir/"
@@ -559,10 +558,8 @@ describe R10K::Action::Deploy::Environment do
     end
 
     it "writes the .r10k-deploy file correctly if all goes well" do
-      allow(R10K::Puppetfile).to receive(:new).and_return(mock_puppetfile)
-
       fake_env = Fake_Environment.new(@tmp_path, {:name => "my_cool_environment", :signature => "pablo picasso"})
-      allow(fake_env).to receive(:modules).and_return(mock_puppetfile.modules)
+      allow(fake_env).to receive(:modules).and_return([mock_git_module_1, mock_git_module_2, mock_forge_module_1])
       subject.send(:write_environment_info!, fake_env, "2019-01-01 23:23:22 +0000", true)
 
       file_contents = File.read("#{@tmp_path}/.r10k-deploy.json")
@@ -585,10 +582,8 @@ describe R10K::Action::Deploy::Environment do
     end
 
     it "writes the .r10k-deploy file correctly if there's a failure" do
-      allow(R10K::Puppetfile).to receive(:new).and_return(mock_puppetfile)
-
       fake_env = Fake_Environment.new(@tmp_path, {:name => "my_cool_environment", :signature => "pablo picasso"})
-      allow(fake_env).to receive(:modules).and_return(mock_puppetfile.modules)
+      allow(fake_env).to receive(:modules).and_return([mock_git_module_1, mock_git_module_2, mock_forge_module_1])
       allow(mock_forge_module_1).to receive(:properties).and_raise(StandardError)
       subject.send(:write_environment_info!, fake_env, "2019-01-01 23:23:22 +0000", true)
 

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -77,6 +77,11 @@ describe R10K::Action::Deploy::Module do
             basedir: '/some/nonexistent/path/control',
             environments: %w[first second]
           }
+        },
+        overrides: {
+          modules: {
+            pool_size: 4
+          }
         }
       )
     end
@@ -107,7 +112,7 @@ describe R10K::Action::Deploy::Module do
             expect(environment).not_to receive(:generate_types!)
           end
           @modules << mod
-          expect(environment.puppetfile).to receive(:modules).and_return([mod]).twice
+          expect(environment.puppetfile).to receive(:modules).and_return([mod]).once
           original.call(environment, &block)
         end
       end
@@ -248,29 +253,27 @@ describe R10K::Action::Deploy::Module do
         # For this test we want to have realistic Modules and access to
         # their internal Repos to validate the sync. Unfortunately, to
         # do so we do some invasive mocking, effectively implementing
-        # our own R10K::Puppetfile#load. We directly update the Puppetfile's
-        # internal ModuleLoader and then call `load` on it so it will create
-        # the correct loaded_content.
-        puppetfile = environment.puppetfile
-        loader = puppetfile.loader
-        expect(puppetfile).to receive(:load) do
+        # our own R10K::ModuleLoader::Puppetfile#load. We directly update
+        # the Environment's internal ModuleLoader and then call `load` on
+        # it so it will create the correct loaded_content.
+        loader = environment.loader
+        allow(loader).to receive(:puppetfile_content).and_return('')
+        expect(loader).to receive(:load) do
           loader.add_module('mod1', { git: 'git://remote' })
           loader.add_module('mod2', { git: 'git://remote' })
           loader.add_module('mod3', { git: 'git://remote' })
 
-          allow(loader).to receive(:puppetfile_content).and_return('')
-          loaded_content = loader.load
-          puppetfile.instance_variable_set(:@loaded_content, loaded_content)
-          puppetfile.instance_variable_set(:@loaded, true)
-        end
-
-        puppetfile.modules.each do |mod|
-          if ['mod1', 'mod2'].include?(mod.name)
-            expect(mod.should_sync?).to be(true)
-          else
-            expect(mod.should_sync?).to be(false)
+          loaded_content = loader.load!
+          loaded_content[:modules].each do |mod|
+            if ['mod1', 'mod2'].include?(mod.name)
+              expect(mod.should_sync?).to be(true)
+            else
+              expect(mod.should_sync?).to be(false)
+            end
+            expect(mod).to receive(:sync).and_call_original
           end
-          expect(mod).to receive(:sync).and_call_original
+
+          loaded_content
         end
 
         original.call(environment, &block)
@@ -307,36 +310,35 @@ describe R10K::Action::Deploy::Module do
                                                                                      R10K::Environment::Name.new('second', {})])
 
       expect(subject).to receive(:visit_environment).and_wrap_original do |original, environment, &block|
-        puppetfile = environment.puppetfile
+        loader = environment.loader
 
         if environment.name == 'first'
           # For this test we want to have realistic Modules and access to
           # their internal Repos to validate the sync. Unfortunately, to
           # do so we do some invasive mocking, effectively implementing
-          # our own R10K::Puppetfile#load. We directly update the Puppetfile's
-          # internal ModuleLoader and then call `load` on it so it will create
-          # the correct loaded_content.
-          loader = puppetfile.loader
-          expect(puppetfile).to receive(:load) do
+          # our own R10K::ModuleLoader::Puppetfile#load. We directly update
+          # the Environment's internal ModuleLoader and then call `load` on
+          # it so it will create the correct loaded_content.
+          allow(loader).to receive(:puppetfile_content).and_return('')
+          expect(loader).to receive(:load) do
             loader.add_module('mod1', { git: 'git://remote' })
             loader.add_module('mod2', { git: 'git://remote' })
 
-            allow(loader).to receive(:puppetfile_content).and_return('')
-            loaded_content = loader.load
-            puppetfile.instance_variable_set(:@loaded_content, loaded_content)
-            puppetfile.instance_variable_set(:@loaded, true)
+            loaded_content = loader.load!
+            loaded_content[:modules].each do |mod|
+              if mod.name == 'mod1'
+                expect(mod.should_sync?).to be(true)
+              else
+                expect(mod.should_sync?).to be(false)
+              end
+              expect(mod).to receive(:sync).and_call_original
+            end
+
+            loaded_content
           end
 
-          puppetfile.modules.each do |mod|
-            if mod.name == 'mod1'
-              expect(mod.should_sync?).to be(true)
-            else
-              expect(mod.should_sync?).to be(false)
-            end
-            expect(mod).to receive(:sync).and_call_original
-          end
         else
-          expect(puppetfile).not_to receive(:load)
+          expect(loader).not_to receive(:load)
         end
 
         original.call(environment, &block)

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -112,7 +112,12 @@ describe R10K::Action::Deploy::Module do
             expect(environment).not_to receive(:generate_types!)
           end
           @modules << mod
-          expect(environment.puppetfile).to receive(:modules).and_return([mod]).once
+          allow(environment.loader).to receive(:load).and_return({
+            modules: [mod],
+            desired_contents: [],
+            managed_directories: [],
+            purge_exclusions: []
+          }).once
           original.call(environment, &block)
         end
       end

--- a/spec/unit/action/puppetfile/check_spec.rb
+++ b/spec/unit/action/puppetfile/check_spec.rb
@@ -3,7 +3,7 @@ require 'r10k/action/puppetfile/check'
 
 describe R10K::Action::Puppetfile::Check do
   let(:default_opts) { {root: "/some/nonexistent/path"} }
-  let(:loader) { instance_double('R10K::ModuleLoader::Puppetfile', :load => {}) }
+  let(:loader) { instance_double('R10K::ModuleLoader::Puppetfile', :load! => {}) }
 
   def checker(opts = {}, argv = [], settings = {})
     opts = default_opts.merge(opts)
@@ -27,7 +27,7 @@ describe R10K::Action::Puppetfile::Check do
   end
 
   it "prints an error message when validating the Puppetfile syntax raised an error" do
-    allow(loader).to receive(:load).and_raise(R10K::Error.new("Boom!"))
+    allow(loader).to receive(:load!).and_raise(R10K::Error.new("Boom!"))
     allow(R10K::Errors::Formatting).
       to receive(:format_exception).
       with(instance_of(R10K::Error), anything).

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -3,9 +3,10 @@ require 'r10k/action/puppetfile/install'
 
 describe R10K::Action::Puppetfile::Install do
   let(:default_opts) { { root: "/some/nonexistent/path" } }
-  let(:puppetfile) {
-    R10K::Puppetfile.new('/some/nonexistent/path',
-                         {:moduledir => nil, :puppetfile_path => nil, :force => false})
+  let(:loader) {
+    R10K::ModuleLoader::Puppetfile.new({
+      basedir: '/some/nonexistent/path',
+      overrides: {force: false}})
   }
 
   def installer(opts = {}, argv = [], settings = {})
@@ -14,11 +15,11 @@ describe R10K::Action::Puppetfile::Install do
   end
 
   before(:each) do
-    allow(puppetfile).to receive(:load!).and_return(nil)
-    allow(R10K::Puppetfile).to receive(:new).
-      with("/some/nonexistent/path",
-           {:moduledir => nil, :puppetfile_path => nil, :force => false}).
-      and_return(puppetfile)
+    allow(loader).to receive(:load).and_return({})
+    allow(R10K::ModuleLoader::Puppetfile).to receive(:new).
+      with({basedir: "/some/nonexistent/path",
+            overrides: {force: false}}).
+      and_return(loader)
   end
 
   it_behaves_like "a puppetfile install action"
@@ -26,13 +27,19 @@ describe R10K::Action::Puppetfile::Install do
   describe "installing modules" do
     let(:modules) do
       (1..4).map do |idx|
-        R10K::Module::Base.new("author/modname#{idx}", "/some/nonexistent/path/modname#{idx}", {})
+        R10K::Module::Base.new("author/modname#{idx}",
+                               "/some/nonexistent/path/modname#{idx}",
+                               {})
       end
     end
 
     before do
-      allow(puppetfile).to receive(:modules).and_return(modules)
-      allow(puppetfile).to receive(:modules_by_vcs_cachedir).and_return({none: modules})
+      allow(loader).to receive(:load).and_return({
+        modules: modules,
+        managed_directories: [],
+        desired_contents: [],
+        purge_exclusions: []
+      })
     end
 
     it "syncs each module in the Puppetfile" do
@@ -50,15 +57,15 @@ describe R10K::Action::Puppetfile::Install do
   end
 
   describe "purging" do
-    before do
-      allow(puppetfile).to receive(:modules).and_return([])
-    end
-
     it "purges the moduledir after installation" do
+      allow(loader).to receive(:load).and_return({
+        modules:             [],
+        desired_contents:    [ 'root/foo' ],
+        managed_directories: [ 'root' ],
+        purge_exclusions:    [ 'root/**/**.rb' ]
+      })
+
       mock_cleaner = double("cleaner")
-      allow(puppetfile).to receive(:desired_contents).and_return(["root/foo"])
-      allow(puppetfile).to receive(:managed_directories).and_return(["root"])
-      allow(puppetfile).to receive(:purge_exclusions).and_return(["root/**/**.rb"])
 
       expect(R10K::Util::Cleaner).to receive(:new).
         with(["root"], ["root/foo"], ["root/**/**.rb"]).
@@ -70,35 +77,34 @@ describe R10K::Action::Puppetfile::Install do
   end
 
   describe "using custom paths" do
-    it "can use a custom puppetfile path" do
-      expect(R10K::Puppetfile).to receive(:new).
-        with("/some/nonexistent/path",
-             {:moduledir => nil, :force => false, puppetfile_path: "/some/other/path/Puppetfile"}).
-        and_return(puppetfile)
+    it "can use a custom moduledir path" do
+      expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
+        with({basedir: "/some/nonexistent/path",
+              overrides: { force: false },
+              puppetfile: "/some/other/path/Puppetfile"}).
+        and_return(loader)
 
       installer({puppetfile: "/some/other/path/Puppetfile"}).call
-    end
 
-    it "can use a custom moduledir path" do
-      expect(R10K::Puppetfile).to receive(:new).
-        with("/some/nonexistent/path",
-             {:puppetfile_path => nil, :force => false, moduledir: "/some/other/path/site-modules"}).
-        and_return(puppetfile)
+      expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
+        with({basedir: "/some/nonexistent/path",
+              overrides: { force: false },
+              moduledir: "/some/other/path/site-modules"}).
+        and_return(loader)
 
       installer({moduledir: "/some/other/path/site-modules"}).call
     end
   end
 
   describe "forcing to overwrite local changes" do
-    before do
-      allow(puppetfile).to receive(:modules).and_return([])
-    end
-
     it "can use the force overwrite option" do
+      allow(loader).to receive(:load!).and_return({ modules: [] })
+
       subject = described_class.new({root: "/some/nonexistent/path", force: true}, [], {})
-      expect(R10K::Puppetfile).to receive(:new).
-        with("/some/nonexistent/path", {:moduledir => nil, :puppetfile_path => nil, :force => true}).
-        and_return(puppetfile)
+      expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
+        with({basedir: "/some/nonexistent/path",
+              overrides: { force: true }}).
+        and_return(loader)
       subject.call
     end
 

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -15,7 +15,7 @@ describe R10K::Action::Puppetfile::Install do
   end
 
   before(:each) do
-    allow(loader).to receive(:load).and_return({})
+    allow(loader).to receive(:load!).and_return({})
     allow(R10K::ModuleLoader::Puppetfile).to receive(:new).
       with({basedir: "/some/nonexistent/path",
             overrides: {force: false}}).
@@ -34,7 +34,7 @@ describe R10K::Action::Puppetfile::Install do
     end
 
     before do
-      allow(loader).to receive(:load).and_return({
+      allow(loader).to receive(:load!).and_return({
         modules: modules,
         managed_directories: [],
         desired_contents: [],
@@ -58,7 +58,7 @@ describe R10K::Action::Puppetfile::Install do
 
   describe "purging" do
     it "purges the moduledir after installation" do
-      allow(loader).to receive(:load).and_return({
+      allow(loader).to receive(:load!).and_return({
         modules:             [],
         desired_contents:    [ 'root/foo' ],
         managed_directories: [ 'root' ],

--- a/spec/unit/action/puppetfile/purge_spec.rb
+++ b/spec/unit/action/puppetfile/purge_spec.rb
@@ -4,11 +4,13 @@ require 'r10k/action/puppetfile/purge'
 describe R10K::Action::Puppetfile::Purge do
   let(:default_opts) { {root: "/some/nonexistent/path"} }
   let(:puppetfile) do
-    instance_double('R10K::Puppetfile',
-                    :load!               => nil,
-                    :managed_directories => %w{foo},
-                    :desired_contents    => %w{bar},
-                    :purge_exclusions    => %w{baz})
+    instance_double('R10K::ModuleLoader::Puppetfile',
+                    :load => {
+                      :modules             => %w{mod},
+                      :managed_directories => %w{foo},
+                      :desired_contents    => %w{bar},
+                      :purge_exclusions    => %w{baz}
+                    })
   end
 
   def purger(opts = {}, argv = [], settings = {})
@@ -17,8 +19,8 @@ describe R10K::Action::Puppetfile::Purge do
   end
 
   before(:each) do
-    allow(R10K::Puppetfile).to receive(:new).
-      with("/some/nonexistent/path", {moduledir: nil, puppetfile_path: nil}).
+    allow(R10K::ModuleLoader::Puppetfile).to receive(:new).
+      with({basedir: "/some/nonexistent/path"}).
       and_return(puppetfile)
   end
 
@@ -37,23 +39,19 @@ describe R10K::Action::Puppetfile::Purge do
   end
 
   describe "using custom paths" do
-    before(:each) do
-      allow(puppetfile).to receive(:purge!)
-    end
-
     it "can use a custom puppetfile path" do
-      expect(R10K::Puppetfile).to receive(:new).
-        with("/some/nonexistent/path",
-             {moduledir: nil, puppetfile_path: "/some/other/path/Puppetfile"}).
+      expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
+        with({basedir: "/some/nonexistent/path",
+              puppetfile: "/some/other/path/Puppetfile"}).
         and_return(puppetfile)
 
       purger({puppetfile: "/some/other/path/Puppetfile"}).call
     end
 
     it "can use a custom moduledir path" do
-      expect(R10K::Puppetfile).to receive(:new).
-        with("/some/nonexistent/path",
-             {moduledir: "/some/other/path/site-modules", puppetfile_path: nil}).
+      expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
+        with({basedir: "/some/nonexistent/path",
+              moduledir: "/some/other/path/site-modules"}).
         and_return(puppetfile)
 
       purger({moduledir: "/some/other/path/site-modules"}).call

--- a/spec/unit/action/puppetfile/purge_spec.rb
+++ b/spec/unit/action/puppetfile/purge_spec.rb
@@ -5,7 +5,7 @@ describe R10K::Action::Puppetfile::Purge do
   let(:default_opts) { {root: "/some/nonexistent/path"} }
   let(:puppetfile) do
     instance_double('R10K::ModuleLoader::Puppetfile',
-                    :load => {
+                    :load! => {
                       :modules             => %w{mod},
                       :managed_directories => %w{foo},
                       :desired_contents    => %w{bar},

--- a/spec/unit/environment/git_spec.rb
+++ b/spec/unit/environment/git_spec.rb
@@ -79,8 +79,7 @@ describe R10K::Environment::Git do
   describe "enumerating modules" do
     it "loads the Puppetfile and returns modules in that puppetfile" do
       mod = double('A module', :name => 'dbl')
-      expect(subject.puppetfile).to receive(:load)
-      expect(subject.puppetfile).to receive(:modules).and_return [mod]
+      expect(subject.loader).to receive(:load).and_return({modules: [mod]})
       expect(subject.modules).to eq([mod])
     end
   end

--- a/spec/unit/environment/git_spec.rb
+++ b/spec/unit/environment/git_spec.rb
@@ -78,8 +78,9 @@ describe R10K::Environment::Git do
 
   describe "enumerating modules" do
     it "loads the Puppetfile and returns modules in that puppetfile" do
+      loaded = { desired_contents: [], managed_directories: [], purge_exclusions: [] }
       mod = double('A module', :name => 'dbl')
-      expect(subject.loader).to receive(:load).and_return({modules: [mod]})
+      expect(subject.loader).to receive(:load).and_return(loaded.merge(modules: [mod]))
       expect(subject.modules).to eq([mod])
     end
   end

--- a/spec/unit/environment/svn_spec.rb
+++ b/spec/unit/environment/svn_spec.rb
@@ -78,9 +78,9 @@ describe R10K::Environment::SVN do
 
   describe "enumerating modules" do
     it "loads the Puppetfile and returns modules in that puppetfile" do
-      expect(subject.puppetfile).to receive(:load)
-      expect(subject.puppetfile).to receive(:modules).and_return [:modules]
-      expect(subject.modules).to eq([:modules])
+      mod = double('A module', :name => 'dbl')
+      expect(subject.loader).to receive(:load).and_return({modules: [mod]})
+      expect(subject.modules).to eq([mod])
     end
   end
 

--- a/spec/unit/environment/svn_spec.rb
+++ b/spec/unit/environment/svn_spec.rb
@@ -78,8 +78,9 @@ describe R10K::Environment::SVN do
 
   describe "enumerating modules" do
     it "loads the Puppetfile and returns modules in that puppetfile" do
+      loaded = { managed_directories: [], desired_contents: [], purge_exclusions: [] }
       mod = double('A module', :name => 'dbl')
-      expect(subject.loader).to receive(:load).and_return({modules: [mod]})
+      expect(subject.loader).to receive(:load).and_return(loaded.merge(modules: [mod]))
       expect(subject.modules).to eq([mod])
     end
   end

--- a/spec/unit/environment/with_modules_spec.rb
+++ b/spec/unit/environment/with_modules_spec.rb
@@ -65,8 +65,9 @@ describe R10K::Environment::WithModules do
 
   describe "modules method" do
     it "returns the configured modules, and Puppetfile modules" do
+      loaded = { managed_directories: [], desired_contents: [], purge_exclusions: [] }
       puppetfile_mod = instance_double('R10K::Module::Base', name: 'zebra')
-      expect(subject.loader).to receive(:load).and_return({modules: [puppetfile_mod]})
+      expect(subject.loader).to receive(:load).and_return(loaded.merge(modules: [puppetfile_mod]))
       returned_modules = subject.modules
       expect(returned_modules.map(&:name).sort).to eq(%w[concat exec stdlib zebra])
     end

--- a/spec/unit/environment/with_modules_spec.rb
+++ b/spec/unit/environment/with_modules_spec.rb
@@ -66,7 +66,7 @@ describe R10K::Environment::WithModules do
   describe "modules method" do
     it "returns the configured modules, and Puppetfile modules" do
       puppetfile_mod = instance_double('R10K::Module::Base', name: 'zebra')
-      expect(subject.puppetfile).to receive(:modules).and_return [puppetfile_mod]
+      expect(subject.loader).to receive(:load).and_return({modules: [puppetfile_mod]})
       returned_modules = subject.modules
       expect(returned_modules.map(&:name).sort).to eq(%w[concat exec stdlib zebra])
     end

--- a/spec/unit/module/base_spec.rb
+++ b/spec/unit/module/base_spec.rb
@@ -4,26 +4,26 @@ require 'r10k/module/base'
 describe R10K::Module::Base do
   describe "parsing the title" do
     it "parses titles with no owner" do
-      m = described_class.new('eight_hundred', '/moduledir', [])
+      m = described_class.new('eight_hundred', '/moduledir', {})
       expect(m.name).to eq 'eight_hundred'
       expect(m.owner).to be_nil
     end
 
     it "parses forward slash separated titles" do
-      m = described_class.new('branan/eight_hundred', '/moduledir', [])
+      m = described_class.new('branan/eight_hundred', '/moduledir', {})
       expect(m.name).to eq 'eight_hundred'
       expect(m.owner).to eq 'branan'
     end
 
     it "parses hyphen separated titles" do
-      m = described_class.new('branan-eight_hundred', '/moduledir', [])
+      m = described_class.new('branan-eight_hundred', '/moduledir', {})
       expect(m.name).to eq 'eight_hundred'
       expect(m.owner).to eq 'branan'
     end
 
     it "raises an error when the title is not correctly formatted" do
       expect {
-        described_class.new('branan!eight_hundred', '/moduledir', [])
+        described_class.new('branan!eight_hundred', '/moduledir', {})
       }.to raise_error(ArgumentError, "Module name (branan!eight_hundred) must match either 'modulename' or 'owner/modulename'")
     end
   end
@@ -76,13 +76,13 @@ describe R10K::Module::Base do
 
   describe "path variables" do
     it "uses the module name as the name" do
-      m = described_class.new('eight_hundred', '/moduledir', [])
+      m = described_class.new('eight_hundred', '/moduledir', {})
       expect(m.dirname).to eq '/moduledir'
       expect(m.path).to eq(Pathname.new('/moduledir/eight_hundred'))
     end
 
     it "does not include the owner in the path" do
-      m = described_class.new('branan/eight_hundred', '/moduledir', [])
+      m = described_class.new('branan/eight_hundred', '/moduledir', {})
       expect(m.dirname).to eq '/moduledir'
       expect(m.path).to eq(Pathname.new('/moduledir/eight_hundred'))
     end
@@ -90,7 +90,7 @@ describe R10K::Module::Base do
 
   describe "with alternate variable names" do
     subject do
-      described_class.new('branan/eight_hundred', '/moduledir', [])
+      described_class.new('branan/eight_hundred', '/moduledir', {})
     end
 
     it "aliases full_name to title" do
@@ -107,7 +107,7 @@ describe R10K::Module::Base do
   end
 
   describe "accepting a visitor" do
-    subject { described_class.new('branan-eight_hundred', '/moduledir', []) }
+    subject { described_class.new('branan-eight_hundred', '/moduledir', {}) }
 
     it "passes itself to the visitor" do
       visitor = spy('visitor')

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -9,6 +9,28 @@ describe R10K::Module::Forge do
   let(:fixture_modulepath) { File.expand_path('spec/fixtures/module/forge', PROJECT_ROOT) }
   let(:empty_modulepath) { File.expand_path('spec/fixtures/empty', PROJECT_ROOT) }
 
+  describe "statically determined version support" do
+    it 'returns explicitly released forge versions' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { version: '8.0.0' })
+      expect(static_version).to eq('8.0.0')
+    end
+
+    it 'returns explicit pre-released forge versions' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { version: '8.0.0-pre1' })
+      expect(static_version).to eq('8.0.0-pre1')
+    end
+
+    it 'retuns nil for latest versions' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { version: :latest })
+      expect(static_version).to eq(nil)
+    end
+
+    it 'retuns nil for undefined versions' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { version: nil })
+      expect(static_version).to eq(nil)
+    end
+  end
+
   describe "implementing the Puppetfile spec" do
     it "should implement 'branan/eight_hundred', '8.0.0'" do
       expect(described_class).to be_implement('branan/eight_hundred', { version: '8.0.0' })

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -10,15 +10,41 @@ describe R10K::Module::Git do
     allow(R10K::Git::StatefulRepository).to receive(:new).and_return(mock_repo)
   end
 
+
+  describe "statically determined version support" do
+    it 'returns a given commit' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { git: 'my/remote', commit: '123adf' })
+      expect(static_version).to eq('123adf')
+    end
+
+    it 'returns a given tag' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { git: 'my/remote', tag: 'v1.2.3' })
+      expect(static_version).to eq('v1.2.3')
+    end
+
+    it 'returns a ref if it looks like a full commit sha' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { git: 'my/remote', ref: '1234567890abcdef1234567890abcdef12345678' })
+      expect(static_version).to eq('1234567890abcdef1234567890abcdef12345678')
+    end
+
+    it 'returns nil for any non-sha-like ref' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { git: 'my/remote', ref: 'refs/heads/main' })
+      expect(static_version).to eq(nil)
+    end
+
+    it 'returns nil for branches' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { git: 'my/remote', branch: 'main' })
+      expect(static_version).to eq(nil)
+    end
+  end
+
   describe "setting the owner and name" do
     describe "with a title of 'branan/eight_hundred'" do
       subject do
         described_class.new(
           'branan/eight_hundred',
           '/moduledir',
-          {
-            :git => 'git://git-server.site/branan/puppet-eight_hundred',
-          }
+          { :git => 'git://git-server.site/branan/puppet-eight_hundred' }
         )
       end
 
@@ -40,9 +66,7 @@ describe R10K::Module::Git do
         described_class.new(
           'eight_hundred',
           '/moduledir',
-          {
-            :git => 'git://git-server.site/branan/puppet-eight_hundred',
-          }
+          { :git => 'git://git-server.site/branan/puppet-eight_hundred' }
         )
       end
 
@@ -111,9 +135,7 @@ describe R10K::Module::Git do
       described_class.new(
         'boolean',
         '/moduledir',
-        {
-          :git => 'git://git.example.com/adrienthebo/puppet-boolean'
-        }
+        { :git => 'git://git.example.com/adrienthebo/puppet-boolean' }
       )
     end
 

--- a/spec/unit/module/svn_spec.rb
+++ b/spec/unit/module/svn_spec.rb
@@ -6,6 +6,13 @@ describe R10K::Module::SVN do
 
   include_context 'fail on execution'
 
+  describe "statically determined version support" do
+    it 'is unsupported by svn backed modules' do
+      static_version = described_class.statically_defined_version('branan/eight_hundred', { svn: 'my/remote', revision: '123adf' })
+      expect(static_version).to eq(nil)
+    end
+  end
+
   describe "determining it implements a Puppetfile mod" do
     it "implements mods with the :svn hash key" do
       implements = described_class.implement?('r10k-fixture-repo', :svn => 'https://github.com/adrienthebo/r10k-fixture-repo')

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -216,7 +216,7 @@ describe R10K::ModuleLoader::Puppetfile do
     it 'returns an array of paths that #purge! will operate within' do
       expect(R10K::Module).to receive(:new).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
       subject.add_module('puppet/test_module', '1.2.3')
-      subject.load
+      subject.load!
 
       expect(subject.modules.length).to be 1
       expect(subject.managed_directories).to match_array([subject.moduledir])
@@ -228,7 +228,7 @@ describe R10K::ModuleLoader::Puppetfile do
 
         expect(R10K::Module).to receive(:new).with('puppet/test_module', basedir, module_opts, anything).and_call_original
         subject.add_module('puppet/test_module', module_opts)
-        subject.load
+        subject.load!
 
         expect(subject.modules.length).to be 1
         expect(subject.managed_directories).to be_empty
@@ -249,7 +249,7 @@ describe R10K::ModuleLoader::Puppetfile do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'invalid-syntax')
       pf_path = File.join(@path, 'Puppetfile')
       expect {
-        subject.load
+        subject.load!
       }.to raise_error do |e|
         expect_wrapped_error(e, pf_path, SyntaxError)
       end
@@ -259,7 +259,7 @@ describe R10K::ModuleLoader::Puppetfile do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'load-error')
       pf_path = File.join(@path, 'Puppetfile')
       expect {
-        subject.load
+        subject.load!
       }.to raise_error do |e|
         expect_wrapped_error(e, pf_path, LoadError)
       end
@@ -269,7 +269,7 @@ describe R10K::ModuleLoader::Puppetfile do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'argument-error')
       pf_path = File.join(@path, 'Puppetfile')
       expect {
-        subject.load
+        subject.load!
       }.to raise_error do |e|
         expect_wrapped_error(e, pf_path, ArgumentError)
       end
@@ -279,7 +279,7 @@ describe R10K::ModuleLoader::Puppetfile do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'duplicate-module-error')
       pf_path = File.join(@path, 'Puppetfile')
       expect {
-        subject.load
+        subject.load!
       }.to raise_error(R10K::Error, /Puppetfiles cannot contain duplicate module names/i)
     end
 
@@ -287,7 +287,7 @@ describe R10K::ModuleLoader::Puppetfile do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'name-error')
       pf_path = File.join(@path, 'Puppetfile')
       expect {
-        subject.load
+        subject.load!
       }.to raise_error do |e|
         expect_wrapped_error(e, pf_path, NameError)
       end
@@ -296,21 +296,21 @@ describe R10K::ModuleLoader::Puppetfile do
     it 'accepts a forge module with a version' do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
       pf_path = File.join(@path, 'Puppetfile')
-      expect { subject.load }.not_to raise_error
+      expect { subject.load! }.not_to raise_error
     end
 
     describe 'setting a custom moduledir' do
       it 'allows setting an absolute moduledir' do
         @path = '/fake/basedir'
         allow(subject).to receive(:puppetfile_content).and_return('moduledir "/fake/moduledir"')
-        subject.load
+        subject.load!
         expect(subject.instance_variable_get(:@moduledir)).to eq('/fake/moduledir')
       end
 
       it 'roots relative moduledirs in the basedir' do
         @path = '/fake/basedir'
         allow(subject).to receive(:puppetfile_content).and_return('moduledir "my/moduledir"')
-        subject.load
+        subject.load!
         expect(subject.instance_variable_get(:@moduledir)).to eq(File.join(@path, 'my/moduledir'))
       end
     end
@@ -318,13 +318,13 @@ describe R10K::ModuleLoader::Puppetfile do
     it 'accepts a forge module without a version' do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-without-version')
       pf_path = File.join(@path, 'Puppetfile')
-      expect { subject.load }.not_to raise_error
+      expect { subject.load! }.not_to raise_error
     end
 
     it 'creates a git module and applies the default branch specified in the Puppetfile' do
       @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'default-branch-override')
       pf_path = File.join(@path, 'Puppetfile')
-      expect { subject.load }.not_to raise_error
+      expect { subject.load! }.not_to raise_error
       git_module = subject.modules[0]
       expect(git_module.default_ref).to eq 'here_lies_the_default_branch'
     end
@@ -334,7 +334,7 @@ describe R10K::ModuleLoader::Puppetfile do
       pf_path = File.join(@path, 'Puppetfile')
       default_branch_override = 'default_branch_override_name'
       subject.default_branch_override = default_branch_override
-      expect { subject.load }.not_to raise_error
+      expect { subject.load! }.not_to raise_error
       git_module = subject.modules[0]
       expect(git_module.default_override_ref).to eq default_branch_override
       expect(git_module.default_ref).to eq 'here_lies_the_default_branch'

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -114,7 +114,7 @@ describe R10K::Puppetfile do
         path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
         subject = described_class.new(path, {})
 
-        expect(subject.loader).to receive(:load).and_call_original.once
+        expect(subject.loader).to receive(:load!).and_call_original.once
 
         loaded_content1 = subject.load
         expect(subject.loaded?).to be true


### PR DESCRIPTION
The first 7 commits are follow work from earlier refactors that remove the Puppetfile class from being used anywhere within the main code paths of R10K. You can see them by themselves here: https://github.com/justinstoller/r10k/compare/61c589ec62851ba427fc7c110a3762a032f43ac4...45d485822fd3b789ce1e074bb434b84b75584dbf The commits are all relatively small and self contained refactors.

The last commit implements most of the this feature (and can be reviewed on its own). Comments on approach specifically are much appreciated.