### PR TITLE
(maint) Replace `git://` protocol with `https://`

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -61,7 +61,7 @@ for installation.
 If you have more specific needs or plan on modifying r10k you can run it out of
 a git repository using Bundler for dependencies:
 
-    git clone git://github.com/puppetlabs/r10k
+    git clone https://github.com/puppetlabs/r10k
     cd r10k
     bundle install
     bundle exec r10k help

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -404,7 +404,7 @@ passwords cannot be prompted for in order to fetch the remote.
 ---
 sources:
   mysource:
-    remote: 'git://git-server.site/my-org/main-modules'
+    remote: 'https://git-server.site/my-org/main-modules'
 ```
 
 ### basedir
@@ -522,7 +522,7 @@ hiera data files are kept. In this case you will specify a single source:
 ---
 sources:
   operations:
-    remote: 'git://git-server.site/my-org/org-modules'
+    remote: 'https://git-server.site/my-org/org-modules'
     basedir: '/etc/puppet/environments'
 ```
 
@@ -535,10 +535,10 @@ repository and your modules in another repository, you can specify two sources:
 ---
 sources:
   operations:
-    remote: 'git://git-server.site/my-org/org-modules'
+    remote: 'https://git-server.site/my-org/org-modules'
     basedir: '/etc/puppet/environments'
   hiera:
-    remote: 'git://git-server.site/my-org/org-hiera-data'
+    remote: 'https://git-server.site/my-org/org-hiera-data'
     basedir: '/etc/puppet/hiera-data'
 ```
 
@@ -553,15 +553,15 @@ not the modules of other groups.
 ---
 sources:
   main:
-    remote: 'git://git-server.site/my-org/main-modules'
+    remote: 'https://git-server.site/my-org/main-modules'
     basedir: '/etc/puppet/environments'
     prefix: false # Prefix defaults to false so this is only here for clarity
   qa:
-    remote: 'git://git-server.site/my-org/qa-puppet-modules'
+    remote: 'https://git-server.site/my-org/qa-puppet-modules'
     basedir: '/etc/puppet/environments'
     prefix: true
   dev:
-    remote: 'git://git-server.site/my-org/dev-puppet-modules'
+    remote: 'https://git-server.site/my-org/dev-puppet-modules'
     basedir: '/etc/puppet/environments'
     prefix: true
 ```
@@ -587,11 +587,11 @@ must override the `prefix` so environment folders line up in both directories:
 ---
 sources:
   app1_data:
-    remote: 'git://git-server.site/my-org/app1-hieradata'
+    remote: 'https://git-server.site/my-org/app1-hieradata'
     basedir: '/etc/puppet/hieradata'
     prefix: "app1"
   app1_modules:
-    remote: 'git://git-server.site/my-org/app1-puppet-modules'
+    remote: 'https://git-server.site/my-org/app1-puppet-modules'
     basedir: '/etc/puppet/environments'
     prefix: "app1"
 ```

--- a/doc/dynamic-environments/configuration.mkd
+++ b/doc/dynamic-environments/configuration.mkd
@@ -398,7 +398,10 @@ specific documentation for more information.
 The 'remote' setting specifies where the source repository should be fetched
 from. It may be any valid URL that the source may check out or clone. The remote
 must be able to be fetched without any interactive input, eg usernames or
-passwords cannot be prompted for in order to fetch the remote.
+passwords cannot be prompted for in order to fetch the remote. We support the
+`git`, `ssh`, and `https` transport protocols. An SSH private key or access
+token must be provided for authentication. Only `https` may be used without
+authentication. See [GitHub's blog on protocol security](https://github.blog/2021-09-01-improving-git-protocol-security-github/) for more info.
 
 ```yaml
 ---

--- a/doc/dynamic-environments/workflow-guide.mkd
+++ b/doc/dynamic-environments/workflow-guide.mkd
@@ -38,7 +38,7 @@ mod "puppetlabs/ntp"
 
 # Your modules:
 mod "custom_facts",
-  :git => "git://github.com/user/custom_facts"
+  :git => "https://github.com/user/custom_facts"
 ```
 
 For any existing modules that you branched, add a reference to the new branch
@@ -46,7 +46,7 @@ name. Don't forget the comma at the end of the *:git* value.
 
 ```
 mod "other_module",
-  :git => "git://github.com/user/other_module",
+  :git => "https://github.com/user/other_module",
   :ref => "feature"
 ```
 
@@ -159,7 +159,7 @@ the *:git* value.
 
 ```
 mod "other_module",
