### PR TITLE
(maint) Remove use of beaker-qa-i18n and disable i18n test

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -16,4 +16,3 @@ gem 'beaker-answers'
 gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1.1')
 gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.4')
 gem 'rototiller', '= 0.1.0'
-gem 'beaker-qa-i18n'

--- a/integration/tests/i18n/deploy_module_with_unicode_in_file_name.rb
+++ b/integration/tests/i18n/deploy_module_with_unicode_in_file_name.rb
@@ -1,9 +1,10 @@
 require 'git_utils'
 require 'r10k_utils'
 require 'master_manipulator'
-require 'beaker-qa-i18n'
+#require 'beaker-qa-i18n'
 
 test_name 'Deploy module with unicode file name'
+skip_test 'Not currently utilizing i18n and need to remove use of beaker-qa-i18n'
 
 #Init
 master_certname = on(master, puppet('config', 'print', 'certname')).stdout.rstrip


### PR DESCRIPTION
We are not currently utilizing i18n, and the beaker-qa-i18n gem is problematic since it isn't on Rubygems. Leaving the code here in anticipation of the day we'll get back to i18n, but for now, skipping the test and removing the gem.