### PR TITLE
(CODEMGMT-1300) Update rugged cache remote if it has changed

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -6,6 +6,7 @@ Unreleased
 
 - (CODEMGMT-1294) Resync repos with unresolvable refs [#1239](https://github.com/puppetlabs/r10k/pull/1239)
 - (RK-378) Restore access to the environment name from the Puppetfile [#1241](https://github.com/puppetlabs/r10k/pull/1241)
+- (CODEMGMT-1300) Ensure the remote url in rugged cache directories is current [#1245](https://github.com/puppetlabs/r10k/pull/1245)
 
 3.13.0
 ------

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -61,6 +61,17 @@ class R10K::Git::Rugged::BaseRepository
     remotes_hash
   end
 
+  # Update a remote URL
+  # @param [String] The remote URL of the git repository
+  # @param [String] An optional remote name for the git repository
+  def update_remote(remote, remote_name='origin')
+
+    if @_rugged_repo && remotes[remote_name] != remote
+      logger.debug2(_("Remote URL is different from cache, updating %{orig} to %{update}") % {orig: remotes[remote_name], update: remote})
+      @_rugged_repo.remotes.set_url(remote_name, remote)
+    end
+  end
+
   private
 
   def with_repo(opts={})

--- a/lib/r10k/git/rugged/base_repository.rb
+++ b/lib/r10k/git/rugged/base_repository.rb
@@ -65,8 +65,7 @@ class R10K::Git::Rugged::BaseRepository
   # @param [String] The remote URL of the git repository
   # @param [String] An optional remote name for the git repository
   def update_remote(remote, remote_name='origin')
-
-    if @_rugged_repo && remotes[remote_name] != remote
+    if @_rugged_repo
       logger.debug2(_("Remote URL is different from cache, updating %{orig} to %{update}") % {orig: remotes[remote_name], update: remote})
       @_rugged_repo.remotes.set_url(remote_name, remote)
     end

--- a/lib/r10k/git/rugged/cache.rb
+++ b/lib/r10k/git/rugged/cache.rb
@@ -8,4 +8,12 @@ class R10K::Git::Rugged::Cache < R10K::Git::Cache
   def self.bare_repository
     R10K::Git::Rugged::BareRepository
   end
+
+  # Update the remote URL if the cache differs from the current configuration
+  def sync!
+    if cached?
+      @repo.update_remote(@remote)
+    end
+    super
+  end
 end

--- a/lib/r10k/git/rugged/cache.rb
+++ b/lib/r10k/git/rugged/cache.rb
@@ -11,7 +11,7 @@ class R10K::Git::Rugged::Cache < R10K::Git::Cache
 
   # Update the remote URL if the cache differs from the current configuration
   def sync!
-    if cached?
+    if cached? && @repo.remotes['origin'] != @remote
       @repo.update_remote(@remote)
     end
     super

--- a/spec/integration/git/rugged/cache_spec.rb
+++ b/spec/integration/git/rugged/cache_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'r10k/git/rugged/cache'
+
+describe R10K::Git::Rugged::Cache, :if => R10K::Features.available?(:rugged) do
+  include_context 'Git integration'
+
+  let(:dirname) { 'working-repo' }
+  let(:remote_name) { 'origin' }
+
+  subject { described_class.new(remote) }
+
+  context "syncing with the remote" do
+    before(:each) do
+      subject.reset!
+    end
+
+    describe "with the correct configuration" do
+      it "is able to sync with the remote" do
+        subject.sync
+        expect(subject.synced?).to eq(true)
+      end
+    end
+
+    describe "with a out of date cached remote" do
+      it "updates the cached remote configuration" do
+        subject.repo.update_remote('foo', remote_name)
+        expect(subject.repo.remotes[remote_name]).to eq('foo')
+        subject.sync
+        expect(subject.repo.remotes[remote_name]).to eq(remote)
+      end
+    end
+  end
+end

--- a/spec/unit/git/rugged/cache_spec.rb
+++ b/spec/unit/git/rugged/cache_spec.rb
@@ -26,4 +26,23 @@ describe R10K::Git::Rugged::Cache, :unless => R10K::Util::Platform.jruby? do
       expect(described_class.settings[:cache_root]).to eq '/some/path'
     end
   end
+
+  describe "remote url updates" do
+    before do
+      allow(subject.repo).to receive(:exist?).and_return true
+      allow(subject.repo).to receive(:fetch)
+      allow(subject.repo).to receive(:remotes).and_return({ 'origin' => 'git://some/git/remote' })
+    end
+
+    it "does not update the URLs if they match" do
+      expect(subject.repo).to_not receive(:update_remote)
+      subject.sync!
+    end
+
+    it "updates the remote URL if they do not match" do
+      allow(subject.repo).to receive(:remotes).and_return({ 'origin' => 'foo'})
+      expect(subject.repo).to receive(:update_remote)
+      subject.sync!
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, if the rugged cache repository had a different
remote url than the current configuration, it would not use the current
configured url. This would cause r10k deployment failures when there was
a malformed or incorrect cached remote URL. This commit changes that
behavior by updating the remote URL if the current configuration and the
cache differ. The current configuration will be used instead of the
cached URL.


To repro this issue, one can simply edit the `config` file in the `r10k` cache and change the `origin` remote URL to be malformed. E.g

```
sed -i 's#github.com/puppetlabs#github.com:puppetlabs#' /var/cache/r10k/https---github.com-puppetlabs-puppetlabs-apache.git/config
 /opt/puppetlabs/puppet/bin/r10k deploy environment -v debug2 -p --trace
```

Without this change, we get the following until the cache is cleared or fixed.

```
[2021-11-09 14:15:00 - ERROR] malformed URL 'https://github.com:puppetlabs/puppetlabs-apache.git' at /var/cache/r10k/https---github.com-puppetlabs-puppetlabs-apache.git at /var/cache/r10k/https---github.com-puppetlabs-puppetlabs-apache.git
```

With this change, we have a successful deployment and the following is logged. 

```
[2021-11-09 14:14:31 - INFO] Deploying module to /etc/puppetlabs/code/environments/production/modules/apache
[2021-11-09 14:14:31 - DEBUG2] Remote URL is different from cache, updating https://github.com:puppetlabs/puppetlabs-apache.git to https://github.com/puppetlabs/puppetlabs-apache.git
[2021-11-09 14:14:31 - DEBUG1] Fetching remote 'origin' at /var/cache/r10k/https---github.com-puppetlabs-puppetlabs-apache.git
[2021-11-09 14:14:32 - DEBUG2] Transferred 0 objects (0 bytes) from 'origin' into /var/cache/r10k/https---github.com-puppetlabs-puppetlabs-apache.git'
```

