### PR TITLE
[#1221] Build docker images from main branch instead of master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker test and publish
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
We renamed the master branch to main, and that broke the GH Action that
build docker images. This commit updates that action to track the main
branch instead.
