### PR TITLE
(maint) Update to windows 2019 for spec testing

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -16,9 +16,9 @@ jobs:
           - {os: ubuntu-18.04, ruby: 2.6}
           - {os: ubuntu-18.04, ruby: 2.7}
           - {os: ubuntu-18.04, ruby: jruby-9.2.10.0}
-          - {os: windows-2016, ruby: 2.5}
-          - {os: windows-2016, ruby: 2.6}
-          - {os: windows-2016, ruby: 2.7}
+          - {os: windows-2019, ruby: 2.5}
+          - {os: windows-2019, ruby: 2.6}
+          - {os: windows-2019, ruby: 2.7}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:


### PR DESCRIPTION
Windows Server 2016 is being deprecated and will be removed March
15 2022; this change updates our spec tests to use 2019.

https://github.com/actions/virtual-environments/issues/4312

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
