### PR TITLE
(RK-397) Check for module on disk before skipping implementation

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- (RK-397) Ensure `--incremental` does not skip undeployed modules [#1278](https://github.com/puppetlabs/r10k/pull/1278)
+
 3.14.1
 ------
 

--- a/doc/dynamic-environments/usage.mkd
+++ b/doc/dynamic-environments/usage.mkd
@@ -84,6 +84,10 @@ explicit, static version. These are released Forge versions, or Git modules usin
 the `:tag`, or `:commit` keys. Git `:ref`s containing only the full 40 character
 commit SHA will also be treated as static versions. Then invoke a deploy with:
 
+There may be issues with deployments apparently successful after an initial errored
+deployment. If this is happening, try running without the `--incremental` flag
+to run a full deployment.
+
     r10k deploy environment production --modules --incremental
 
 - - -

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -157,11 +157,14 @@ module R10K
           return @modules
         end
 
-        # If this module's metadata has a static version and that version
-        # matches the existing module declaration use it, otherwise create
-        # a regular module to sync.
-        unless mod.version && (mod.version == @existing_module_versions_by_name[mod.name])
-          mod = mod.to_implementation
+        # If this module's metadata has a static version, and that version
+        # matches the existing module declaration, and it ostensibly
+        # has already has been deployed to disk, use it. Otherwise create a
+        # regular module to sync.
+        unless mod.version &&
+               mod.version == @existing_module_versions_by_name[mod.name] &&
+               File.directory?(mod.path)
+            mod = mod.to_implementation
         end
 
         @modules << mod

--- a/spec/fixtures/unit/puppetfile/various-modules/modules/apt/.gitkeep
+++ b/spec/fixtures/unit/puppetfile/various-modules/modules/apt/.gitkeep
@@ -1,0 +1,1 @@
+This only exists so the directory can be committed to git for testing purposes.

--- a/spec/fixtures/unit/puppetfile/various-modules/modules/baz/.gitkeep
+++ b/spec/fixtures/unit/puppetfile/various-modules/modules/baz/.gitkeep
@@ -1,0 +1,1 @@
+This only exists so the directory can be committed to git for testing purposes.

--- a/spec/fixtures/unit/puppetfile/various-modules/modules/buzz/.gitkeep
+++ b/spec/fixtures/unit/puppetfile/various-modules/modules/buzz/.gitkeep
@@ -1,0 +1,1 @@
+This only exists so the directory can be committed to git for testing purposes.

--- a/spec/fixtures/unit/puppetfile/various-modules/modules/canary/.gitkeep
+++ b/spec/fixtures/unit/puppetfile/various-modules/modules/canary/.gitkeep
@@ -1,0 +1,1 @@
+This only exists so the directory can be committed to git for testing purposes.

--- a/spec/fixtures/unit/puppetfile/various-modules/modules/fizz/.gitkeep
+++ b/spec/fixtures/unit/puppetfile/various-modules/modules/fizz/.gitkeep
@@ -1,0 +1,1 @@
+This only exists so the directory can be committed to git for testing purposes.

--- a/spec/fixtures/unit/puppetfile/various-modules/modules/rpm/.gitkeep
+++ b/spec/fixtures/unit/puppetfile/various-modules/modules/rpm/.gitkeep
@@ -1,0 +1,1 @@
+This only exists so the directory can be committed to git for testing purposes.

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -385,7 +385,7 @@ describe R10K::ModuleLoader::Puppetfile do
         expect(metadata['canary']).to eq('0.0.0')
       end
 
-      it 'does not load module implementations for static versioned' do
+      it 'does not load module implementations for static versions unless the module install path does not exist on disk' do
         @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'various-modules')
         subject.load_metadata
         modules = subject.load[:modules].map { |mod| [ mod.name, mod ] }.to_h
@@ -394,7 +394,7 @@ describe R10K::ModuleLoader::Puppetfile do
         expect(modules['concat']).to be_a_kind_of(R10K::Module::Forge)
         expect(modules['rpm']).to be_a_kind_of(R10K::Module::Definition)
         expect(modules['foo']).to be_a_kind_of(R10K::Module::Git)
-        expect(modules['bar']).to be_a_kind_of(R10K::Module::Definition)
+        expect(modules['bar']).to be_a_kind_of(R10K::Module::Git)
         expect(modules['baz']).to be_a_kind_of(R10K::Module::Definition)
         expect(modules['fizz']).to be_a_kind_of(R10K::Module::Definition)
         expect(modules['buzz']).to be_a_kind_of(R10K::Module::Git)


### PR DESCRIPTION
Prior to this change, the puppetfile module loader would check
to see if the static version changed after an environment sync.
However, if the static version failed to deploy, this check
would prevent a deploy from re-attempting to deploy that
static version. This results in deploys returning without
error because it never re-attempts to deploy the invalid static
version.

This change just ensures that the install path for the module
also exists before skipping, so we can be reasonably certain that
what is installed on disk is the version r10k expects.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
