### PR TITLE
(maint) Use `select` method, rather than `filter`

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,8 +3,7 @@ CHANGELOG
 
 Unreleased
 ----------
-- Fixes error when using install_path from environment module [#1288](https://github.com/puppetlabs/r10k/issues/1288)
-
+- Fix error when using install_path from environment module [#1288](https://github.com/puppetlabs/r10k/issues/1288)
 - (RK-399) Do not warn about local modifications in the spec directory when `exclude_spec` is set [#1291](https://github.com/puppetlabs/r10k/pull/1291)
 
 3.14.2

--- a/lib/r10k/git/rugged/working_repository.rb
+++ b/lib/r10k/git/rugged/working_repository.rb
@@ -120,7 +120,7 @@ class R10K::Git::Rugged::WorkingRepository < R10K::Git::Rugged::BaseRepository
   def dirty?(exclude_spec=false)
     with_repo do |repo|
       if exclude_spec
-        diff = repo.diff_workdir('HEAD').filter { |d| ! d.delta.old_file[:path].start_with?('spec/') }
+        diff = repo.diff_workdir('HEAD').select { |d| ! d.delta.old_file[:path].start_with?('spec/') }
       else
         diff = repo.diff_workdir('HEAD').to_a
       end


### PR DESCRIPTION
The `filter` method is an alias for the `select` method that was introduced in
Ruby 2.6. In order to maintain backwards compatibility with older Ruby versions,
we should use the `select` method.