### PR TITLE
(RK-378) Restore access to the environment name from the Puppetfile

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - (CODEMGMT-1294) Resync repos with unresolvable refs [#1239](https://github.com/puppetlabs/r10k/pull/1239)
+- (RK-378) Restore access to the environment name from the Puppetfile [#1241](https://github.com/puppetlabs/r10k/pull/1241)
 
 3.13.0
 ------

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -165,6 +165,13 @@ module R10K
         @modules << mod
       end
 
+      # @deprecated
+      # @return [String] The base directory that contains the Puppetfile
+      def basedir
+        logger.warn _('"basedir" has been deprecated and will be removed in a future release')
+        @basedir
+      end
+
      private
 
       def empty_load_output

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -16,7 +16,8 @@ module R10K
 
       attr_accessor :default_branch_override, :environment
       attr_reader :modules, :moduledir, :puppetfile_path,
-        :managed_directories, :desired_contents, :purge_exclusions
+        :managed_directories, :desired_contents, :purge_exclusions,
+        :environment_name
 
       # @param basedir [String] The path that contains the moduledir &
       #     Puppetfile by default. May be an environment, project, or
@@ -40,6 +41,7 @@ module R10K
         @puppetfile_path  = resolve_path(@basedir, puppetfile)
         @overrides   = overrides
         @environment = environment
+        @environment_name = @environment&.name
         @default_branch_override = @overrides.dig(:environments, :default_branch_override)
         @allow_puppetfile_forge = @overrides.dig(:forge, :allow_puppetfile_override)
 
@@ -168,7 +170,7 @@ module R10K
       # @deprecated
       # @return [String] The base directory that contains the Puppetfile
       def basedir
-        logger.warn _('"basedir" has been deprecated and will be removed in a future release')
+        logger.warn _('"basedir" is deprecated. Please use "environment_name" instead. "basedir" will be removed in a future version.')
         @basedir
       end
 

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -167,6 +167,7 @@ describe R10K::ModuleLoader::Puppetfile do
     it 'should disable and not add modules that conflict with the environment' do
       env = instance_double('R10K::Environment::Base')
       mod = instance_double('R10K::Module::Base', name: 'conflict', origin: :puppetfile, 'origin=': nil)
+      allow(env).to receive(:name).and_return('conflict')
       loader = R10K::ModuleLoader::Puppetfile.new(basedir: basedir, environment: env)
       allow(env).to receive(:'module_conflicts?').with(mod).and_return(true)
       allow(mod).to receive(:spec_deletable=)
@@ -187,7 +188,9 @@ describe R10K::ModuleLoader::Puppetfile do
     context 'when belonging to an environment' do
       let(:env_contents) { ['env1', 'env2' ] }
       let(:env) { double(:environment, desired_contents: env_contents) }
-
+      before {
+        allow(env).to receive(:name).and_return('env1')
+      }
       subject { R10K::ModuleLoader::Puppetfile.new(basedir: '/test/basedir', environment: env) }
 
       it "includes environment's desired_contents" do


### PR DESCRIPTION
This PR restores the `basedir` getter in the Puppetfile DSL with a deprecation warning and adds a new 'environment_name' getter that can be used to get the name of the environment.