### PR TITLE
(maint) Release r10k 3.15.0 #minor

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,11 @@ CHANGELOG
 
 Unreleased
 ----------
+
+3.15.0
+------
+
+- Support and test Ruby 3
 - Allow puppet_forge 3.x & newer versions of fast_gettext/gettext [#1302](https://github.com/puppetlabs/r10k/pull/1302)
 - Allow newer cri versions [#1302](https://github.com/puppetlabs/r10k/pull/1302)
 - Fix error when using install_path from environment module [#1288](https://github.com/puppetlabs/r10k/issues/1288)

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '3.14.2'
+  VERSION = '3.15.0'
 end


### PR DESCRIPTION
Includes support for installing and running on Ruby 3.
