### PR TITLE
(maint) Restore the ability to load a Puppetfile from a relative `basedir`

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -9,6 +9,7 @@ Unreleased
 - (CODEMGMT-1421) Add skeleton for deploy_spec option [#1189](https://github.com/puppetlabs/r10k/pull/1189)
 - (RK-369) Make module deploys run the postrun command if any environments were updated. [#982](https://github.com/puppetlabs/r10k/issues/982)
 - Add support for Github App auth token. This allows r10k to authenticate under strict SSO/2FA guidelines that cannot utilize machine users for code deployment. [#1180](https://github.com/puppetlabs/r10k/pull/1180)
+- Restore the ability to load a Puppetfile from a relative `basedir`. [#1202](https://github.com/puppetlabs/r10k/pull/1202)
 
 3.10.0
 ------

--- a/lib/r10k/puppetfile.rb
+++ b/lib/r10k/puppetfile.rb
@@ -82,7 +82,7 @@ class Puppetfile
     @loader = ::R10K::ModuleLoader::Puppetfile.new(
       basedir: @basedir,
       moduledir: @moduledir,
-      puppetfile: @puppetfile_path,
+      puppetfile: @puppetfile_name,
       forge: @forge,
       overrides: @overrides,
       environment: @environment

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -80,6 +80,17 @@ describe R10K::Puppetfile do
         expect(has_some_data).to be true
       end
 
+      it "handles a relative basedir" do
+        path = File.join('spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
+        subject = described_class.new(path, {})
+
+        loaded_content = subject.load
+        expect(loaded_content).to be_an_instance_of(Hash)
+
+        has_some_data = loaded_content.values.none?(&:empty?)
+        expect(has_some_data).to be true
+      end
+
       it "is idempotent" do
         path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'valid-forge-with-version')
         subject = described_class.new(path, {})


### PR DESCRIPTION
This commit updates the `R10K::Puppetfile` class to pass just the Puppetfile
name to the module loader, rather than passing the whole path. Prior to this
change, if you used a relative `basedir`, we'd pass a relative Puppetfile path
to `R10K::ModuleLoader::Puppetfile`, which would then try to resolve the path
against the `basedir` again. This resulted in attempting to load the Puppetfile
from a path like `my/cool/basedir/my/cool/basedir/Puppetfile`, which doesn't
exist, so loading would fail.
