### PR TITLE
(maint) Allow gettext-setup < 2

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Fix dirty working copy debug logging [#1321](https://github.com/puppetlabs/r10k/pull/1321)
+- Allow gettext-setup < 2 for compatibility with Ruby 3.2 and Puppet 8 [#1325](https://github.com/puppetlabs/r10k/pull/1325)
 
 3.15.2
 ------

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'puppet_forge', '>= 2.3.0'
 
-  s.add_dependency 'gettext-setup', '~>0.24'
+  s.add_dependency 'gettext-setup', ['>=0.24', '< 2.0.0']
   s.add_dependency 'fast_gettext', ['>= 1.1.0', '< 3.0.0']
   s.add_dependency 'gettext', ['>= 3.0.2', '< 4.0.0']
 


### PR DESCRIPTION
Accept gettext-setup >= 1.1.0 for compatibility with fast-gettext 2.1 and Ruby 3.2.

See https://github.com/puppetlabs/gettext-setup-gem/commit/f4b292c51d2c72e76515f3b81d5ebd379a2bbda8
