### PR TITLE
(maint) Add `r10k.log` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 integration/log
 integration/junit
 integration/configs
+r10k.log


### PR DESCRIPTION
This file is generated when running rspec tests locally.
