### PR TITLE
(RK-368) remove "purge_whitelist" setting

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- (RK-368) remove `purge_whitelist` setting [#1277](https://github.com/puppetlabs/r10k/pull/1277)
 - (RK-390) Remove default ref for deploying git modules [#1275](http://github.com/puppetlabs/r10k/pull/1275)
 - (RK-391) Change `exclude_spec` default to true for module spec dir deletion [#1264](https://github.com/puppetlabs/r10k/pull/1261)
 - (maint) Add Ruby 3.0 to rspec CI matrix [#1261](https://github.com/puppetlabs/r10k/pull/1261)

--- a/integration/tests/purging/does_not_purge_files_on_allowlist.rb
+++ b/integration/tests/purging/does_not_purge_files_on_allowlist.rb
@@ -1,7 +1,7 @@
 require 'git_utils'
 require 'r10k_utils'
 require 'master_manipulator'
-test_name 'RK-257 - C98046 - r10k does not purge files on whitelist'
+test_name 'RK-257 - C98046 - r10k does not purge files on allowlist'
 
 #Init
 env_path = on(master, puppet('config print environmentpath')).stdout.rstrip
@@ -42,7 +42,7 @@ sources:
     remote: "#{git_control_remote}"
 deploy:
   purge_levels: ['deployment', 'environment', 'puppetfile']
-  purge_whitelist: ['**/*.pp']
+  purge_allowlist: ['**/*.pp']
 CONF
 
 step 'Update the "r10k" Config'

--- a/lib/r10k/action/deploy/environment.rb
+++ b/lib/r10k/action/deploy/environment.rb
@@ -54,8 +54,7 @@ module R10K
               },
               purging: {
                 purge_levels: settings.dig(:deploy, :purge_levels) || [],
-                purge_allowlist: read_purge_allowlist(settings.dig(:deploy, :purge_whitelist) || [],
-                                                      settings.dig(:deploy, :purge_allowlist) || [])
+                purge_allowlist: settings.dig(:deploy, :purge_allowlist) || []
               },
               forge: {
                 allow_puppetfile_override: settings.dig(:forge, :allow_puppetfile_override) || false
@@ -83,23 +82,6 @@ module R10K
         end
 
         private
-
-        def read_purge_allowlist (whitelist, allowlist)
-          whitelist_has_content = !whitelist.empty?
-          allowlist_has_content = !allowlist.empty?
-          case
-          when whitelist_has_content == false && allowlist_has_content == false
-            []
-          when whitelist_has_content && allowlist_has_content
-            raise R10K::Error.new "Values found for both purge_whitelist and purge_allowlist. Setting " <<
-                                  "purge_whitelist is deprecated, please only use purge_allowlist."
-          when allowlist_has_content
-            allowlist
-          else
-            logger.warn "Setting purge_whitelist is deprecated; please use purge_allowlist instead."
-            whitelist
-          end
-        end
 
         def visit_deployment(deployment)
           # Ensure that everything can be preloaded. If we cannot preload all

--- a/lib/r10k/settings.rb
+++ b/lib/r10k/settings.rb
@@ -179,11 +179,6 @@ module R10K
           :default => [],
         }),
 
-        Definition.new(:purge_whitelist, {
-          :desc => "Deprecated; please use purge_allowlist instead. This setting will be removed in a future version.",
-          :default => [],
-        }),
-
         Definition.new(:generate_types, {
           :desc => "Controls whether to generate puppet types after deploying an environment. Defaults to false.",
           :default => false,

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -66,17 +66,6 @@ describe R10K::Action::Deploy::Environment do
     it 'can accept an incremental option' do
       described_class.new({ :incremental => true }, [], {})
     end
-
-    describe "initializing errors" do
-      let (:settings) { { deploy: { purge_levels: [:environment],
-                                    purge_whitelist: ['coolfile', 'coolfile2'],
-                                    purge_allowlist: ['anothercoolfile']}}}
-
-      subject { described_class.new({config: "/some/nonexistent/path"}, [], settings)}
-      it 'errors out when both purge_whitelist and purge_allowlist are set' do
-        expect{subject}.to raise_error(R10K::Error, /Values found for both purge_whitelist and purge_allowlist./)
-    end
-   end
   end
 
   describe "when called" do
@@ -269,7 +258,7 @@ describe R10K::Action::Deploy::Environment do
       end
     end
 
-    describe "Purging white/allowlist" do
+    describe "Purging allowlist" do
 
       let(:settings) { { pool_size: 4, deploy: { purge_levels: [:environment], purge_allowlist: ['coolfile', 'coolfile2'] } } }
       let(:overrides) { { environments: {}, modules: { pool_size: 4 }, purging: { purge_levels: [:environment], purge_allowlist: ['coolfile', 'coolfile2'] } } }
@@ -287,16 +276,6 @@ describe R10K::Action::Deploy::Environment do
         expect(subject.logger).to receive(:debug).with(/Purging unmanaged content for environment/)
         expect(subject.settings[:overrides][:purging][:purge_allowlist]).to eq(['coolfile', 'coolfile2'])
         subject.call
-      end
-
-      describe "purge_whitelist" do
-        let (:settings) { { deploy: { purge_levels: [:environment], purge_whitelist: ['coolfile', 'coolfile2'] } } }
-
-        it "reads in the purge_whitelist setting and still sets it to purge_allowlist and purges accordingly" do
-          expect(subject.logger).to receive(:debug).with(/Purging unmanaged content for environment/)
-          expect(subject.settings[:overrides][:purging][:purge_allowlist]).to eq(['coolfile', 'coolfile2'])
-          subject.call
-        end
       end
     end
 


### PR DESCRIPTION
da2c636041299c26bfeeab60e4c0c49e03cf8313 deprecated the "purge_whitelist"
setting in favor of "purge_allowlist". This change removes "purge_whitelist"
entirely.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
