### PR TITLE
(maint) Emit more debug output when mod sync fails

### DIFF
--- a/lib/r10k/content_synchronizer.rb
+++ b/lib/r10k/content_synchronizer.rb
@@ -79,8 +79,13 @@ module R10K
         begin
           while mods = mods_queue.pop(true) do
             mods.each do |mod|
-              updated = mod.sync
-              updated_modules << mod.name if updated
+              begin
+                updated = mod.sync
+                updated_modules << mod.name if updated
+              rescue Exception => e
+                logger.error _("Module %{mod_name} failed to synchronize due to %{message}") % {mod_name: mod.name, message: e.message}
+                raise e
+              end
             end
           end
         rescue ThreadError => e


### PR DESCRIPTION
I can't seem to reopen https://github.com/puppetlabs/r10k/pull/1334 So here is that PR with the logging level set to error.

/cc @Sharpie 


Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
