### PR TITLE
Revert "Bump the version of puppet_forge"

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
 
-  s.add_dependency 'puppet_forge', ['>= 2.3.0', '< 4.0.0']
+  s.add_dependency 'puppet_forge', '~> 2.3.0'
 
   s.add_dependency 'gettext-setup', '~>0.24'
   # These two pins narrow what is allowed by gettext-setup,


### PR DESCRIPTION
This reverts commit 101d58a575eea70377983dc336904ecd34d6dd2e.
While bundler will appropriately resolve dependencies based on ruby version, we
discovered that a `gem install` on ruby 2.3 will fail if we allow newer versions
of the puppet_forge gem:
```
prosaic-legacy:~ root# ruby --version
ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]
prosaic-legacy:~ root# gem install r10k-3.11.999.gem
Fetching: jwt-2.2.3.gem (100%)
Successfully installed jwt-2.2.3
Fetching: text-1.3.1.gem (100%)
Successfully installed text-1.3.1
Fetching: locale-2.1.3.gem (100%)
Successfully installed locale-2.1.3
Fetching: gettext-3.2.9.gem (100%)
Successfully installed gettext-3.2.9
Fetching: fast_gettext-1.1.2.gem (100%)
Successfully installed fast_gettext-1.1.2
Fetching: gettext-setup-0.34.gem (100%)
Successfully installed gettext-setup-0.34
Fetching: faraday-em_http-1.0.0.gem (100%)
ERROR:  Error installing r10k-3.11.999.gem:
	faraday-em_http requires Ruby version >= 2.4.0.
```

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
