### PR TITLE
Restore Ruby 3 compatibility

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- Restore Ruby 3 compatibility [#1234](https://github.com/puppetlabs/r10k/pull/1234)
 - (RK-381) Do not recurse into symlinked dirs when finding files to purge. [#1233](https://github.com/puppetlabs/r10k/pull/1233)
 - Purge should remove unmanaged directories, in addition to unmanaged files. [#1222](https://github.com/puppetlabs/r10k/pull/1222)
 

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -4,9 +4,9 @@ require 'r10k/action/puppetfile/install'
 describe R10K::Action::Puppetfile::Install do
   let(:default_opts) { { root: "/some/nonexistent/path" } }
   let(:loader) {
-    R10K::ModuleLoader::Puppetfile.new({
+    R10K::ModuleLoader::Puppetfile.new(
       basedir: '/some/nonexistent/path',
-      overrides: {force: false}})
+      overrides: {force: false})
   }
 
   def installer(opts = {}, argv = [], settings = {})


### PR DESCRIPTION
fc5673ed9 added parantheses around the parameters which broke Ruby 3
support.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
