### PR TITLE
(CODEMGMT-1295) Update default module git branch to `main`

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -8,6 +8,7 @@ Unreleased
 - (RK-386) Remove deprecated `bare` environment type. [#1235](https://github.com/puppetlabs/r10k/issues/1235)
 - Refactor internal module creation to always expect a hash, even for Forge modules, which can be specified in the Puppetfile with just a version string. [#1170](https://github.com/puppetlabs/r10k/pull/1170)
 - Drop EoL Ruby 2.3/2.4 support [#1280](https://github.com/puppetlabs/r10k/pull/1208)
+- (CODEMGMT-1295) Change default branch for git modules to `main`. [#1258](https://github.com/puppetlabs/r10k/pull/1258)
 
 3.14.0
 ------

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -70,7 +70,7 @@ class R10K::Module::Git < R10K::Module::Base
     force = @overrides.dig(:modules, :force)
     @force = force == false ? false : true
 
-    @desired_ref ||= 'master'
+    @desired_ref ||= 'main'
 
     if @desired_ref == :control_branch
       if @environment && @environment.respond_to?(:ref)

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -90,7 +90,7 @@ describe R10K::Module::Git do
     end
 
     before(:each) do
-      allow(mock_repo).to receive(:resolve).with('master').and_return('abc123')
+      allow(mock_repo).to receive(:resolve).with('main').and_return('abc123')
       allow(mock_repo).to receive(:head).and_return('abc123')
     end
 
@@ -99,7 +99,7 @@ describe R10K::Module::Git do
     end
 
     it "sets the expected version" do
-      expect(subject.properties).to include(:expected => 'master')
+      expect(subject.properties).to include(:expected => 'main')
     end
 
     it "sets the actual version to the revision when the revision is available" do
@@ -122,7 +122,7 @@ describe R10K::Module::Git do
     subject { described_class.new(title, dirname, {}) }
 
     before(:each) do
-      allow(mock_repo).to receive(:resolve).with('master').and_return('abc123')
+      allow(mock_repo).to receive(:resolve).with('main').and_return('abc123')
     end
 
     it 'defaults to keeping the spec dir' do
@@ -159,8 +159,8 @@ describe R10K::Module::Git do
     end
 
     it "delegates to the repo" do
-      expect(subject).to receive(:version).and_return 'master'
-      expect(mock_repo).to receive(:status).with('master').and_return :some_status
+      expect(subject).to receive(:version).and_return 'main'
+      expect(mock_repo).to receive(:status).with('main').and_return :some_status
 
       expect(subject.status).to eq(:some_status)
     end
@@ -179,10 +179,10 @@ describe R10K::Module::Git do
 
     describe "desired ref" do
       context "when no desired ref is given" do
-        it "defaults to master" do
-          expect(mock_repo).to receive(:resolve).with('master').and_return('abc123')
+        it "defaults to main" do
+          expect(mock_repo).to receive(:resolve).with('main').and_return('abc123')
 
-          expect(test_module({}).properties).to include(expected: 'master')
+          expect(test_module({}).properties).to include(expected: 'main')
         end
       end
 


### PR DESCRIPTION
The git ecosystem in general and the Puppet module ecosystem in
particular are moving from `master` as the default branch to `main`.
This commit updates r10k's default to match this shift.

Now, if a git module is defined in a Puppetfile with no ref specified,
r10k will attempt to deploy its `main` branch. If this is undesirable
for a user's module, they should specify a ref explicitly to use
instead.
