### PR TITLE
shellgit: Ensure the passed filepath to diff-index is interpreted as filepath

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- shellgit: Ensure the passed filepath to diff-index is interpreted as filepath [#1367](https://github.com/puppetlabs/r10k/pull/1367)
 
 4.0.0
 -----

--- a/lib/r10k/git/shellgit/working_repository.rb
+++ b/lib/r10k/git/shellgit/working_repository.rb
@@ -101,7 +101,7 @@ class R10K::Git::ShellGit::WorkingRepository < R10K::Git::ShellGit::BaseReposito
         logger.debug(_("Found local modifications in %{file_path}" % {file_path: File.join(@path, file)}))
 
         # Do this in a block so that the extra subprocess only gets invoked when needed.
-        logger.debug1 { git(['diff-index', '-p', 'HEAD', file], :path => @path.to_s, :raise_on_fail => false).stdout }
+        logger.debug1 { git(['diff-index', '-p', 'HEAD', '--', file], :path => @path.to_s, :raise_on_fail => false).stdout }
       end
 
       return dirty_files.size > 0


### PR DESCRIPTION
Simplified, the code in the past was like this
(data/roles/pe_primary.yaml is a random test file):

`git diff-index -p HEAD data/roles/pe_primary.yaml`

Which results in the following error if the file is tracked in git but
was deleted locally:

```
$ git status
HEAD detached at 3140475
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    data/roles/pe_primary.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.r10k-deploy.json
	.resource_types/
	modules/

no changes added to commit (use "git add" and/or "git commit -a")
$ git diff-index -p HEAD data/roles/pe_primary.yaml
fatal: ambiguous argument 'data/roles/pe_primary.yaml': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
$ echo $?
128
```

With adding `--` to the command, we ensure it's interpreted as path.
This changes the exit code to 0.

```
$ git status
HEAD detached at 3140475
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    data/roles/pe_primary.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.r10k-deploy.json
	.resource_types/
	modules/

no changes added to commit (use "git add" and/or "git commit -a")
$ git diff-index -p HEAD -- data/roles/pe_primary.yaml
diff --git a/data/roles/pe_primary.yaml b/data/roles/pe_primary.yaml
deleted file mode 100644
index b827047..0000000
--- a/data/roles/pe_primary.yaml
+++ /dev/null
@@ -1,48 +0,0 @@
----
-classes:
-  - profiles::nftables
$ echo $?
0
```