### PR TITLE
Fixes error when using install_path from environment module

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,7 @@ CHANGELOG
 
 Unreleased
 ----------
+- Fixes error when using install_path from environment module [#1288](https://github.com/puppetlabs/r10k/issues/1288)
 
 3.14.2
 ------

--- a/spec/unit/environment/with_modules_spec.rb
+++ b/spec/unit/environment/with_modules_spec.rb
@@ -72,4 +72,51 @@ describe R10K::Environment::WithModules do
       expect(returned_modules.map(&:name).sort).to eq(%w[concat exec stdlib zebra])
     end
   end
+
+  describe "module options" do
+    let(:subject_params) {{
+      :modules => {
+        'hieradata' => {
+          :type => 'git',
+          :source => 'git@git.example.com:site_data.git',
+          :install_path => ''
+        },
+        'site_data_2' => {
+          :type => 'git',
+          :source => 'git@git.example.com:site_data.git',
+          :install_path => 'subdir'
+        },
+
+      }
+    }}
+
+    it "should support empty install_path" do
+      modules = subject.modules
+      expect(modules[0].title).to eq 'hieradata'
+      expect(modules[0].path).to eq Pathname.new('/some/nonexistent/environmentdir/prefix_release42/hieradata')
+
+    end
+
+    it "should support install_path" do
+      modules = subject.modules
+      expect(modules[1].title).to eq 'site_data_2'
+      expect(modules[1].path).to eq Pathname.new('/some/nonexistent/environmentdir/prefix_release42/subdir/site_data_2')
+    end
+
+    context "with invalid configuration" do
+      let(:subject_params) {{
+      :modules => {
+          'site_data_2' => {
+            :type => 'git',
+            :source => 'git@git.example.com:site_data.git',
+            :install_path => '/absolute_path_outside_of_containing_environment'
+          }
+        }
+      }}
+
+      it "raises an error" do
+        expect{ subject.modules }.to raise_error(R10K::Error, /Environment cannot.*outside of containing environment.*/i)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1288

Using `install_path` on environment modules would error with: `undefined method `resolve_install_path' for #<R10K::Environment::Git:0x000055f413f20050>`

This PR fixes this error, borrowing the similarly named functions from https://github.com/puppetlabs/r10k/commit/a153c84dfba737fa5732f8440a8e1ec1ed796f28
