### PR TITLE
(CODEMGMT-1454) Ensure missing repo caches are re-synced

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- (CODEMGMT-1454) Ensure missing repo caches are re-synced [#1210](https://github.com/puppetlabs/r10k/pull/1210)
+
 3.11.0
 ------
 

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -73,6 +73,8 @@ class R10K::Git::StatefulRepository
   def status(ref)
     if !@repo.exist?
       :absent
+    elsif !@cache.exist?
+      :mismatched
     elsif !@repo.git_dir.exist?
       :mismatched
     elsif !@repo.git_dir.directory?


### PR DESCRIPTION
This commit updates the `status` method for stateful git repos to check for the
presence of the git cache when determining whether repo updates are necessary.
Previously, if the repo's working dir and git dir were present, but the cache
was missing, the `@repo.dirty?` check would fail when attempting to diff the
workdir (`object not found - no match for id`). This would occur during an
environment deploy if the environment used the same remote repo as another
environment that had been deleted (and thus its artifacts cleaned up). By
setting the status to `:mismatched` when the cache doesn't exist, we ensure that
the cache is resynced and the deployment may proceed.