-  :git => "git://github.com/user/other_module",
+  :git => "https://github.com/user/other_module",
   :ref => "feature"
 ```
 

--- a/integration/tests/git_source/HTTP_proxy_and_git_source.rb
+++ b/integration/tests/git_source/HTTP_proxy_and_git_source.rb
@@ -16,7 +16,7 @@ r10k_config_bak_path = "#{r10k_config_path}.bak"
 
 puppetfile =<<-EOS
 mod 'motd',
-  :git    => 'git://github.com/puppetlabs/puppetlabs-motd'
+  :git    => 'https://github.com/puppetlabs/puppetlabs-motd'
 EOS
 
 proxy_env_value = 'http://cattastic.net:3219'

--- a/integration/tests/git_source/git_source_repeated_remote.rb
+++ b/integration/tests/git_source/git_source_repeated_remote.rb
@@ -29,11 +29,11 @@ CONF
 # Install the same module in two different places
 puppetfile = <<-EOS
 mod 'prod_apache',
-  :git => 'git://github.com/puppetlabs/puppetlabs-apache.git',
+  :git => 'https://github.com/puppetlabs/puppetlabs-apache.git',
   :tag => 'v6.0.0'
 
 mod 'test_apache',
-  :git => 'git://github.com/puppetlabs/puppetlabs-apache.git',
+  :git => 'https://github.com/puppetlabs/puppetlabs-apache.git',
   :tag => 'v6.0.0'
 EOS
 

--- a/integration/tests/purging/content_not_purged_at_root.rb
+++ b/integration/tests/purging/content_not_purged_at_root.rb
@@ -30,12 +30,12 @@ CONF
 puppetfile = <<-EOS
 mod 'non_module_object_1',
   :install_path => './',
-  :git => 'git://github.com/puppetlabs/control-repo.git',
+  :git => 'https://github.com/puppetlabs/control-repo.git',
   :branch => 'production'
 
 mod 'non_module_object_2',
  :install_path => '',
- :git => 'git://github.com/puppetlabs/control-repo.git',
+ :git => 'https://github.com/puppetlabs/control-repo.git',
   :branch => 'production'
 EOS
 

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
@@ -27,7 +27,7 @@ stdlib_notify_message_regex = /The test message is:.*one.*=>.*1.*two.*=>.*bats.*
 puppet_file = <<-PUPPETFILE
 mod "puppetlabs/motd"
 mod 'puppetlabs/stdlib',
-  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git',
+  :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git',
   :tag => 'v7.0.1'
 PUPPETFILE
 

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
@@ -31,7 +31,7 @@ puppet_file = <<-PUPPETFILE
 moduledir '#{@module_path}'
 mod "puppetlabs/motd"
 mod 'puppetlabs/stdlib',
-  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git',
+  :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git',
   :tag => 'v7.0.1'
 PUPPETFILE
 

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -65,7 +65,7 @@ env_structs = {:production => GitEnv.new('/git_repos',
                                          '/git_repos_alt/environments_alt.git',
                                          '/root/environments_alt',
                                          '/root/environments_alt/Puppetfile',
-                                         'mod "puppetlabs/stdlib", :git => "git://github.com/puppetlabs/puppetlabs-stdlib.git", :tag => "v7.0.1"',
+                                         'mod "puppetlabs/stdlib", :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git", :tag => "v7.0.1"',
                                          '/root/environments_alt/manifests/site.pp',
                                          create_site_pp(master_certname, stage_env_manifest)
                                         ),

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
@@ -15,7 +15,7 @@ r10k_fqp = get_r10k_fqp(master)
 
 #File
 puppet_file = <<-PUPPETFILE
-mod 'broken', :git => 'git://github.com/puppetlabs/puppetlabs-broken'
+mod 'broken', :git => 'https://github.com/puppetlabs/puppetlabs-broken'
 PUPPETFILE
 
 puppet_file_path = File.join(git_environments_path, 'Puppetfile')

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module_ref.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module_ref.rb
@@ -12,7 +12,7 @@ r10k_fqp = get_r10k_fqp(master)
 #File
 puppet_file = <<-PUPPETFILE
 mod 'broken',
-  :git => 'git://github.com/puppetlabs/puppetlabs-motd',
+  :git => 'https://github.com/puppetlabs/puppetlabs-motd',
   :ref => 'does_not_exist'
 PUPPETFILE
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
@@ -28,7 +28,7 @@ notify_message_regex = /I am in the production environment/
 puppet_file = <<-PUPPETFILE
 mod "puppetlabs/motd"
 mod 'puppetlabs/inifile',
-  :git => 'git://github.com/puppetlabs/puppetlabs-inifile',
+  :git => 'https://github.com/puppetlabs/puppetlabs-inifile',
   :tag => 'v5.0.1'
 PUPPETFILE
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_switch_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_switch_forge_git_module.rb
@@ -27,7 +27,7 @@ PUPPETFILE
 
 puppet_file_git = <<-PUPPETFILE
 mod "puppetlabs/motd",
-  :git => 'git://github.com/puppetlabs/puppetlabs-motd',
+  :git => 'https://github.com/puppetlabs/puppetlabs-motd',
   :tag => '1.2.0'
 PUPPETFILE
 

--- a/spec/unit/action/deploy/module_spec.rb
+++ b/spec/unit/action/deploy/module_spec.rb
@@ -231,7 +231,7 @@ describe R10K::Action::Deploy::Module do
         original.call(settings.merge({
           sources: {
             main: {
-              remote: 'git://not/a/remote',
+              remote: 'https://not/a/remote',
               basedir: '/not/a/basedir',
               type: 'git'
             }
@@ -253,9 +253,9 @@ describe R10K::Action::Deploy::Module do
         loader = environment.loader
         allow(loader).to receive(:puppetfile_content).and_return('')
         expect(loader).to receive(:load) do
-          loader.add_module('mod1', { git: 'git://remote' })
-          loader.add_module('mod2', { git: 'git://remote' })
-          loader.add_module('mod3', { git: 'git://remote' })
+          loader.add_module('mod1', { git: 'https://remote' })
+          loader.add_module('mod2', { git: 'https://remote' })
+          loader.add_module('mod3', { git: 'https://remote' })
 
           loaded_content = loader.load!
           loaded_content[:modules].each do |mod|
@@ -290,7 +290,7 @@ describe R10K::Action::Deploy::Module do
         original.call(settings.merge({
           sources: {
             main: {
-              remote: 'git://not/a/remote',
+              remote: 'https://not/a/remote',
               basedir: '/not/a/basedir',
               type: 'git'
             }
@@ -315,8 +315,8 @@ describe R10K::Action::Deploy::Module do
           # it so it will create the correct loaded_content.
           allow(loader).to receive(:puppetfile_content).and_return('')
           expect(loader).to receive(:load) do
-            loader.add_module('mod1', { git: 'git://remote' })
-            loader.add_module('mod2', { git: 'git://remote' })
+            loader.add_module('mod1', { git: 'https://remote' })
+            loader.add_module('mod2', { git: 'https://remote' })
 
             loaded_content = loader.load!
             loaded_content[:modules].each do |mod|

--- a/spec/unit/environment/git_spec.rb
+++ b/spec/unit/environment/git_spec.rb
@@ -9,7 +9,7 @@ describe R10K::Environment::Git do
       '/some/nonexistent/environmentdir',
       'gitref',
       {
-        :remote => 'git://git-server.site/my-repo.git',
+        :remote => 'https://git-server.site/my-repo.git',
         :ref    => 'd026ea677116424d2968edb9cee8cbc24d09322b',
       }
     )
@@ -45,7 +45,7 @@ describe R10K::Environment::Git do
     end
 
     it "can return the environment remote" do
-      expect(subject.remote).to eq 'git://git-server.site/my-repo.git'
+      expect(subject.remote).to eq 'https://git-server.site/my-repo.git'
     end
 
     it "can return the environment ref" do

--- a/spec/unit/git/alternates_spec.rb
+++ b/spec/unit/git/alternates_spec.rb
@@ -13,13 +13,13 @@ describe R10K::Git::Alternates do
     it "reads the alternates file and splits on lines" do
       expect(subject.file).to receive(:file?).and_return true
       expect(subject.file).to receive(:readlines).and_return([
-        "/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git\n",
-        "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git\n",
+        "/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git\n",
+        "/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git\n",
       ])
 
       expect(subject.read).to eq([
-        "/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-        "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+        "/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+        "/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
       ])
     end
 
@@ -33,17 +33,17 @@ describe R10K::Git::Alternates do
   describe "determining if an entry is already present" do
     before do
       allow(subject).to receive(:to_a).and_return([
-        "/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-        "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
+        "/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+        "/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
       ])
     end
 
     it "is true if the element is in the array of read entries" do
-      expect(subject).to include("/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")
+      expect(subject).to include("/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git")
     end
 
     it "is false if the element is not in the array of read entries" do
-      expect(subject).to_not include("/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")
+      expect(subject).to_not include("/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git")
     end
   end
 
@@ -52,7 +52,7 @@ describe R10K::Git::Alternates do
     describe "and the git objects/info directory does not exist" do
       it "raises an error when the parent directory does not exist" do
         expect {
-          subject.write(["/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
+          subject.write(["/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git"])
         }.to raise_error(R10K::Git::GitError,"Cannot write /some/nonexistent/path/.git/objects/info/alternates; parent directory does not exist")
       end
     end
@@ -66,51 +66,51 @@ describe R10K::Git::Alternates do
       end
 
       it "creates the alternates file with the new entry when not present" do
-        subject.write(["/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
-        expect(io.string).to eq("/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git\n")
+        subject.write(["/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git"])
+        expect(io.string).to eq("/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git\n")
       end
 
       it "rewrites the file with all alternate entries" do
-        subject.write(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-                       "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-                       "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
+        subject.write(["/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+                       "/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+                       "/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git"])
 
         expect(io.string).to eq(<<-EOD)
-/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git
-/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git
-/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git
+/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git
+/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git
+/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git
         EOD
       end
     end
 
     describe "appending a new alternate object entry" do
       it "re-writes the file with the new entry concatenated to the file" do
-        expect(subject).to receive(:to_a).and_return(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-                                                       "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
+        expect(subject).to receive(:to_a).and_return(["/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+                                                       "/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git"])
 
-        expect(subject).to receive(:write).with(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-                                                 "/vagrant/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-                                                 "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
+        expect(subject).to receive(:write).with(["/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+                                                 "/vagrant/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+                                                 "/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git"])
 
-        subject.add("/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")
+        subject.add("/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git")
       end
     end
   end
 
   describe "conditionally appending a new alternate object entry" do
     before do
-      expect(subject).to receive(:read).and_return(%w[/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git])
+      expect(subject).to receive(:read).and_return(%w[/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git])
     end
 
     it "adds the entry and returns true when the entry doesn't exist" do
-      expect(subject).to receive(:write).with(["/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git",
-                                               "/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git"])
-      expect(subject.add?("/tmp/.r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")).to eq true
+      expect(subject).to receive(:write).with(["/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git",
+                                               "/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git"])
+      expect(subject.add?("/tmp/.r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git")).to eq true
     end
 
     it "doesn't modify the file and returns false when the entry exists" do
       expect(subject).to_not receive(:write)
-      expect(subject.add?("/var/cache/r10k/git/git---github.com-puppetlabs-puppetlabs-apache.git")).to eq false
+      expect(subject.add?("/var/cache/r10k/git/https---github.com-puppetlabs-puppetlabs-apache.git")).to eq false
     end
   end
 end

--- a/spec/unit/git/cache_spec.rb
+++ b/spec/unit/git/cache_spec.rb
@@ -21,7 +21,7 @@ describe R10K::Git::Cache do
     end
   end
 
-  let(:remote) { 'git://some/git/remote' }
+  let(:remote) { 'https://some/git/remote' }
   subject { subclass.new(remote) }
 
   describe "updating the cache" do

--- a/spec/unit/git/rugged/cache_spec.rb
+++ b/spec/unit/git/rugged/cache_spec.rb
@@ -5,7 +5,7 @@ describe R10K::Git::Rugged::Cache, :unless => R10K::Util::Platform.jruby? do
     require 'r10k/git/rugged/cache'
   end
 
-  subject(:cache) { described_class.new('git://some/git/remote') }
+  subject(:cache) { described_class.new('https://some/git/remote') }
 
   it "wraps a Rugged::BareRepository instance" do
     expect(cache.repo).to be_a_kind_of R10K::Git::Rugged::BareRepository
@@ -31,7 +31,7 @@ describe R10K::Git::Rugged::Cache, :unless => R10K::Util::Platform.jruby? do
     before do
       allow(subject.repo).to receive(:exist?).and_return true
       allow(subject.repo).to receive(:fetch)
-      allow(subject.repo).to receive(:remotes).and_return({ 'origin' => 'git://some/git/remote' })
+      allow(subject.repo).to receive(:remotes).and_return({ 'origin' => 'https://some/git/remote' })
     end
 
     it "does not update the URLs if they match" do

--- a/spec/unit/git/shellgit/cache_spec.rb
+++ b/spec/unit/git/shellgit/cache_spec.rb
@@ -3,7 +3,7 @@ require 'r10k/git/shellgit/cache'
 
 describe R10K::Git::ShellGit::Cache do
 
-  subject { described_class.new('git://some/git/remote') }
+  subject { described_class.new('https://some/git/remote') }
 
   it "wraps a ShellGit::BareRepository instance" do
     expect(subject.repo).to be_a_kind_of R10K::Git::ShellGit::BareRepository

--- a/spec/unit/git/stateful_repository_spec.rb
+++ b/spec/unit/git/stateful_repository_spec.rb
@@ -4,7 +4,7 @@ require 'r10k/git/stateful_repository'
 
 describe R10K::Git::StatefulRepository do
 
-  let(:remote) { 'git://some.site/some-repo.git' }
+  let(:remote) { 'https://some.site/some-repo.git' }
   let(:ref) { '0.9.x' }
 
   subject { described_class.new(remote, '/some/nonexistent/basedir', 'some-dirname') }

--- a/spec/unit/module/git_spec.rb
+++ b/spec/unit/module/git_spec.rb
@@ -44,7 +44,7 @@ describe R10K::Module::Git do
         described_class.new(
           'branan/eight_hundred',
           '/moduledir',
-          { :git => 'git://git-server.site/branan/puppet-eight_hundred' }
+          { :git => 'https://git-server.site/branan/puppet-eight_hundred' }
         )
       end
 
@@ -66,7 +66,7 @@ describe R10K::Module::Git do
         described_class.new(
           'eight_hundred',
           '/moduledir',
-          { :git => 'git://git-server.site/branan/puppet-eight_hundred' }
+          { :git => 'https://git-server.site/branan/puppet-eight_hundred' }
         )
       end
 
@@ -86,7 +86,7 @@ describe R10K::Module::Git do
 
   describe "properties" do
     subject do
-      described_class.new('boolean', '/moduledir', {:git => 'git://git.example.com/adrienthebo/puppet-boolean'})
+      described_class.new('boolean', '/moduledir', {:git => 'https://git.example.com/adrienthebo/puppet-boolean'})
     end
 
     before(:each) do
@@ -154,7 +154,7 @@ describe R10K::Module::Git do
       described_class.new(
         'boolean',
         '/moduledir',
-        { :git => 'git://git.example.com/adrienthebo/puppet-boolean' }
+        { :git => 'https://git.example.com/adrienthebo/puppet-boolean' }
       )
     end
 
@@ -171,7 +171,7 @@ describe R10K::Module::Git do
       described_class.new('boolean', '/moduledir', base_opts.merge(extra_opts), env)
     end
 
-    let(:base_opts) { { git: 'git://git.example.com/adrienthebo/puppet-boolean' } }
+    let(:base_opts) { { git: 'https://git.example.com/adrienthebo/puppet-boolean' } }
 
     before(:each) do
       allow(mock_repo).to receive(:head).and_return('abc123')

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -12,7 +12,7 @@ describe R10K::ModuleLoader::Puppetfile do
           environment: R10K::Environment::Git.new('env',
                                                   '/test/basedir/',
                                                   'env',
-                                                  { remote: 'git://foo/remote',
+                                                  { remote: 'https://foo/remote',
                                                     ref: 'env' })
         }
       end

--- a/spec/unit/util/cacheable_spec.rb
+++ b/spec/unit/util/cacheable_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe R10K::Util::Cacheable do
   subject { Object.new.extend(R10K::Util::Cacheable) }
 
   describe "dirname sanitization" do
-    let(:input) { 'git://some/git/remote' }
+    let(:input) { 'https://some/git/remote' }
 
     it 'sanitizes URL to directory name' do
-      expect(subject.sanitized_dirname(input)).to eq('git---some-git-remote')
+      expect(subject.sanitized_dirname(input)).to eq('https---some-git-remote')
     end
 
     context 'with username and password' do


### PR DESCRIPTION
This commit updates tests and documentation to use the `https` protocol for
cloning repos, rather than `git`. On March 15, 2022, GitHub permanently disabled
usage of the unencrypted `git` protocol, so tests began to fail with the
following error:
```
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
