### PR TITLE
(RK-383) Remove deprecated `basedir` method from Puppetfile DSL

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,7 @@ CHANGELOG
 
 Unreleased
 ----------
+- (RK-383) Remove deprecated `basedir` method from Puppetfile DSL. Users should use `environment_name` instead. [#1254](https://github.com/puppetlabs/r10k/pull/1254)
 
 3.14.0
 ------

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -167,13 +167,6 @@ module R10K
         @modules << mod
       end
 
-      # @deprecated
-      # @return [String] The base directory that contains the Puppetfile
-      def basedir
-        logger.warn _('"basedir" is deprecated. Please use "environment_name" instead. "basedir" will be removed in a future version.')
-        @basedir
-      end
-
      private
 
       def empty_load_output


### PR DESCRIPTION
Users should switch to the new, more explicit `environment_name` method
in their Puppetfiles.