### PR TITLE
(RK-388) Add splat operators to avoid warnings on Ruby 2.7

### DIFF
--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -64,7 +64,7 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     results = nil
 
     R10K::Git.with_proxy(proxy) do
-      results = with_repo { |repo| repo.fetch(remote_name, refspecs, options) }
+      results = with_repo { |repo| repo.fetch(remote_name, refspecs, **options) }
     end
 
     report_transfer(results, remote_name)

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -93,7 +93,7 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
     results = nil
 
     R10K::Git.with_proxy(proxy) do
-      results = with_repo { |repo| repo.fetch(remote_name, refspecs, options) }
+      results = with_repo { |repo| repo.fetch(remote_name, refspecs, **options) }
     end
 
     report_transfer(results, remote)


### PR DESCRIPTION
Rugged's Repository's `fetch` method expects the last set of args to be
a series of keyword arugments. Previously, we were passing these as a
hash, but this became deprecated in Ruby 2.7, and now issues a warning.
This commit updates the calls to use a splat operator instead, which
avoids the warning.
