### PR TITLE
Add R10K::ConfigError class

### DIFF
--- a/lib/r10k/errors.rb
+++ b/lib/r10k/errors.rb
@@ -58,4 +58,9 @@ module R10K
       str.gsub(/^/, prefix)
     end
   end
+
+  # An error class for configuration errors
+  #
+  class ConfigError < Error
+  end
 end

--- a/lib/r10k/source/yaml.rb
+++ b/lib/r10k/source/yaml.rb
@@ -7,7 +7,7 @@ class R10K::Source::Yaml < R10K::Source::Hash
     begin
       contents = ::YAML.load_file(config)
     rescue => e
-      raise ConfigError, _("Couldn't open environments file %{file}: %{err}") % {file: config, err: e.message}
+      raise R10K::ConfigError, _("Couldn't open environments file %{file}: %{err}") % {file: config, err: e.message}
     end
 
     # Set the environments key for the parent class to consume


### PR DESCRIPTION
To use in raising general configuration errors. Discovered this not to
be a thing based on an attempt to raise an error in R10K::Source::Yaml.
Modified R10K::Source::Yaml to raise R10K::ConfigError now that it
exists.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
