### PR TITLE
(maint) Prevent certain issues and PRs from being marked stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,5 +15,7 @@ jobs:
         days-before-close: 7
         stale-issue-message: 'This issue has been marked stale because it has had no activity for 60 days. The Puppet Team is actively prioritizing existing bugs and new features, if this issue is still important to you please comment and we will add this to our backlog to complete. Otherwise, it will be closed in 7 days.'
         stale-issue-label: 'stale'
+        exempt-issue-labels: 'community interest'
         stale-pr-message: "This PR has been marked stale because it has had no activity for 60 days. If you are still interested in getting this merged, please comment and we'll try to move it forward. Otherwise, it will be closed in 7 days."
         stale-pr-label: 'stale'
+        exempt-pr-labels: 'community interest'


### PR DESCRIPTION
This commit enables the `exempt-issue-labels` and `exempt-pr-labels` settings
to prevent the `stale` Github Action from marking stale issues and PRs with the
specified label. The label should only be applied to issues and PRs that the
`stale` action has previously marked but were revived by user interest.
