### PR TITLE
(RK-393) Don't modify base module overrides

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- (RK-393) Bug fix: not all spec directories are deleted when :exclude_spec is true [#1267](https://github.com/puppetlabs/r10k/pull/1267)
 - Refactor internal module creation to always expect a hash, even for Forge modules, which can be specified in the Puppetfile with just a version string. [#1170](https://github.com/puppetlabs/r10k/pull/1170)
 
 3.14.0

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -61,7 +61,7 @@ class R10K::Module::Base
     @overrides = args.delete(:overrides) || {}
     @spec_deletable = true
     @exclude_spec = args.delete(:exclude_spec)
-    @exclude_spec = @overrides[:modules].delete(:exclude_spec) if @overrides.dig(:modules, :exclude_spec)
+    @exclude_spec = @overrides.dig(:modules, :exclude_spec) if @overrides.dig(:modules, :exclude_spec)
     @origin = 'external' # Expect Puppetfile or R10k::Environment to set this to a specific value
 
     @requested_modules = @overrides.dig(:modules, :requested_modules) || []

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -80,7 +80,8 @@ describe R10K::ModuleLoader::Puppetfile do
   describe 'adding modules' do
     let(:basedir) { '/test/basedir' }
 
-    subject { R10K::ModuleLoader::Puppetfile.new(basedir: basedir) }
+    subject { R10K::ModuleLoader::Puppetfile.new(basedir: basedir,
+                                                 overrides: {modules: {exclude_spec: true}}) }
 
     it 'should transform Forge modules with a string arg to have a version key' do
       expect(R10K::Module).to receive(:from_metadata).with('puppet/test_module', subject.moduledir, hash_including(version: '1.2.3'), anything).and_call_original
@@ -97,6 +98,12 @@ describe R10K::ModuleLoader::Puppetfile do
       }.to raise_error(ArgumentError, /module version .* is not a valid forge module version/i)
 
       expect(subject.modules.collect(&:name)).not_to include('test_module')
+    end
+
+    it 'should not modify the overrides when adding modules' do
+      module_opts = { git: 'git@example.com:puppet/test_module.git' }
+      subject.add_module('puppet/test_module', module_opts)
+      expect(subject.instance_variable_get("@overrides")[:modules]).to eq({exclude_spec: true})
     end
 
     it 'should set :spec_deletable to true for modules in the basedir' do


### PR DESCRIPTION
The base module class would modify the overrides supplied from
the puppetfile module loader; this ends up corrupting every
subsequent #add_module call. This change only reads that value
into the `exclude_spec` instance var for the module base class.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
