### PR TITLE
(maint) Run unit tests with ruby 3.2

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -15,7 +15,7 @@ jobs:
           - {os: ubuntu-18.04, ruby: 2.5}
           - {os: ubuntu-18.04, ruby: 2.6}
           - {os: ubuntu-18.04, ruby: 2.7}
-          - {os: ubuntu-18.04, ruby: 3.1}
+          - {os: ubuntu-18.04, ruby: 3.2}
           - {os: ubuntu-18.04, ruby: jruby-9.2.10.0}
           - {os: windows-2019, ruby: 2.5}
           - {os: windows-2019, ruby: 2.6}

--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-18.04, ruby: 2.4}
-          - {os: ubuntu-18.04, ruby: 2.5}
-          - {os: ubuntu-18.04, ruby: 2.6}
-          - {os: ubuntu-18.04, ruby: 2.7}
-          - {os: ubuntu-18.04, ruby: 3.2}
-          - {os: ubuntu-18.04, ruby: jruby-9.2.10.0}
+          - {os: ubuntu-latest, ruby: 2.4}
+          - {os: ubuntu-latest, ruby: 2.5}
+          - {os: ubuntu-latest, ruby: 2.6}
+          - {os: ubuntu-latest, ruby: 2.7}
+          - {os: ubuntu-latest, ruby: 3.2}
+          - {os: ubuntu-latest, ruby: jruby-9.2.10.0}
           - {os: windows-2019, ruby: 2.5}
           - {os: windows-2019, ruby: 2.6}
           - {os: windows-2019, ruby: 2.7}

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ group :development do
   gem 'ruby-prof', :platforms => :ruby
 end
 
-if File.exists? "#{__FILE__}.local"
+if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/spec/unit/action/deploy/environment_spec.rb
+++ b/spec/unit/action/deploy/environment_spec.rb
@@ -589,7 +589,7 @@ describe R10K::Action::Deploy::Environment do
 
     before(:all) do
       @tmp_path = "./tmp-r10k-test-dir/"
-      Dir.mkdir(@tmp_path) unless File.exists?(@tmp_path)
+      Dir.mkdir(@tmp_path) unless File.exist?(@tmp_path)
     end
 
     after(:all) do


### PR DESCRIPTION
Puppet 8 platform will ship with at least ruby 3.2 (not 3.1), 3.2 has some breaking changes we want to catch with unit tests.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
