### PR TITLE
(maint) [fixes #1223] Have mix-in modules require logging utils as necessary

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- Fix requiring individual R10K::Actions without having already required 'r10k'. [#1223](https://github.com/puppetlabs/r10k/issues/1223)
 - Fix evaluation of Puppetfiles that include local modules. [#1224](https://github.com/puppetlabs/r10k/pull/1224)
 
 3.12.0

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,9 @@ CHANGELOG
 Unreleased
 ----------
 
+3.12.1
+------
+
 - Fix requiring individual R10K::Actions without having already required 'r10k'. [#1223](https://github.com/puppetlabs/r10k/issues/1223)
 - Fix evaluation of Puppetfiles that include local modules. [#1224](https://github.com/puppetlabs/r10k/pull/1224)
 

--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -1,12 +1,12 @@
-require 'r10k/util/setopts'
 require 'r10k/logging'
+require 'r10k/util/setopts'
 
 module R10K
   module Action
     class Base
 
-      include R10K::Util::Setopts
       include R10K::Logging
+      include R10K::Util::Setopts
 
       attr_accessor :settings
 

--- a/lib/r10k/action/base.rb
+++ b/lib/r10k/action/base.rb
@@ -5,8 +5,8 @@ module R10K
   module Action
     class Base
 
-      include R10K::Logging
       include R10K::Util::Setopts
+      include R10K::Logging
 
       attr_accessor :settings
 

--- a/lib/r10k/action/deploy/deploy_helpers.rb
+++ b/lib/r10k/action/deploy/deploy_helpers.rb
@@ -1,7 +1,11 @@
+require 'r10k/logging'
+
 module R10K
   module Action
     module Deploy
       module DeployHelpers
+
+        include R10K::Logging
 
         # Ensure that a config file has been found (and presumably loaded) and exit
         # with a helpful error if it hasn't.

--- a/lib/r10k/action/deploy/display.rb
+++ b/lib/r10k/action/deploy/display.rb
@@ -1,6 +1,6 @@
-require 'r10k/deployment'
 require 'r10k/action/base'
 require 'r10k/action/deploy/deploy_helpers'
+require 'r10k/deployment'
 
 module R10K
   module Action

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -1,10 +1,9 @@
-require 'r10k/util/setopts'
-require 'r10k/util/cleaner'
-require 'r10k/deployment'
-require 'r10k/logging'
-require 'r10k/action/visitor'
 require 'r10k/action/base'
 require 'r10k/action/deploy/deploy_helpers'
+require 'r10k/action/visitor'
+require 'r10k/deployment'
+require 'r10k/util/setopts'
+
 require 'json'
 
 module R10K
@@ -13,6 +12,7 @@ module R10K
       class Environment < R10K::Action::Base
 
         include R10K::Action::Deploy::DeployHelpers
+        include R10K::Action::Visitor
 
         # Deprecated
         attr_reader :force
@@ -80,8 +80,6 @@ module R10K
 
           @visit_ok
         end
-
-        include R10K::Action::Visitor
 
         private
 

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -1,7 +1,7 @@
-require 'r10k/deployment'
-require 'r10k/action/visitor'
 require 'r10k/action/base'
 require 'r10k/action/deploy/deploy_helpers'
+require 'r10k/action/visitor'
+require 'r10k/deployment'
 
 module R10K
   module Action
@@ -9,6 +9,7 @@ module R10K
       class Module < R10K::Action::Base
 
         include R10K::Action::Deploy::DeployHelpers
+        include R10K::Action::Visitor
 
         # Deprecated
         attr_reader :force
@@ -68,8 +69,6 @@ module R10K
 
           @visit_ok
         end
-
-        include R10K::Action::Visitor
 
         private
 

--- a/lib/r10k/action/visitor.rb
+++ b/lib/r10k/action/visitor.rb
@@ -1,4 +1,5 @@
 require 'r10k/errors/formatting'
+require 'r10k/logging'
 
 module R10K
   module Action
@@ -12,6 +13,8 @@ module R10K
     #
     # @api private
     module Visitor
+
+      include R10K::Logging
 
       # Dispatch to the type specific visitor method
       #

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -1,5 +1,9 @@
+require 'r10k/errors'
 require 'r10k/logging'
 require 'r10k/module'
+require 'r10k/module_loader/puppetfile/dsl'
+
+require 'pathname'
 
 module R10K
   module ModuleLoader

--- a/lib/r10k/util/purgeable.rb
+++ b/lib/r10k/util/purgeable.rb
@@ -1,3 +1,5 @@
+require 'r10k/logging'
+
 require 'fileutils'
 
 module R10K
@@ -8,6 +10,8 @@ module R10K
     # @abstract Classes using this mixin need to implement {#managed_directory} and
     #   {#desired_contents}
     module Purgeable
+
+      include R10K::Logging
 
       HIDDEN_FILE = /\.[^.]+/
 

--- a/lib/r10k/util/setopts.rb
+++ b/lib/r10k/util/setopts.rb
@@ -1,3 +1,5 @@
+require 'r10k/logging'
+
 module R10K
   module Util
 

--- a/lib/r10k/util/subprocess.rb
+++ b/lib/r10k/util/subprocess.rb
@@ -1,3 +1,4 @@
+require 'r10k/logging'
 require 'r10k/util/platform'
 
 module R10K

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '3.12.0'
+  VERSION = '3.12.1'
 end


### PR DESCRIPTION
See individual commits for details though the main commits are:

14e7e7e
```
 (maint) Include Logging utils to Action mixins

Previously, the modules R10K::Action::Visitor, R10K::Util::Setopts, and
R10K::Action::Deploy::DeployHelpers used the logging utils without
requiring or including the logging util module. It was therefore a
requirement of classes including them to include the logging utils.

The actions themselves all descend from R10K::Action::Base which
includes the logging utils. However, Base and some child actions require
Setops prior to requiring anything else that would bring the logging
utils into scope. This causes users who require an action without first
either require 'r10k', the CLI runner, or some other r10k subsystem that
requires the logging utils to fail.

This patch forces all modules that require logging utils and are mixed
into the actions to require and include the logging utils themselves, so
that the mixins may be required by the actions in any order and users do
not have to load any namespace prior to loading an action.
```

and

877ae12 
```
 (maint) Release #patch 3.12.1
```
