### PR TITLE
Remove spec from gem spec

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 - Add TOC to configuration docs [#1298](https://github.com/puppetlabs/r10k/issues/1298)
+- Remove the spec folder from gemspec [#1316].(https://github.com/puppetlabs/r10k/issues/1316)
 
 3.15.0
 ------

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,7 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 - Add TOC to configuration docs [#1298](https://github.com/puppetlabs/r10k/issues/1298)
-- Remove the spec folder from gemspec [#1316].(https://github.com/puppetlabs/r10k/issues/1316)
+- Remove the spec folder from gemspec [#1316](https://github.com/puppetlabs/r10k/issues/1316)
 
 3.15.0
 ------

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'yard', '~> 0.9.11'
 
-  s.files        = %x[git ls-files].split($/)
+  s.files        = %x[git ls-files].split($/).reject { |f| f.match(%r{^spec}) }
   s.require_path = 'lib'
   s.bindir       = 'bin'
   s.executables  = 'r10k'


### PR DESCRIPTION
This change updates gemspec to ignore the Spec directory when creating a gem file to allow the r10k gem to be installed on windows servers without admin or symlink creation access, this in turn allows PDK to be installed as a rubygem as per https://github.com/puppetlabs/r10k/issues/1316