### PR TITLE
(maint) Make travis and GH Actions do the right thing on the 4.x branch

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -3,7 +3,7 @@ name: Rspec tests
 on:
   pull_request:
     branches:
-      - main
+      - 4.x
 
 jobs:
   rspec_tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 ---
 language: ruby
 bundler_args: "--without system"
-script: "bundle exec rspec --color --format documentation spec"
 notifications:
   email: false
 sudo: false
-jdk:
-  - openjdk11
-before_install: gem install bundler -v '< 2' --no-document
-matrix:
+jobs:
   include:
-    - stage: r10k tests
-      rvm: 2.3.0
     - stage: r10k container tests
       dist: focal
       language: ruby


### PR DESCRIPTION
This drops Ruby 2.3 testing from Travis, in preparation for us dropping
support for that version, leaving just container testing in Travis. It
also updates the spec and release Github Actions to trigger on relevant
actions on the 4.x branch.
