### PR TITLE
[WIP] Adds ability to resolve dependencies into a lockfile

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Purge should remove unmanaged directories, in addition to unmanaged files. [#1222](https://github.com/puppetlabs/r10k/pull/1222)
+- Add ability to resolve dependencies into a lockfile [#1232](https://github.com/puppetlabs/r10k/pull/1232)
 
 3.12.1
 ------

--- a/lib/r10k/action/puppetfile.rb
+++ b/lib/r10k/action/puppetfile.rb
@@ -5,6 +5,7 @@ module R10K
       require 'r10k/action/puppetfile/install'
       require 'r10k/action/puppetfile/check'
       require 'r10k/action/puppetfile/purge'
+      require 'r10k/action/puppetfile/resolve'
     end
   end
 end

--- a/lib/r10k/action/puppetfile/resolve.rb
+++ b/lib/r10k/action/puppetfile/resolve.rb
@@ -1,0 +1,68 @@
+require 'r10k/action/base'
+require 'r10k/content_synchronizer'
+require 'r10k/errors/formatting'
+require 'r10k/module_loader/puppetfile'
+require 'r10k/util/cleaner'
+require 'puppetfile-resolver'
+require 'puppetfile-resolver/puppetfile/parser/r10k_eval'
+
+module R10K
+  module Action
+    module Puppetfile
+      class Resolve < R10K::Action::Base
+
+        def call
+          begin
+            @puppetfile ||= 'Puppetfile'
+            @lockfile     = "#{@puppetfile}.lock"
+
+            unless @force
+              logger.error "Pass --force to overwrite existing lockfile" if File.exist? @lockfile
+              return false
+            end
+
+            content    = File.read(@puppetfile)
+            puppetfile = PuppetfileResolver::Puppetfile::Parser::R10KEval.parse(content)
+
+            # Make sure the Puppetfile is valid
+            unless puppetfile.valid?
+              logger.error 'Puppetfile is not valid'
+              puppetfile.validation_errors.each { |err| logger.error err }
+              return false
+            end
+
+            resolver = PuppetfileResolver::Resolver.new(puppetfile, nil)
+            result   = resolver.resolve(strict_mode: true)
+
+            # Output resolution validation errors
+            result.validation_errors.each { |err| logger.warn err}
+
+            File.open(@lockfile, "w+") do |file|
+              # copy over the existing Puppetfile, then add resolved dependencies below
+              file.write puppetfile.content
+              file.write "\n####### resolved dependencies #######\n"
+
+              result.dependency_graph.each do |dep|
+                # ignore the original modules, they're already in the lockfile
+                next if puppetfile.modules.find {|mod| mod.name == dep.name}
+
+                mod = dep.payload
+                next unless mod.is_a? PuppetfileResolver::Models::ModuleSpecification
+
+                file.write "mod '#{dep.payload.owner}-#{dep.payload.name}', '#{dep.payload.version}'\n"
+              end
+            end
+          end
+
+          logger.warn "Please inspect #{@lockfile} and the modules it declares to ensure you know what you are deploying in your infrastructure."
+        end
+
+        private
+
+        def allowed_initialize_opts
+          super.merge(root: :self, puppetfile: :self, force: :self )
+        end
+      end
+    end
+  end
+end

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -63,6 +63,21 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
         end
       end
     end
+
+    module Resolve
+      def self.command
+        @cmd ||= Cri::Command.define do
+          name  'resolve'
+          usage 'resolve'
+          summary 'Resolve all the dependencies of a Puppetfile into Puppetfile.lock'
+
+          option nil, :puppetfile, 'Path to Puppetfile', argument: :required
+          flag   nil, :force, 'Overwrite existing lockfile'
+          runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Resolve)
+        end
+      end
+    end
+
   end
 end
 
@@ -71,3 +86,4 @@ R10K::CLI.command.add_command(R10K::CLI::Puppetfile.command)
 R10K::CLI::Puppetfile.command.add_command(R10K::CLI::Puppetfile::Install.command)
 R10K::CLI::Puppetfile.command.add_command(R10K::CLI::Puppetfile::Check.command)
 R10K::CLI::Puppetfile.command.add_command(R10K::CLI::Puppetfile::Purge.command)
+R10K::CLI::Puppetfile.command.add_command(R10K::CLI::Puppetfile::Resolve.command)

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -37,7 +37,7 @@ module R10K
 
         @basedir     = cleanpath(basedir)
         @moduledir   = resolve_path(@basedir, moduledir)
-        @puppetfile_path  = resolve_path(@basedir, puppetfile)
+        @puppetfile_path  = resolve_lockfile(resolve_path(@basedir, puppetfile))
         @overrides   = overrides
         @environment = environment
         @default_branch_override = @overrides.dig(:environments, :default_branch_override)
@@ -229,6 +229,11 @@ module R10K
         else
           cleanpath(File.join(base, path))
         end
+      end
+
+      def resolve_lockfile(path)
+        lockfile = "#{path}.lock"
+        File.exist?(lockfile) ? lockfile : path
       end
 
       def validate_install_path(path, modname)

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -38,6 +38,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jwt', '~> 2.2.3'
 
+  s.add_dependency 'puppetfile-resolver', '~> 0.5.0'
+
   s.add_development_dependency 'rspec', '~> 3.1'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This modifies the path resolution so that /path/to/Puppetfile.lock is
preferred. If the lockfile exists, then it will be used instead of the
Puppetfile. It also adds a `puppetfile resolve` action that will resolve
dependencies and write out that lockfile.

Note: all dependencies will be satisfied from the Forge, no matter what
the original source was.

Expected user workflow:

* Write Puppetfile that describes only the modules you intend to use.
* Run `r10k puppetfile resolve` to resolve all dependencies of those
  modules.
* Optional: review the dependent modules for quality and security
  purposes.
* Deploy.

@glennsarti what do you think about this implementation? It feels a bit
weird to have multiple Puppetfile parsers in the same tool, but don't
really see a better way. And am I using the dependency graph properly?
