### PR TITLE
Implement exclude regex for puppetfile install

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,7 @@ CHANGELOG
 
 Unreleased
 ----------
+- Implement exclude regex for puppetfile install [#1248](https://github.com/puppetlabs/r10k/issues/1248)
 
 3.15.1
 ------

--- a/lib/r10k/action/puppetfile/install.rb
+++ b/lib/r10k/action/puppetfile/install.rb
@@ -14,6 +14,7 @@ module R10K
             options = { basedir: @root, overrides: { force: @force || false } }
             options[:moduledir]  = @moduledir  if @moduledir
             options[:puppetfile] = @puppetfile if @puppetfile
+            options[:module_exclude_regex] = @module_exclude_regex if @module_exclude_regex
 
             loader = R10K::ModuleLoader::Puppetfile.new(**options)
             loaded_content = loader.load!
@@ -40,7 +41,7 @@ module R10K
         private
 
         def allowed_initialize_opts
-          super.merge(root: :self, puppetfile: :self, moduledir: :self, force: :self )
+          super.merge(root: :self, puppetfile: :self, moduledir: :self, :'module-exclude-regex' => :self, force: :self )
         end
       end
     end

--- a/lib/r10k/cli/puppetfile.rb
+++ b/lib/r10k/cli/puppetfile.rb
@@ -31,6 +31,7 @@ Puppetfile (http://bombasticmonkey.com/librarian-puppet/).
           summary 'Install all modules from a Puppetfile'
           option nil, :moduledir, 'Path to install modules to', argument: :required
           option nil, :puppetfile, 'Path to puppetfile', argument: :required
+          option nil, :'module-exclude-regex', 'A regex to exclude modules from installation. Helpful in CI environments.', argument: :required
           flag     nil, :force, 'Force locally changed files to be overwritten'
           runner R10K::Action::Puppetfile::CriRunner.wrap(R10K::Action::Puppetfile::Install)
         end

--- a/spec/unit/module_loader/puppetfile_spec.rb
+++ b/spec/unit/module_loader/puppetfile_spec.rb
@@ -416,6 +416,24 @@ describe R10K::ModuleLoader::Puppetfile do
 
         expect(modules['apt']).to be_a_kind_of(R10K::Module::Forge)
       end
+
+    end
+
+    describe 'using module-exclude-regex' do
+      it 'can exclude a module from being installed' do
+        @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'various-modules')
+        puppetfile = R10K::ModuleLoader::Puppetfile.new(basedir: @path, module_exclude_regex: '^concat$')
+        puppetfile.load!
+        expect(puppetfile.modules.collect(&:name)).not_to include('concat')
+      end
+
+      it 'can exclude multiple modules from being installed' do
+        @path = File.join(PROJECT_ROOT, 'spec', 'fixtures', 'unit', 'puppetfile', 'various-modules')
+        puppetfile = R10K::ModuleLoader::Puppetfile.new(basedir: @path, module_exclude_regex: '^ba[rz]$')
+        puppetfile.load!
+        expect(puppetfile.modules.collect(&:name)).not_to include('bar')
+        expect(puppetfile.modules.collect(&:name)).not_to include('baz')
+      end
     end
   end
 end


### PR DESCRIPTION
This implements an exclude regex option for `puppetfile install` as described in #1248. I've tested this on CLI and it seems to work as intended. Sadly I wasn't able to understand how I'm supposed to add a unit test for this. Could you please help me with it?

---
Fixes #1248.