### PR TITLE
(CODEMGMT-1294) Resync repos with unresolvable refs

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- (CODEMGMT-1294) Resync repos with unresolvable refs [#1239](https://github.com/puppetlabs/r10k/pull/1239)
+
 3.13.0
 ------
 

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -20,7 +20,8 @@ class R10K::Git::Rugged::BaseRepository
     else
       object.oid
     end
-  rescue ::Rugged::ReferenceError
+  rescue ::Rugged::ReferenceError, ::Rugged::OdbError => e
+    logger.debug2(_("Unable to resolve %{pattern}: %{e} ") % {pattern: pattern, e: e })
     nil
   end
 

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -86,6 +86,8 @@ class R10K::Git::StatefulRepository
       :mismatched
     elsif !(@repo.origin == @remote)
       :mismatched
+    elsif @repo.head.nil?
+      :mismatched
     elsif @repo.dirty?
       :dirty
     elsif !(@repo.head == @cache.resolve(ref))


### PR DESCRIPTION
Prior to this commit, if the git repo did not have a valid HEAD or the
ref was not resolvable, r10k would raise an error and fail. This commit
changes the behavior to do a forceful resync of the git repo.
This commit updates the `status` method for stateful git repos to return
:mismatched when the repo.head is nil. This commit updates the resolve
method for rugged base repositories to catch `Rugged::OdbError`, which
would have resulted in `object not found - no match for id` messages.
This condition would occur when the local repo was out of sync with the
upstream repo and a local commit could not be found in the upstream
repo. Since this condition indicates that the repo has diverged from the
upstream repository, this change forces a full resync of the git repo to
ensure it is in sync.