### PR TITLE
(maint) Define `statically_defined_version` for local modules

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- Fix evaluation of Puppetfiles that include local modules. [#1224](https://github.com/puppetlabs/r10k/pull/1224)
+
 3.12.0
 ------
 

--- a/lib/r10k/module/local.rb
+++ b/lib/r10k/module/local.rb
@@ -11,8 +11,12 @@ class R10K::Module::Local < R10K::Module::Base
     args.is_a?(Hash) && (args[:local] || args[:type].to_s == 'local')
   end
 
-  def version
+  def self.statically_defined_version(name, args)
     "0.0.0"
+  end
+
+  def version
+    self.class.statically_defined_version(self.name, nil)
   end
 
   def properties

--- a/spec/fixtures/unit/puppetfile/various-modules/Puppetfile
+++ b/spec/fixtures/unit/puppetfile/various-modules/Puppetfile
@@ -7,3 +7,4 @@ mod 'bar', git: 'this/remote', tag: 'v1.2.3'
 mod 'baz', git: 'this/remote', commit: '123abc456'
 mod 'fizz', git: 'this/remote', ref: '1234567890abcdef1234567890abcdef12345678'
 mod 'buzz', git: 'this/remote', ref: 'refs/heads/main'
+mod 'canary', local: true

--- a/spec/fixtures/unit/puppetfile/various-modules/Puppetfile.new
+++ b/spec/fixtures/unit/puppetfile/various-modules/Puppetfile.new
@@ -7,3 +7,4 @@ mod 'bar', git: 'this/remote', tag: 'v1.2.3'
 mod 'baz', git: 'this/remote', commit: '123abc456'
 mod 'fizz', git: 'this/remote', ref: '1234567890abcdef1234567890abcdef12345678'
 mod 'buzz', git: 'this/remote', ref: 'refs/heads/main'
+mod 'canary', local: true

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -366,6 +366,7 @@ describe R10K::ModuleLoader::Puppetfile do
         expect(metadata['baz']).to eq('123abc456')
         expect(metadata['fizz']).to eq('1234567890abcdef1234567890abcdef12345678')
         expect(metadata['buzz']).to eq(nil)
+        expect(metadata['canary']).to eq('0.0.0')
       end
 
       it 'does not load module implementations for static versioned' do
@@ -381,6 +382,7 @@ describe R10K::ModuleLoader::Puppetfile do
         expect(modules['baz']).to be_a_kind_of(R10K::Module::Definition)
         expect(modules['fizz']).to be_a_kind_of(R10K::Module::Definition)
         expect(modules['buzz']).to be_a_kind_of(R10K::Module::Git)
+        expect(modules['canary']).to be_a_kind_of(R10K::Module::Definition)
       end
 
       it 'loads module implementations whose static versions are different' do


### PR DESCRIPTION
This commit adds a `statically_defined_version` method to the
`R10K::Module::Local` class. This method is called when instantiating a new
module definition, so previously, Puppetfiles that defined local modules could
not be evaluated because the method was missing.