### PR TITLE
Align terminology with Puppet; bare => plain

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -7,6 +7,7 @@ Unreleased
 - Restore Ruby 3 compatibility [#1234](https://github.com/puppetlabs/r10k/pull/1234)
 - (RK-381) Do not recurse into symlinked dirs when finding files to purge. [#1233](https://github.com/puppetlabs/r10k/pull/1233)
 - Purge should remove unmanaged directories, in addition to unmanaged files. [#1222](https://github.com/puppetlabs/r10k/pull/1222)
+- Rename experimental environment type "bare" to "plain". [#1228](https://github.com/puppetlabs/r10k/pull/1228)
 
 3.12.1
 ------

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -760,16 +760,16 @@ modules:
     version: 62d07f2
 ```
 
-### Bare Environment Type
+### Plain Environment Type
 
 A "control repository" typically contains a hiera.yaml, an environment.conf, a manifests/site.pp file, and a few other things. However, none of these are strictly necessary for an environment to be functional if modules can be deployed to it.
 
-The bare environment type allows sources that support environment modules to operate without a control repo being required. Modules can be deployed directly.
+The plain environment type allows sources that support environment modules to operate without a control repo being required. Modules can be deployed directly.
 
 ```yaml
 ---
 production:
-  type: bare
+  type: plain
   modules:
     puppetlabs-stdlib:
       type: forge
@@ -783,7 +783,7 @@ production:
       version: 62d07f2
 
 development:
-  type: bare
+  type: plain
   modules:
     puppetlabs-stdlib:
       type: forge

--- a/lib/r10k/environment.rb
+++ b/lib/r10k/environment.rb
@@ -30,6 +30,7 @@ module R10K
 
     require 'r10k/environment/base'
     require 'r10k/environment/with_modules'
+    require 'r10k/environment/plain'
     require 'r10k/environment/bare'
     require 'r10k/environment/git'
     require 'r10k/environment/svn'

--- a/lib/r10k/environment/bare.rb
+++ b/lib/r10k/environment/bare.rb
@@ -1,13 +1,10 @@
-class R10K::Environment::Bare < R10K::Environment::WithModules
+class R10K::Environment::Bare < R10K::Environment::Plain
 
   R10K::Environment.register(:bare, self)
 
-  def sync
-    path.mkpath
-  end
-
-  def status
-    :not_applicable
+  def initialize(name, basedir, dirname, options = {})
+    logger.warn _('"bare" environment type is deprecated; please use "plain" instead (environment: %{name})') % {name: name}
+    super
   end
 
   def signature

--- a/lib/r10k/environment/plain.rb
+++ b/lib/r10k/environment/plain.rb
@@ -1,0 +1,16 @@
+class R10K::Environment::Plain < R10K::Environment::WithModules
+
+  R10K::Environment.register(:plain, self)
+
+  def sync
+    path.mkpath
+  end
+
+  def status
+    :not_applicable
+  end
+
+  def signature
+    'plain-default'
+  end
+end

--- a/spec/unit/environment/bare_spec.rb
+++ b/spec/unit/environment/bare_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'r10k/environment'
+
+describe R10K::Environment::Bare do
+  it "warns on initialization" do
+    logger_spy = spy('logger')
+    allow_any_instance_of(described_class).to receive(:logger).and_return(logger_spy)
+
+    described_class.new('envname', '/basedir', 'dirname', {})
+
+    expect(logger_spy).to have_received(:warn).with(%r{deprecated.*envname})
+  end
+end

--- a/spec/unit/environment/plain_spec.rb
+++ b/spec/unit/environment/plain_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'r10k/environment'
+
+describe R10K::Environment::Plain do
+  it "initializes successfully" do
+    expect(described_class.new('envname', '/basedir', 'dirname', {})).to be_a_kind_of(described_class)
+  end
+end

--- a/spec/unit/environment/with_modules_spec.rb
+++ b/spec/unit/environment/with_modules_spec.rb
@@ -8,7 +8,7 @@ describe R10K::Environment::WithModules do
       '/some/nonexistent/environmentdir',
       'prefix_release42',
       {
-        :type             => 'bare',
+        :type             => 'plain',
         :modules          => {
           'puppetlabs-stdlib' => { local: true },
           'puppetlabs-concat' => { local: true },


### PR DESCRIPTION
Puppet already uses a term in the indirector system to indicate that an implementation doesn't really do anything, and that term is "plain". For the R10K environment type that doesn't do anything, we should use this same terminology. The initial choice of the term "bare" isn't ecosystem congruent, and has the language problem of being used meaningfully when describing Git repos, but that meaning doesn't translate at all to the environment type.

Using the term "plain" both aligns terminology with Puppet, and eliminates any potential language collisions with the Git meaning of the term.

I doubt this feature is much-used, and it's still documented as "experimental" so we could probably just change the name and be done. The PR includes a formal deprecation just in case anyone thinks it's needed pre-4.0.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
