### PR TITLE
Implement R10K::Util::Cacheable

### DIFF
--- a/lib/r10k/forge/module_release.rb
+++ b/lib/r10k/forge/module_release.rb
@@ -1,5 +1,6 @@
 require 'r10k/logging'
 require 'r10k/settings/mixin'
+require 'r10k/util/cacheable'
 require 'fileutils'
 require 'tmpdir'
 require 'puppet_forge'
@@ -13,7 +14,7 @@ module R10K
 
       def_setting_attr :proxy
       def_setting_attr :baseurl
-      def_setting_attr :cache_root, File.expand_path(ENV['HOME'] ? '~/.r10k/cache': '/root/.r10k/cache')
+      def_setting_attr :cache_root, R10K::Util::Cacheable.default_cachedir
 
       include R10K::Logging
 

--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -18,17 +18,7 @@ class R10K::Git::Cache
   include R10K::Settings::Mixin
   include R10K::Util::Cacheable
 
-  #@api private
-  def self.determine_cache_root
-    if R10K::Util::Platform.windows?
-      File.join(ENV['LOCALAPPDATA'], 'r10k', 'git')
-    else
-      File.expand_path(ENV['HOME'] ? '~/.r10k/git': '/root/.r10k/git')
-    end
-  end
-  private_class_method :determine_cache_root
-
-  def_setting_attr :cache_root, determine_cache_root
+  def_setting_attr :cache_root, R10K::Util::Cacheable.default_cachedir('git')
 
   @instance_cache = R10K::InstanceCache.new(self)
 

--- a/lib/r10k/git/cache.rb
+++ b/lib/r10k/git/cache.rb
@@ -3,6 +3,7 @@ require 'r10k/git'
 require 'r10k/settings'
 require 'r10k/instance_cache'
 require 'forwardable'
+require 'r10k/util/cacheable'
 
 # Cache Git repository mirrors for object database reuse.
 #
@@ -15,6 +16,7 @@ require 'forwardable'
 class R10K::Git::Cache
 
   include R10K::Settings::Mixin
+  include R10K::Util::Cacheable
 
   #@api private
   def self.determine_cache_root
@@ -109,8 +111,7 @@ class R10K::Git::Cache
 
   alias cached? exist?
 
-  # Reformat the remote name into something that can be used as a directory
   def sanitized_dirname
-    @sanitized_dirname ||= @remote.gsub(/(\w+:\/\/)(.*)(@)/, '\1').gsub(/[^@\w\.-]/, '-')
+    @sanitized_dirname ||= super(@remote)
   end
 end

--- a/lib/r10k/util/cacheable.rb
+++ b/lib/r10k/util/cacheable.rb
@@ -1,0 +1,31 @@
+module R10K
+  module Util
+
+    # Utility mixin for classes that need to implement caches
+    #
+    # @abstract Classes using this mixin need to implement {#managed_directory} and
+    #   {#desired_contents}
+    module Cacheable
+
+      # Provide a default cachedir location. This is consumed by R10K::Settings
+      # for appropriate global default values.
+      #
+      # @return [String] Path to the default cache directory
+      def self.default_cachedir(basename = 'cache')
+        if R10K::Util::Platform.windows?
+          File.join(ENV['LOCALAPPDATA'], 'r10k', basename)
+        else
+          File.join(ENV['HOME'] || '/root', '.r10k', basename)
+        end
+      end
+
+      # Reformat a string into something that can be used as a directory
+      #
+      # @param string [String] An identifier to create a sanitized dirname for
+      # @return [String] A sanitized dirname for the given string
+      def sanitized_dirname(string)
+        string.gsub(/(\w+:\/\/)(.*)(@)/, '\1').gsub(/[^@\w\.-]/, '-')
+      end
+    end
+  end
+end

--- a/spec/unit/git/cache_spec.rb
+++ b/spec/unit/git/cache_spec.rb
@@ -21,7 +21,8 @@ describe R10K::Git::Cache do
     end
   end
 
-  subject { subclass.new('git://some/git/remote') }
+  let(:remote) { 'git://some/git/remote' }
+  subject { subclass.new(remote) }
 
   describe "updating the cache" do
     it "only updates the cache once" do
@@ -60,20 +61,6 @@ describe R10K::Git::Cache do
     it "aliases #cached? to #exist?" do
       expect(subject.repo).to receive(:exist?)
       subject.cached?
-    end
-  end
-
-  describe "dirname sanitization" do
-    it 'sanitizes cache directory name' do
-      expect(subject.sanitized_dirname).to eq('git---some-git-remote')
-    end
-
-    context 'with username and password' do
-      subject { subclass.new('https://"user:pa$$w0rd:@some/git/remote') }
-
-      it 'sanitizes cache directory name' do
-        expect(subject.sanitized_dirname).to eq('https---some-git-remote')
-      end
     end
   end
 end

--- a/spec/unit/util/cacheable_spec.rb
+++ b/spec/unit/util/cacheable_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'r10k/util/cacheable'
+
+RSpec.describe R10K::Util::Cacheable do
+
+  subject { Object.new.extend(R10K::Util::Cacheable) }
+
+  describe "dirname sanitization" do
+    let(:input) { 'git://some/git/remote' }
+
+    it 'sanitizes URL to directory name' do
+      expect(subject.sanitized_dirname(input)).to eq('git---some-git-remote')
+    end
+
+    context 'with username and password' do
+      let(:input) { 'https://"user:pa$$w0rd:@authenticated/git/remote' }
+
+      it 'sanitizes authenticated URL to directory name' do
+        expect(subject.sanitized_dirname(input)).to eq('https---authenticated-git-remote')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Chunk PR in support of (original monster PR) #1159

The purpose of `R10K::Util::Cacheable` is to centrally define values and functions used by objects that implement caches. We already have two such objects in the codebase (`R10K::Git::Cache`, and `R10K::Forge::ModuleRelease`). Adding Tarball-based types would introduce a third.

Centralizing in adherence with the DRY principle.