### PR TITLE
(RK-390) Remove hardcoded default for git ref

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,12 +4,12 @@ CHANGELOG
 Unreleased
 ----------
 
+- (RK-390) Remove default ref for deploying git modules [#1275](http://github.com/puppetlabs/r10k/pull/1275)
 - (RK-391) Change `exclude_spec` default to true for module spec dir deletion [#1264](https://github.com/puppetlabs/r10k/pull/1261)
 - (maint) Add Ruby 3.0 to rspec CI matrix [#1261](https://github.com/puppetlabs/r10k/pull/1261)
 - (RK-383) Remove deprecated `basedir` method from Puppetfile DSL. Users should use `environment_name` instead. [#1254](https://github.com/puppetlabs/r10k/pull/1254)
 - (RK-386) Remove deprecated `bare` environment type. [#1235](https://github.com/puppetlabs/r10k/issues/1235)
 - Drop EoL Ruby 2.3/2.4 support [#1280](https://github.com/puppetlabs/r10k/pull/1208)
-- (CODEMGMT-1295) Change default branch for git modules to `main`. [#1258](https://github.com/puppetlabs/r10k/pull/1258)
 
 3.14.1
 ------

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -100,7 +100,8 @@ regarding Git providers.
 
 r10k is unable to deploy a git module if no `ref` is specified. A `default_ref` can be
 set in the r10k config that will become the ref a module uses if not otherwise specified. This
-is the lowest priority setting for a module's `ref`. Read [here](../puppetfile.mkd#git) for more info.
+is the lowest priority setting for a module's `ref`. Read the [Puppetfile documentation](../puppetfile.mkd#git)
+for higher priority settings to determine a module's ref.
 
 ```yaml
 git:

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -96,6 +96,17 @@ git:
 See the [git provider documentation](../git/providers.mkd) for more information
 regarding Git providers.
 
+#### default_ref
+
+r10k is unable to deploy a git module if no `ref` is specified. A `default_ref` can be
+set in the r10k config that will become the ref a module uses if not otherwise specified. This
+is the lowest priority setting for a module's `ref`. Read [here](../puppetfile.mkd#git) for more info.
+
+```yaml
+git:
+  default_ref: main
+```
+
 #### proxy
 
 The 'proxy' setting allows you to set or override the global proxy setting specifically

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -137,7 +137,7 @@ branch reference.
 
 In r10k 3.x the default branch was hardcoded to `master`; in 4.x that was
 removed. A `default_ref` can be specified in the r10k config to
-to mimick that old behavior, but it is recommended to set the ref on a
+to mimic that old behavior, but it is recommended to set the ref on a
 per-module basis in the Puppetfile. Read [here](dynamic-environments/configuration.mkd#default_ref) for more info
 on the `default_ref` setting.
 

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -137,7 +137,9 @@ branch reference.
 
 In r10k 3.x the default branch was hardcoded to `master`; in 4.x that was
 removed. A `default_ref` can be specified in the r10k config to
-to mimick that old behavior, read [here](dynamic-environments/configuration.mkd#default_ref) for more info.
+to mimick that old behavior, but it is recommended to set the ref on a
+per-module basis in the Puppetfile. Read [here](dynamic-environments/configuration.mkd#default_ref) for more info
+on the `default_ref` setting.
 
 #### Examples
 

--- a/doc/puppetfile.mkd
+++ b/doc/puppetfile.mkd
@@ -135,6 +135,10 @@ operations when updating the repo, which can speed up install times. When
 Module versions can also be specified using `:branch` to track a specific
 branch reference.
 
+In r10k 3.x the default branch was hardcoded to `master`; in 4.x that was
+removed. A `default_ref` can be specified in the r10k config to
+to mimick that old behavior, read [here](dynamic-environments/configuration.mkd#default_ref) for more info.
+
 #### Examples
 
 ```ruby

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -45,6 +45,7 @@ module R10K
                 incremental: @incremental
               },
               modules: {
+                default_ref: settings.dig(:git, :default_ref),
                 exclude_spec: settings.dig(:deploy, :exclude_spec),
                 requested_modules: [],
                 deploy_modules: @modules,

--- a/lib/r10k/action/deploy/module.rb
+++ b/lib/r10k/action/deploy/module.rb
@@ -39,6 +39,7 @@ module R10K
                 generate_types: @generate_types
               },
               modules: {
+                default_ref: settings.dig(:git, :default_ref),
                 exclude_spec: settings.dig(:deploy, :exclude_spec),
                 pool_size: @settings[:pool_size] || 4,
                 requested_modules: @argv.map.to_a,

--- a/lib/r10k/action/puppetfile/check.rb
+++ b/lib/r10k/action/puppetfile/check.rb
@@ -9,12 +9,19 @@ module R10K
 
         def call
           options = { basedir: @root }
+          options[:overrides] = {}
+          options[:overrides][:modules] = { default_ref: @settings.dig(:git, :default_ref) }
           options[:moduledir] = @moduledir if @moduledir
           options[:puppetfile] = @puppetfile if @puppetfile
 
           loader = R10K::ModuleLoader::Puppetfile.new(**options)
           begin
             loader.load!
+            loader.modules.each do |mod|
+              if mod.instance_of?(R10K::Module::Git)
+                mod.validate_ref_defined
+              end
+            end
             $stderr.puts _("Syntax OK")
             true
           rescue => e

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -12,6 +12,7 @@ module R10K
         def call
           begin
             options = { basedir: @root, overrides: { force: @force || false } }
+            options[:overrides][:modules] = { default_ref: @settings.dig(:git, :default_ref) }
             options[:moduledir]  = @moduledir  if @moduledir
             options[:puppetfile] = @puppetfile if @puppetfile
 

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -118,7 +118,7 @@ class R10K::Module::Git < R10K::Module::Base
   def validate_ref_defined
     if @desired_ref.nil? && @default_ref.nil? && @default_override_ref.nil?
       msg = "No ref defined for module #{@name}. Add a ref to the module definition "
-      msg << "or add a default in the r10k config for git:default_ref."
+      msg << "or set git:default_ref in the r10k.yaml config to configure a global default ref."
       raise ArgumentError, msg
     end
   end
@@ -155,7 +155,7 @@ class R10K::Module::Git < R10K::Module::Base
         vars[:default] = default
       else
         msg << "and no default provided. r10k no longer hardcodes 'master' as the default ref."
-        msg << "Consider setting this per module in the Puppetfile or setting git:default_ref"
+        msg << "Consider setting a ref per module in the Puppetfile or setting git:default_ref"
         msg << "in your r10k config."
       end
 

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -63,14 +63,13 @@ class R10K::Module::Git < R10K::Module::Base
       :commit                  => :desired_ref,
       :ref                     => :desired_ref,
       :git                     => :remote,
-      :default_branch          => :default_ref,
+      :default_branch          => :default_branch,
       :default_branch_override => :default_override_ref,
     }, :raise_on_unhandled => false)
 
+    @default_ref = @default_branch.nil? ? @overrides.dig(:modules, :default_ref) : @default_branch
     force = @overrides[:force]
     @force = force == false ? false : true
-
-    @desired_ref ||= 'main'
 
     if @desired_ref == :control_branch
       if @environment && @environment.respond_to?(:ref)
@@ -147,7 +146,8 @@ class R10K::Module::Git < R10K::Module::Base
         msg << "or resolve default ref '%{default}'"
         vars[:default] = default
       else
-        msg << "and no default provided"
+        msg << "and no default provided. r10k no longer hardcodes 'master' as the default ref. "
+        msg << "Consider setting git:default_ref in your r10k config."
       end
 
       raise ArgumentError, _(msg.join(' ')) % vars

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -147,7 +147,8 @@ class R10K::Module::Git < R10K::Module::Base
         vars[:default] = default
       else
         msg << "and no default provided. r10k no longer hardcodes 'master' as the default ref. "
-        msg << "Consider setting git:default_ref in your r10k config."
+        msg << "Consider setting this per module in the Puppetfile or setting git:default_ref "
+        msg << "in your r10k config."
       end
 
       raise ArgumentError, _(msg.join(' ')) % vars

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -115,6 +115,14 @@ class R10K::Module::Git < R10K::Module::Base
     @repo.cache.sanitized_dirname
   end
 
+  def validate_ref_defined
+    if @desired_ref.nil? && @default_ref.nil? && @default_override_ref.nil?
+      msg = "No ref defined for module #{@name}. Add a ref to the module definition "
+      msg << "or add a default in the r10k config for git:default_ref."
+      raise ArgumentError, msg
+    end
+  end
+
   private
 
   def validate_ref(desired, default, default_override)
@@ -146,8 +154,8 @@ class R10K::Module::Git < R10K::Module::Base
         msg << "or resolve default ref '%{default}'"
         vars[:default] = default
       else
-        msg << "and no default provided. r10k no longer hardcodes 'master' as the default ref. "
-        msg << "Consider setting this per module in the Puppetfile or setting git:default_ref "
+        msg << "and no default provided. r10k no longer hardcodes 'master' as the default ref."
+        msg << "Consider setting this per module in the Puppetfile or setting git:default_ref"
         msg << "in your r10k config."
       end
 

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -19,6 +19,10 @@ module R10K
     def self.git_settings
       R10K::Settings::Collection.new(:git, [
 
+        Definition.new(:default_ref, {
+          :desc => "User defined default from which to deploy modules when not otherwise specified; nil unless configured via the r10k.yaml config.",
+          :default => nil}),
+
         EnumDefinition.new(:provider, {
           :desc => "The Git provider to use. Valid values: 'shellgit', 'rugged'",
           :normalize => lambda { |input| input.to_sym },

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -20,7 +20,7 @@ module R10K
       R10K::Settings::Collection.new(:git, [
 
         Definition.new(:default_ref, {
-          :desc => "User defined default from which to deploy modules when not otherwise specified; nil unless configured via the r10k.yaml config.",
+          :desc => "User-defined default ref from which to deploy modules when not otherwise specified; nil unless configured via the r10k.yaml config.",
           :default => nil}),
 
         EnumDefinition.new(:provider, {

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -221,7 +221,7 @@ describe R10K::Action::Deploy::Module do
 
   describe 'with modules' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path' }, ['mod1', 'mod2'], {git: {default_ref: 'main'}}) }
+    subject { described_class.new({ config: '/some/nonexistent/path' }, ['mod1', 'mod2'], {}) }
 
     let(:cache) { instance_double("R10K::Git::Cache", 'sanitized_dirname' => 'foo', 'cached?' => true, 'sync' => true) }
     let(:repo) { instance_double("R10K::Git::StatefulRepository", cache: cache, resolve: 'main', tracked_paths: []) }
@@ -253,9 +253,9 @@ describe R10K::Action::Deploy::Module do
         loader = environment.loader
         allow(loader).to receive(:puppetfile_content).and_return('')
         expect(loader).to receive(:load) do
-          loader.add_module('mod1', { git: 'git://remote' })
-          loader.add_module('mod2', { git: 'git://remote' })
-          loader.add_module('mod3', { git: 'git://remote' })
+          loader.add_module('mod1', { git: 'git://remote', default_branch: 'main'})
+          loader.add_module('mod2', { git: 'git://remote', default_branch: 'main'})
+          loader.add_module('mod3', { git: 'git://remote', default_branch: 'main'})
 
           loaded_content = loader.load!
           loaded_content[:modules].each do |mod|
@@ -280,7 +280,7 @@ describe R10K::Action::Deploy::Module do
   end
 
   describe 'with environments' do
-    subject { described_class.new({ config: '/some/nonexistent/path', environment: 'first' }, ['mod1'], {git: {default_ref: 'main'}}) }
+    subject { described_class.new({ config: '/some/nonexistent/path', environment: 'first' }, ['mod1'], {}) }
 
     let(:cache) { instance_double("R10K::Git::Cache", 'sanitized_dirname' => 'foo', 'cached?' => true, 'sync' => true) }
     let(:repo) { instance_double("R10K::Git::StatefulRepository", cache: cache, resolve: 'main', tracked_paths: []) }
@@ -315,8 +315,8 @@ describe R10K::Action::Deploy::Module do
           # it so it will create the correct loaded_content.
           allow(loader).to receive(:puppetfile_content).and_return('')
           expect(loader).to receive(:load) do
-            loader.add_module('mod1', { git: 'git://remote' })
-            loader.add_module('mod2', { git: 'git://remote' })
+            loader.add_module('mod1', { git: 'git://remote', default_branch: 'main'})
+            loader.add_module('mod2', { git: 'git://remote', default_branch: 'main'})
 
             loaded_content = loader.load!
             loaded_content[:modules].each do |mod|

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -221,7 +221,7 @@ describe R10K::Action::Deploy::Module do
 
   describe 'with modules' do
 
-    subject { described_class.new({ config: '/some/nonexistent/path' }, ['mod1', 'mod2'], {}) }
+    subject { described_class.new({ config: '/some/nonexistent/path' }, ['mod1', 'mod2'], {git: {default_ref: 'main'}}) }
 
     let(:cache) { instance_double("R10K::Git::Cache", 'sanitized_dirname' => 'foo', 'cached?' => true, 'sync' => true) }
     let(:repo) { instance_double("R10K::Git::StatefulRepository", cache: cache, resolve: 'main', tracked_paths: []) }
@@ -280,7 +280,7 @@ describe R10K::Action::Deploy::Module do
   end
 
   describe 'with environments' do
-    subject { described_class.new({ config: '/some/nonexistent/path', environment: 'first' }, ['mod1'], {}) }
+    subject { described_class.new({ config: '/some/nonexistent/path', environment: 'first' }, ['mod1'], {git: {default_ref: 'main'}}) }
 
     let(:cache) { instance_double("R10K::Git::Cache", 'sanitized_dirname' => 'foo', 'cached?' => true, 'sync' => true) }
     let(:repo) { instance_double("R10K::Git::StatefulRepository", cache: cache, resolve: 'main', tracked_paths: []) }

--- a/spec/unit/action/puppetfile/install_spec.rb
+++ b/spec/unit/action/puppetfile/install_spec.rb
@@ -3,14 +3,16 @@ require 'r10k/action/puppetfile/install'
 
 describe R10K::Action::Puppetfile::Install do
   let(:default_opts) { { root: "/some/nonexistent/path" } }
+  let(:default_settings) { {git: {default_ref: 'main'}} }
   let(:loader) {
     R10K::ModuleLoader::Puppetfile.new(
       basedir: '/some/nonexistent/path',
-      overrides: {force: false})
+      overrides: {force: false, modules: {default_ref: 'main'}})
   }
 
   def installer(opts = {}, argv = [], settings = {})
     opts = default_opts.merge(opts)
+    settings = default_settings.merge(opts)
     return described_class.new(opts, argv, settings)
   end
 
@@ -18,7 +20,7 @@ describe R10K::Action::Puppetfile::Install do
     allow(loader).to receive(:load!).and_return({})
     allow(R10K::ModuleLoader::Puppetfile).to receive(:new).
       with({basedir: "/some/nonexistent/path",
-            overrides: {force: false}}).
+            overrides: {force: false, modules: {default_ref: 'main'}}}).
       and_return(loader)
   end
 
@@ -80,7 +82,7 @@ describe R10K::Action::Puppetfile::Install do
     it "can use a custom moduledir path" do
       expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
         with({basedir: "/some/nonexistent/path",
-              overrides: { force: false },
+              overrides: {force: false, modules: {default_ref: 'main'}},
               puppetfile: "/some/other/path/Puppetfile"}).
         and_return(loader)
 
@@ -88,7 +90,7 @@ describe R10K::Action::Puppetfile::Install do
 
       expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
         with({basedir: "/some/nonexistent/path",
-              overrides: { force: false },
+              overrides: {force: false, modules: {default_ref: 'main'}},
               moduledir: "/some/other/path/site-modules"}).
         and_return(loader)
 
@@ -100,10 +102,10 @@ describe R10K::Action::Puppetfile::Install do
     it "can use the force overwrite option" do
       allow(loader).to receive(:load!).and_return({ modules: [] })
 
-      subject = described_class.new({root: "/some/nonexistent/path", force: true}, [], {})
+      subject = described_class.new({root: "/some/nonexistent/path", force: true}, [], {git: {default_ref: 'main'}})
       expect(R10K::ModuleLoader::Puppetfile).to receive(:new).
         with({basedir: "/some/nonexistent/path",
-              overrides: { force: true }}).
+              overrides: {force: true, modules: {default_ref: 'main'}}}).
         and_return(loader)
       subject.call
     end


### PR DESCRIPTION
Previously r10k fell back to the 'main' ref if no other ref was
specified. With this patch, r10k will no longer fall back to that
ref, and error when no ref is found.

To mitigate breakage relying on the hardcoded ref, a user can
set `default_ref` in the r10k config to a ref of their
choice, mimicking the old behavior.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
