### PR TITLE
Feature: Add `extra_delete` option: rm files after sync

### DIFF
--- a/lib/r10k/module/forge.rb
+++ b/lib/r10k/module/forge.rb
@@ -76,6 +76,7 @@ class R10K::Module::Forge < R10K::Module::Base
         updated = true
       end
       maybe_delete_spec_dir
+      maybe_extra_delete
     end
     updated
   end

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -104,6 +104,7 @@ class R10K::Module::Git < R10K::Module::Base
       updated = false
     end
     maybe_delete_spec_dir
+    maybe_extra_delete
     updated
   end
 

--- a/lib/r10k/module/svn.rb
+++ b/lib/r10k/module/svn.rb
@@ -90,6 +90,7 @@ class R10K::Module::SVN < R10K::Module::Base
         updated = true
       end
       maybe_delete_spec_dir
+      maybe_extra_delete
     end
     updated
   end

--- a/lib/r10k/module/tarball.rb
+++ b/lib/r10k/module/tarball.rb
@@ -67,6 +67,7 @@ class R10K::Module::Tarball < R10K::Module::Base
         tarball.unpack(path.to_s)
       end
       maybe_delete_spec_dir
+      maybe_extra_delete
       true
     else
       false

--- a/spec/unit/module/base_spec.rb
+++ b/spec/unit/module/base_spec.rb
@@ -81,6 +81,74 @@ describe R10K::Module::Base do
     end
   end
 
+  describe 'deleting the extra_delete' do
+    let(:module_org) { "coolorg" }
+    let(:module_name) { "coolmod" }
+    let(:title) { "#{module_org}-#{module_name}" }
+    let(:dirname) { Pathname.new(Dir.mktmpdir) }
+    let(:example_delete_directories) { [ "empty_dir" ].map { |v| v.prepend( dirname.to_path + '/' + module_name + '/') } }
+    let(:example_delete_kept_directories) { [ "dir_with_files" ].map { |v| v.prepend( dirname.to_path + '/' + module_name + '/') } }
+    let(:example_delete_files) { [ "UNWANTED", "dir_with_files/FileA", "dir_with_files/FileB" ].map { |v| v.prepend( dirname.to_path + '/' + module_name + '/' ) } }
+
+    before(:each) do
+      logger = double("logger")
+      allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
+      allow(logger).to receive(:debug2).with(any_args)
+      allow(logger).to receive(:info).with(any_args)
+    end
+    it 'does not remove any extra files/directories by default' do
+      (example_delete_directories + example_delete_kept_directories).each do | d |
+        FileUtils.mkdir_p(d)
+        m = described_class.new(title, dirname, {})
+        m.maybe_extra_delete
+        expect(Dir.exist?(d)).to eq true
+      end
+      example_delete_files.each do | f |
+        FileUtils.touch(f)
+        m = described_class.new(title, dirname, {})
+        m.maybe_extra_delete
+        expect(File.exist?(f)).to eq true
+      end
+    end
+
+    it 'removes files if extra_deletes is non-empty' do
+      (example_delete_directories + example_delete_kept_directories).each do | d |
+        FileUtils.mkdir_p(d)
+      end
+      example_delete_files.each do | f |
+        FileUtils.touch(f)
+      end
+      m = described_class.new(title, dirname, { extra_delete: [ "empty_dir", "UNWANTED", "dir_with_files/*" ] } )
+      m.maybe_extra_delete
+      example_delete_files.each do | f |
+        expect(File.exist?(f)).to eq false
+      end
+      # We want to be sure that `dir_with_files/` is *not* removed, but empty_dir (as specified) is
+      example_delete_directories.each do | d |
+        expect(Dir.exist?(d)).to eq false
+      end
+      # We want to be sure that `dir_with_files/` is *not* removed, just the files!
+      example_delete_kept_directories.each do | d |
+        expect(Dir.exist?(d)).to eq true
+      end
+    end
+
+    it 'does not remove files if extra_deletes is empty' do
+      (example_delete_directories + example_delete_kept_directories).each do | d |
+        FileUtils.mkdir_p(d)
+        m = described_class.new(title, dirname, {extra_delete: []})
+        m.maybe_extra_delete
+        expect(Dir.exist?(d)).to eq true
+      end
+      example_delete_files.each do | f |
+        FileUtils.touch(f)
+        m = described_class.new(title, dirname, {extra_delete: []})
+        m.maybe_extra_delete
+        expect(File.exist?(f)).to eq true
+      end
+    end
+  end
+
   describe "path variables" do
     it "uses the module name as the name" do
       m = described_class.new('eight_hundred', '/moduledir', {})


### PR DESCRIPTION
This PR implements the option to each module of a list of files to delete after the copy into the local directory.

The use case is repositories/modules with "unwanted" information. In our environment all modules downloaded with `r10k` are checked into our main Puppet git repository. We want to skip files in our repo that we don't need, and do so in a repeatable way.

Example `Puppetfile` with this feature:

```
mod 'puppetlabs-cron_core',
  type:    'forge',
  version: '1.2.0',
  extra_delete: ['.github', 'locales', '*/README_*.md', ]
```

This downloads `puppetlabs-cron_core`, then removes the directory `.github`, the directory `locales`, and the glob `*/README_*.md`.

The module on filesytem without this option:

```
original
└── cron_core
    ├── CHANGELOG.md
    ├── CODEOWNERS
    ├── LICENSE
    ├── README.md
    ├── REFERENCE.md
    ├── data
    │   └── common.yaml
    ├── hiera.yaml
    ├── lib
    │   └── puppet
    │       ├── provider
    │       │   └── cron
    │       │       ├── crontab.rb
    │       │       └── filetype.rb
    │       └── type
    │           └── cron.rb
    ├── locales
    │   ├── config.yaml
    │   ├── ja
    │   │   └── puppetlabs-cron_core.po
    │   └── puppetlabs-cron_core.pot
    ├── metadata.json
    ├── pdk.yaml
    └── readmes
        └── README_ja_JP.md

11 directories, 16 files
```

The module on the filesytem with this option as show above:

```
excluded
└── cron_core
    ├── CHANGELOG.md
    ├── CODEOWNERS
    ├── LICENSE
    ├── README.md
    ├── REFERENCE.md
    ├── data
    │   └── common.yaml
    ├── hiera.yaml
    ├── lib
    │   └── puppet
    │       ├── provider
    │       │   └── cron
    │       │       ├── crontab.rb
    │       │       └── filetype.rb
    │       └── type
    │           └── cron.rb
    ├── metadata.json
    ├── pdk.yaml
    └── readmes

9 directories, 12 files
```

This option uses `Dir.glob` for matching: https://ruby-doc.org/core-2.6.3/Dir.html#method-c-glob

If a directory is listed, the entire directory is removed: (`rm -rf`).

Not setting `extra_delete: ...` is equivalent to `extra_delete: []`, which will cause no files to be deleted.
