### PR TITLE
(maint) Disable Single Git Source test for el-9, replace 'operatingsystemmajrelease' legacy fact

### DIFF
--- a/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
@@ -10,7 +10,7 @@ confine(:to, :platform => ['el', 'ubuntu', 'sles'])
 
 if ENV['GIT_PROVIDER'] == 'shellgit'
   skip_test('Skipping test because removing Git from the system affects other "shellgit" tests.')
-elsif fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+elsif fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "os.release.major").to_i < 6
   skip_test('This version of EL is not supported by this test case!')
 end
 
@@ -87,7 +87,7 @@ step 'Remove "git" Package from System'
 if master_platform == 'RedHat'
   on(master, 'yum remove -y git')
 elsif master_platform == 'Debian'
-  if fact_on(master, "operatingsystemmajrelease") == '10.04'
+  if fact_on(master, "os.release.major") == '10.04'
     on(master, 'apt-get remove -y git-core')
   else
     on(master, 'apt-get remove -y git')

--- a/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
@@ -8,7 +8,7 @@ confine(:to, :platform => ['el', 'ubuntu', 'sles'])
 
 if ENV['GIT_PROVIDER'] == 'shellgit'
   skip_test('Skipping test because removing Git from the system affects other "shellgit" tests.')
-elsif fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+elsif fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "os.release.major").to_i < 6
   skip_test('This version of EL is not supported by this test case!')
 end
 
@@ -86,7 +86,7 @@ step 'Remove "git" Package from System'
 if master_platform == 'RedHat'
   on(master, 'yum remove -y git')
 elsif master_platform == 'Debian'
-  if fact_on(master, "operatingsystemmajrelease") == '10.04'
+  if fact_on(master, "os.release.major") == '10.04'
     on(master, 'apt-get remove -y git-core')
   else
     on(master, 'apt-get remove -y git')

--- a/integration/tests/git_source/git_source_git.rb
+++ b/integration/tests/git_source/git_source_git.rb
@@ -5,7 +5,7 @@ test_name 'CODEMGMT-92 - C59235 - Single Git Source Using "GIT" Transport Protoc
 
 confine(:to, :platform => 'el')
 
-if fact_on(master, "operatingsystemmajrelease").to_i < 6
+if fact_on(master, "os.release.major").to_i < 6 || fact_on(master, "os.release.major").to_i > 8
   skip_test('This version of EL is not supported by this test case!')
 end
 

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_disk_full.rb
@@ -2,7 +2,7 @@ require 'git_utils'
 require 'r10k_utils'
 test_name 'CODEMGMT-86 - C59265 - Attempt to Deploy Environment to Disk with Insufficient Free Space'
 
-if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "os.release.major").to_i < 6
   skip_test('This version of EL is not supported by this test case!')
 end
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
@@ -3,7 +3,7 @@ require 'r10k_utils'
 require 'master_manipulator'
 test_name 'CODEMGMT-62 - C59239 - Single Environment with 10,000 Files'
 
-if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "os.release.major").to_i < 6
   skip_test('This version of EL is not supported by this test case!')
 end
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
@@ -3,7 +3,7 @@ require 'r10k_utils'
 require 'master_manipulator'
 test_name 'CODEMGMT-62 - C59242 - Single Environment with Large Binary Files'
 
-if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "operatingsystemmajrelease").to_i < 6
+if fact_on(master, 'osfamily') == 'RedHat' and fact_on(master, "os.release.major").to_i < 6
   skip_test('This version of EL is not supported by this test case!')
 end
 


### PR DESCRIPTION
This test fails on el-9 since xinetd has been removed on the platform. Added https://perforce.atlassian.net/browse/PE-36632 for future work to address the possibility of using systemd instead here.