### PR TITLE
(maint) Allow 'file' transport when adding git submodules

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Install bundler and gems
         run: |
-          gem install bundler
+          # Pin bundler to maintain support for Ruby 2.4 and 2.5
+          gem install bundler -v 2.3.26
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,10 @@ CHANGELOG
 Unreleased
 ----------
 
+3.15.4
+------
+- Pin dependencies to maintain support for old Ruby versions [#1329](https://github.com/puppetlabs/r10k/pull/1329)
+
 3.15.3
 ------
 - Fix dirty working copy debug logging [#1321](https://github.com/puppetlabs/r10k/pull/1321)

--- a/integration/tests/git_source/git_source_submodule.rb
+++ b/integration/tests/git_source/git_source_submodule.rb
@@ -44,7 +44,7 @@ scp_to(master, helloworld_module_path, File.join(git_clone_module_path, 'hellowo
 git_add_commit_push(master, 'master', 'Add module.', git_clone_module_path)
 
 step 'Add "helloworld" Module Git Repo as Submodule'
-on(master, "cd #{git_environments_path};git submodule add file://#{git_repo_module_path} dist")
+on(master, "cd #{git_environments_path};git -c protocol.file.allow=always submodule add file://#{git_repo_module_path} dist")
 
 step 'Checkout "production" Branch'
 git_on(master, 'checkout production', git_environments_path)

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '3.15.3'
+  VERSION = '3.15.4'
 end

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
 
-  s.add_dependency 'puppet_forge', '>= 2.3.0'
+  s.add_dependency 'puppet_forge', ['>= 2.3.0', '< 4.0.0']
 
   s.add_dependency 'gettext-setup', ['>=0.24', '< 2.0.0']
   s.add_dependency 'fast_gettext', ['>= 1.1.0', '< 3.0.0']


### PR DESCRIPTION
Due to a recent CVE, the 'file' transport is considered unsafe by default. This results in an error when attempting to add submodules on ubuntu. This commit explicitly allows the 'file' transport protocol when adding submodules in acceptance tests.
For more info, see https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253
