### PR TITLE
(RK-395) Allow Puppetfile override for exclude_spec

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- (RK-395) Make `exclude_spec` from a Puppetfile the priority override [#1271](https://github.com/puppetlabs/r10k/issues/1271)
 - (RK-394) Fix `force` always resolving to true for `puppetfile install` [#1269](https://github.com/puppetlabs/r10k/issues/1265)
 - (RK-393) Bug fix: not all spec directories are deleted when :exclude_spec is true [#1267](https://github.com/puppetlabs/r10k/pull/1267)
 - Refactor internal module creation to always expect a hash, even for Forge modules, which can be specified in the Puppetfile with just a version string. [#1170](https://github.com/puppetlabs/r10k/pull/1170)

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -373,12 +373,13 @@ deploy:
 
 #### exclude_spec
 
-During module deployment, r10k's default behavior is to deploy the spec directory.
-This behavior can be configured for all modules using the `exclude_spec` setting in the r10k config.
-This config setting can be overridden in each module definition in the Puppetfile
-or more globally via the CLI for deploys. The following example sets all modules to
-not deploy the spec dir.
-
+During module deployment, r10k's default behavior is to deploy the spec directory. Setting
+`exclude_spec` to true will deploy modules without their spec directory. This behavior
+can be configured for all modules using the `exclude_spec` setting in the r10k config.
+It can also be passed as a CLI argument for `deploy environment/module`, overriding the
+r10k config. Setting this per module in a `Puppetfile` will override the default, r10k config,
+and cli flag for that module. The following example sets all modules to not deploy the spec
+dir via the r10k config.
 
 ```yaml
 deploy:

--- a/lib/r10k/module/base.rb
+++ b/lib/r10k/module/base.rb
@@ -60,8 +60,12 @@ class R10K::Module::Base
     @environment = environment
     @overrides = args.delete(:overrides) || {}
     @spec_deletable = true
-    @exclude_spec = args.delete(:exclude_spec)
+    @exclude_spec = false
     @exclude_spec = @overrides.dig(:modules, :exclude_spec) if @overrides.dig(:modules, :exclude_spec)
+    if args.has_key?(:exclude_spec)
+      logger.debug2 _("Overriding :exclude_spec setting with per module setting for #{@title}")
+      @exclude_spec = args.delete(:exclude_spec)
+    end
     @origin = 'external' # Expect Puppetfile or R10k::Environment to set this to a specific value
 
     @requested_modules = @overrides.dig(:modules, :requested_modules) || []

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -106,6 +106,12 @@ describe R10K::ModuleLoader::Puppetfile do
       expect(subject.instance_variable_get("@overrides")[:modules]).to eq({exclude_spec: true})
     end
 
+    it 'should read the `exclude_spec` setting in the module definition and override the overrides' do
+      module_opts = { git: 'git@example.com:puppet/test_module.git', exclude_spec: false }
+      subject.add_module('puppet/test_module', module_opts)
+      expect(subject.modules[0].instance_variable_get("@exclude_spec")).to be false
+    end
+
     it 'should set :spec_deletable to true for modules in the basedir' do
       module_opts = { git: 'git@example.com:puppet/test_module.git' }
       subject.add_module('puppet/test_module', module_opts)

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -90,12 +90,21 @@ describe R10K::Module do
         }.not_to raise_error
       end
       describe 'the exclude_spec setting' do
+        it 'sets the exclude_spec instance variable to false by default' do
+          obj = R10K::Module.new(name, '/modulepath', options)
+          expect(obj.instance_variable_get("@exclude_spec")).to eq(false)
+        end
         it 'sets the exclude_spec instance variable' do
           obj = R10K::Module.new(name, '/modulepath', options.merge({exclude_spec: true}))
           expect(obj.instance_variable_get("@exclude_spec")).to eq(true)
         end
-        it 'can be overridden by the overrides map' do
-          options = options.merge({exclude_spec: false, overrides: {modules: {exclude_spec: true}}})
+        it 'cannot be overridden by the settings from the cli, r10k.yaml, or settings default' do
+          options = options.merge({exclude_spec: true, overrides: {modules: {exclude_spec: false}}})
+          obj = R10K::Module.new(name, '/modulepath', options)
+          expect(obj.instance_variable_get("@exclude_spec")).to eq(true)
+        end
+        it 'reads the setting from the cli, r10k.yaml, or settings default when not provided directly' do
+          options = options.merge({overrides: {modules: {exclude_spec: true}}})
           obj = R10K::Module.new(name, '/modulepath', options)
           expect(obj.instance_variable_get("@exclude_spec")).to eq(true)
         end


### PR DESCRIPTION
Previously, the r10k setting `exclude_spec` read in the settings
from the puppetfile first, and then overrode it with the setting
that comes from the defaults, r10k.yaml, or the cli. In order to
support PE customers who want to override the r10k.yaml setting
per module, the puppetfile setting should win out.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
