### PR TITLE
  [#1215] Ensure module postrun command only runs for modified envs

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -8,6 +8,7 @@ Unreleased
 - (CODEMGMT-1415) Provide a `--incremental` flag to only sync those modules in a Puppetfile whose definitions have changed since last sync, or those whose versions could change. [#1200](https://github.com/puppetlabs/r10k/pull/1200)
 - (CODEMGMT-1454) Ensure missing repo caches are re-synced [#1210](https://github.com/puppetlabs/r10k/pull/1210)
 - (PF-2437) Allow token authentication to be used with the Forge. [#1192](https://github.com/puppetlabs/r10k/pull/1192)
+- Only run the module postrun command for environments in which the module was modified. [#1215](https://github.com/puppetlabs/r10k/issues/1215)
 
 3.11.0
 ------

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -135,6 +135,7 @@ module R10K
               envs.reject! { |e| !requested_envs.include?(e) } if requested_envs.any?
               postcmd = postcmd.map { |e| e.gsub('$modifiedenvs', envs.join(' ')) }
             end
+            logger.debug _("Executing postrun command.")
             subproc = R10K::Util::Subprocess.new(postcmd)
             subproc.logger = logger
             subproc.execute

--- a/lib/r10k/content_synchronizer.rb
+++ b/lib/r10k/content_synchronizer.rb
@@ -8,24 +8,31 @@ module R10K
     end
 
     def self.serial_sync(modules)
+      updated_modules = []
       modules.each do |mod|
-        mod.sync
+        updated = mod.sync
+        updated_modules << mod.name if updated
       end
+      updated_modules
     end
 
+    # Returns a Queue of the names of modules actually updated
     def self.concurrent_accept(modules, visitor, loader, pool_size, logger)
       mods_queue = modules_visit_queue(modules, visitor, loader)
       sync_queue(mods_queue, pool_size, logger)
     end
 
+    # Returns a Queue of the names of modules actually updated
     def self.concurrent_sync(modules, pool_size, logger)
       mods_queue = modules_sync_queue(modules)
       sync_queue(mods_queue, pool_size, logger)
     end
 
+    # Returns a Queue of the names of modules actually updated
     def self.sync_queue(mods_queue, pool_size, logger)
       logger.debug _("Updating modules with %{pool_size} threads") % {pool_size: pool_size}
-      thread_pool = pool_size.times.map { sync_thread(mods_queue, logger) }
+      updated_modules = Queue.new
+      thread_pool = pool_size.times.map { sync_thread(mods_queue, logger, updated_modules) }
       thread_exception = nil
 
       # If any threads raise an exception the deployment is considered a failure.
@@ -33,6 +40,8 @@ module R10K
       # current work, then re-raise the first exception caught.
       begin
         thread_pool.each(&:join)
+        # Return the list of all modules that were actually updated
+        updated_modules
       rescue => e
         logger.error _("Error during concurrent deploy of a module: %{message}") % {message: e.message}
         mods_queue.clear
@@ -65,11 +74,14 @@ module R10K
       modules_by_cachedir.values.each {|mods| queue << mods }
     end
 
-    def self.sync_thread(mods_queue, logger)
+    def self.sync_thread(mods_queue, logger, updated_modules)
       Thread.new do
         begin
           while mods = mods_queue.pop(true) do
-            mods.each { |mod| mod.sync }
+            mods.each do |mod|
+              updated = mod.sync
+              updated_modules << mod.name if updated
+            end
           end
         rescue ThreadError => e
           logger.debug _("Module thread %{id} exiting: %{message}") % {message: e.message, id: Thread.current.object_id}

--- a/lib/r10k/environment/base.rb
+++ b/lib/r10k/environment/base.rb
@@ -147,6 +147,8 @@ class R10K::Environment::Base
     end
   end
 
+
+  # Returns a Queue of the names of modules actually updated
   def deploy
     if @base_modules.nil?
       load_puppetfile_modules
@@ -154,13 +156,15 @@ class R10K::Environment::Base
 
     if ! @base_modules.empty?
       pool_size = @overrides.dig(:modules, :pool_size)
-      R10K::ContentSynchronizer.concurrent_sync(@base_modules, pool_size, logger)
+      updated_modules = R10K::ContentSynchronizer.concurrent_sync(@base_modules, pool_size, logger)
     end
 
     if (@overrides.dig(:purging, :purge_levels) || []).include?(:puppetfile)
       logger.debug("Purging unmanaged Puppetfile content for environment '#{dirname}'...")
       @puppetfile_cleaner.purge!
     end
+
+    updated_modules
   end
 
   def load_puppetfile_modules

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -35,6 +35,7 @@ class R10K::Git::StatefulRepository
     @cache.resolve(ref)
   end
 
+  # Returns true if the sync actually updated the repo, false otherwise
   def sync(ref, force=true)
     @cache.sync if sync_cache?(ref)
 
@@ -46,6 +47,7 @@ class R10K::Git::StatefulRepository
 
     workdir_status = status(ref)
 
+    updated = true
     case workdir_status
     when :absent
       logger.debug(_("Cloning %{repo_path} and checking out %{ref}") % {repo_path: @repo.path, ref: ref })
@@ -64,10 +66,13 @@ class R10K::Git::StatefulRepository
         @repo.checkout(sha, {:force => force})
       else
         logger.warn(_("Skipping %{repo_path} due to local modifications") % {repo_path: @repo.path})
+        updated = false
       end
     else
       logger.debug(_("%{repo_path} is already at Git ref %{ref}") % {repo_path: @repo.path, ref: ref })
+      updated = false
     end
+    updated
   end
 
   def status(ref)

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -106,6 +106,7 @@ class R10K::Module::Base
 
   # Synchronize this module with the indicated state.
   # @param [Hash] opts Deprecated
+  # @return [Boolean] true if the module was updated, false otherwise
   def sync(opts={})
     raise NotImplementedError
   end

--- a/lib/r10k/module/definition.rb
+++ b/lib/r10k/module/definition.rb
@@ -23,8 +23,10 @@ class R10K::Module::Definition < R10K::Module::Base
   end
 
   # syncing is a noop for module definitions
+  # Returns false to inidicate the module was not updated
   def sync(args = {})
     logger.debug1(_("Not updating module %{name}, assuming content unchanged") % {name: name})
+    false
   end
 
   def status

--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -60,18 +60,24 @@ class R10K::Module::Forge < R10K::Module::Base
   end
 
   # @param [Hash] opts Deprecated
+  # @return [Boolean] true if the module was updated, false otherwise
   def sync(opts={})
+    updated = false
     if should_sync?
       case status
       when :absent
         install
+        updated = true
       when :outdated
         upgrade
+        updated = true
       when :mismatched
         reinstall
+        updated = true
       end
       maybe_delete_spec_dir
     end
+    updated
   end
 
   def properties

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -98,10 +98,16 @@ class R10K::Module::Git < R10K::Module::Base
   end
 
   # @param [Hash] opts Deprecated
+  # @return [Boolean] true if the module was updated, false otherwise
   def sync(opts={})
     force = opts[:force] || @force
-    @repo.sync(version, force) if should_sync?
+    if should_sync?
+      updated = @repo.sync(version, force)
+    else
+      updated = false
+    end
     maybe_delete_spec_dir
+    updated
   end
 
   def status

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -28,7 +28,9 @@ class R10K::Module::Local < R10K::Module::Base
   end
 
   # @param [Hash] opts Deprecated
+  # @return [Boolean] false, because local modules are always considered in-sync
   def sync(opts={})
     logger.debug1 _("Module %{title} is a local module, always indicating synced.") % {title: title}
+    false
   end
 end

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -74,18 +74,24 @@ class R10K::Module::SVN < R10K::Module::Base
   end
 
   # @param [Hash] opts Deprecated
+  # @return [Boolean] true if the module was updated, false otherwise
   def sync(opts={})
+    updated = false
     if should_sync?
       case status
       when :absent
         install
+        updated = true
       when :mismatched
         reinstall
+        updated = true
       when :outdated
         update
+        updated = true
       end
       maybe_delete_spec_dir
     end
+    updated
   end
 
   def exist?

--- a/spec/unit/module/forge_spec.rb
+++ b/spec/unit/module/forge_spec.rb
@@ -212,25 +212,31 @@ describe R10K::Module::Forge do
       expect(subject).to receive(:install).never
       expect(subject).to receive(:upgrade).never
       expect(subject).to receive(:reinstall).never
-      subject.sync
+      expect(subject.sync).to be false
     end
 
     it 'reinstalls the module when it is mismatched' do
       allow(subject).to receive(:status).and_return :mismatched
       expect(subject).to receive(:reinstall)
-      subject.sync
+      expect(subject.sync).to be true
     end
 
     it 'upgrades the module when it is outdated' do
       allow(subject).to receive(:status).and_return :outdated
       expect(subject).to receive(:upgrade)
-      subject.sync
+      expect(subject.sync).to be true
     end
 
     it 'installs the module when it is absent' do
       allow(subject).to receive(:status).and_return :absent
       expect(subject).to receive(:install)
-      subject.sync
+      expect(subject.sync).to be true
+    end
+
+    it 'returns false if `should_sync?` is false' do
+      # modules do not sync if they are not requested
+      mod = described_class.new('my_org/my_mod', '/path/to/mod', { overrides: { modules: { requested_modules: ['other_mod'] } } })
+      expect(mod.sync).to be false
     end
   end
 

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -121,12 +121,31 @@ describe R10K::Module::Git do
     let(:spec_path) { dirname + module_name + 'spec' }
     subject { described_class.new(title, dirname, {}) }
 
+    before(:each) do
+      allow(mock_repo).to receive(:resolve).with('master').and_return('abc123')
+    end
+
     it 'defaults to keeping the spec dir' do
       FileUtils.mkdir_p(spec_path)
-      allow(mock_repo).to receive(:resolve).with('master').and_return('abc123')
       allow(mock_repo).to receive(:sync)
       subject.sync
       expect(Dir.exist?(spec_path)).to eq true
+    end
+
+    it 'returns true if repo was updated' do
+      expect(mock_repo).to receive(:sync).and_return(true)
+      expect(subject.sync).to be true
+    end
+
+    it 'returns false if repo was not updated (in-sync)' do
+      expect(mock_repo).to receive(:sync).and_return(false)
+      expect(subject.sync).to be false
+    end
+
+    it 'returns false if `should_sync?` is false' do
+      # modules do not sync if they are not requested
+      mod = described_class.new(title, dirname, { overrides: { modules: { requested_modules: ['other_mod'] } } })
+      expect(mod.sync).to be false
     end
   end
 

--- a/spec/unit/module/svn_spec.rb
+++ b/spec/unit/module/svn_spec.rb
@@ -135,7 +135,6 @@ describe R10K::Module::SVN do
     subject { described_class.new(title, dirname, {}) }
 
     it 'is kept by default' do
-
       FileUtils.mkdir_p(spec_path)
       expect(subject).to receive(:status).and_return(:absent)
       expect(subject).to receive(:install).and_return(nil)
@@ -157,7 +156,7 @@ describe R10K::Module::SVN do
 
       it "installs the SVN module" do
         expect(subject).to receive(:install)
-        subject.sync
+        expect(subject.sync).to be true
       end
     end
 
@@ -167,14 +166,14 @@ describe R10K::Module::SVN do
       it "reinstalls the module" do
         expect(subject).to receive(:reinstall)
 
-        subject.sync
+        expect(subject.sync).to be true
       end
 
       it "removes the existing directory" do
         expect(subject.path).to receive(:rmtree)
         allow(subject).to receive(:install)
 
-        subject.sync
+        expect(subject.sync).to be true
       end
     end
 
@@ -184,7 +183,7 @@ describe R10K::Module::SVN do
       it "upgrades the repository" do
         expect(subject).to receive(:update)
 
-        subject.sync
+        expect(subject.sync).to be true
       end
     end
 
@@ -196,8 +195,14 @@ describe R10K::Module::SVN do
         expect(subject).to receive(:reinstall).never
         expect(subject).to receive(:update).never
 
-        subject.sync
+        expect(subject.sync).to be false
       end
+    end
+
+    it 'and `should_sync?` is false' do
+      # modules do not sync if they are not requested
+      mod = described_class.new('my_mod', '/path/to/mod', { overrides: { modules: { requested_modules: ['other_mod'] } } })
+      expect(mod.sync).to be false
     end
   end
 end

--- a/spec/unit/puppetfile_spec.rb
+++ b/spec/unit/puppetfile_spec.rb
@@ -273,7 +273,7 @@ describe R10K::Puppetfile do
       expect(subject).to receive(:modules).and_return([mod1, mod2])
 
       expect(Thread).to receive(:new).exactly(pool_size).and_call_original
-      expect(Queue).to receive(:new).and_call_original
+      expect(Queue).to receive(:new).and_call_original.twice
 
       subject.accept(visitor)
     end


### PR DESCRIPTION
Previously, when a postrun command with interpolated environments was
specified, the `deploy module` command with no environments specified
would cause the command to be run for all environments that contained
the module, whether or not the env was actually updated by the
deploy.

Similarly, `puppet generate types` would be run for any environment that
contained the module, not just those for which it was updated. Together,
these two things could result in a huge amount of unnecessary work.

This commit makes modules return the result of their syncing, true for
"updated" and false for "not updated". The environment's `deploy`
function collects this information, recording the names of each module
that was updated as part of the deploy. The `module deploy` action then
uses this to determine which environments actually had modules modified,
and uses that to populate the `$modifiedenvs` in the postrun command. So
now, the command will only be run for environments that actually updated
a module.

This also updates the logic for running `puppet generate types` to
follow the same pattern: it is only run for environments that actually
had an updated module.

Note this does not affect environment deploys.