### PR TITLE
(RK-399) Do not warn on spec changes with exclude_spec

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- (RK-399) Do not warn about local modifications in the spec directory when `exclude_spec` is set [#1291](https://github.com/puppetlabs/r10k/pull/1291)
+
 3.14.2
 ------
 

--- a/lib/r10k/git/rugged/thin_repository.rb
+++ b/lib/r10k/git/rugged/thin_repository.rb
@@ -75,6 +75,13 @@ class R10K::Git::Rugged::ThinRepository < R10K::Git::Rugged::WorkingRepository
     end
   end
 
+  def stage_files(files=['.'])
+    with_repo do |repo|
+      index = repo.index
+      files.each { |p| index.add( :path => p ) }
+    end
+  end
+
   private
 
   # Override the parent class repo setup so that we can make sure the alternates file is up to date

--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -43,6 +43,10 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
     git(['ls-tree', '-t', '-r', '--name-only', ref], :path => @path.to_s).stdout.split("\n")
   end
 
+  def stage_files(files=['.'])
+    git(['add', files].flatten, :path => @path.to_s)
+  end
+
   private
 
   def setup_cache_remote

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -36,7 +36,7 @@ class R10K::Git::StatefulRepository
   end
 
   # Returns true if the sync actually updated the repo, false otherwise
-  def sync(ref, force=true)
+  def sync(ref, force=true, exclude_spec=false)
     @cache.sync if sync_cache?(ref)
 
     sha = @cache.resolve(ref)
@@ -45,7 +45,7 @@ class R10K::Git::StatefulRepository
       raise R10K::Git::UnresolvableRefError.new(_("Unable to sync repo to unresolvable ref '%{ref}'") % {ref: ref}, :git_dir => @repo.git_dir)
     end
 
-    workdir_status = status(ref)
+    workdir_status = status(ref, exclude_spec)
 
     updated = true
     case workdir_status
@@ -75,7 +75,7 @@ class R10K::Git::StatefulRepository
     updated
   end
 
-  def status(ref)
+  def status(ref, exclude_spec=false)
     if !@repo.exist?
       :absent
     elsif !@cache.exist?
@@ -88,7 +88,7 @@ class R10K::Git::StatefulRepository
       :mismatched
     elsif @repo.head.nil?
       :mismatched
-    elsif @repo.dirty?
+    elsif @repo.dirty?(exclude_spec)
       :dirty
     elsif !(@repo.head == @cache.resolve(ref))
       :outdated

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -100,7 +100,7 @@ class R10K::Module::Git < R10K::Module::Base
   def sync(opts={})
     force = opts[:force] || @force
     if should_sync?
-      updated = @repo.sync(version, force)
+      updated = @repo.sync(version, force, @exclude_spec)
     else
       updated = false
     end

--- a/spec/integration/git/stateful_repository_spec.rb
+++ b/spec/integration/git/stateful_repository_spec.rb
@@ -83,6 +83,22 @@ describe R10K::Git::StatefulRepository do
       end
     end
 
+    describe "when the workdir has spec dir modifications" do
+      before(:each) do
+        thinrepo.clone(remote, {:ref => ref})
+        FileUtils.mkdir_p(File.join(thinrepo.path, 'spec'))
+        File.open(File.join(thinrepo.path, 'spec', 'file_spec.rb'), 'a') { |f| f.write('local modifications!') }
+        thinrepo.stage_files(['spec/file_spec.rb'])
+      end
+      it "is dirty with exclude_spec false" do
+        expect(subject.status(ref, false)).to eq :dirty
+      end
+
+      it "is insync with exclude_spec true" do
+        expect(subject.status(ref, true)).to eq :insync
+      end
+    end
+
     describe "if the right ref is checked out" do
       it "is insync" do
         thinrepo.clone(remote, {:ref => ref})


### PR DESCRIPTION
Prior to this change, r10k would warn about local changes on the files
in the spec dir when exclude_spec was set. Since r10k was removing the
files, the warning would always be present for each git module when
exclude_spec was set. This change removes the spec files from the insync
checks so that the repo will not be marked as dirty if there are only changes
to the spec files. After this change, the warning about local
modifications on the spec files should not be present.

