### PR TITLE
[#1305] Fix SVN source setopts

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- Make SVN source ignore unused options. [#1305](https://github.com/puppetlabs/r10k/issues/1305)
+
 3.15.0
 ------
 

--- a/lib/r10k/environment/svn.rb
+++ b/lib/r10k/environment/svn.rb
@@ -52,7 +52,7 @@ class R10K::Environment::SVN < R10K::Environment::Base
       :remote   => :self,
       :username => :self,
       :password => :self,
-    })
+    }, raise_on_unhandled: false)
 
     @working_dir = R10K::SVN::WorkingDir.new(Pathname.new(@full_path), :username => @username, :password => @password)
   end

--- a/lib/r10k/source/svn.rb
+++ b/lib/r10k/source/svn.rb
@@ -53,16 +53,23 @@ class R10K::Source::SVN < R10K::Source::Base
   # @option options [Boolean] :prefix Whether to prefix the source name to the
   #   environment directory names. Defaults to false.
   # @option options [String] :remote The URL to the base directory of the SVN repository
+  # @option options [Array<String>] :ignore_branch_prefixes Prefixes of branches that should not be deployed
   # @option options [String] :username The SVN username
   # @option options [String] :password The SVN password
   # @option options [String] :puppetfile_name The puppetfile name
   def initialize(name, basedir, options = {})
     super
 
-    setopts(options, {:remote => :self, :username => :self, :password => :self, :puppetfile_name => :self })
+    setopts(options, {
+      :remote => :self,
+      :ignore_branch_prefixes => :self,
+      :username => :self,
+      :password => :self,
+      :puppetfile_name => :self
+    }, raise_on_unhandled: false)
+
     @environments = []
     @svn_remote = R10K::SVN::Remote.new(@remote, :username => @username, :password => @password)
-    @ignore_branch_prefixes = options[:ignore_branch_prefixes]
   end
 
   def reload!


### PR DESCRIPTION
This commit allows the Setopts config in the SVN source and
environment to ignore keys it doesn't use without throwing
an error (for example, `overrides`).

It also adds `ignore_branch_prefix` to the Setopts.