### PR TITLE
fetch tags to local, if different to remote

### DIFF
--- a/lib/r10k/git/shellgit/thin_repository.rb
+++ b/lib/r10k/git/shellgit/thin_repository.rb
@@ -31,7 +31,12 @@ class R10K::Git::ShellGit::ThinRepository < R10K::Git::ShellGit::WorkingReposito
 
   # Fetch refs from the backing bare Git repository.
   def fetch(remote = 'cache')
-    git ['fetch', remote, '--prune'], :path => @path.to_s
+    git ['fetch', remote, '--prune', '--tags', '--prune-tags'], :path => @path.to_s
+  end
+
+  # Prune deleted branches
+  def prune
+    git ['fetch', '--prune'], :path => @path.to_s
   end
 
   # @return [String] The origin remote URL

--- a/lib/r10k/git/stateful_repository.rb
+++ b/lib/r10k/git/stateful_repository.rb
@@ -63,11 +63,16 @@ class R10K::Git::StatefulRepository
       if force
         logger.warn(_("Overwriting local modifications to %{repo_path}") % {repo_path: @repo.path})
         logger.debug(_("Updating %{repo_path} to %{ref}") % {repo_path: @repo.path, ref: ref })
+        @repo.prune
+        @repo.fetch
         @repo.checkout(sha, {:force => force})
       else
         logger.warn(_("Skipping %{repo_path} due to local modifications") % {repo_path: @repo.path})
         updated = false
       end
+    when :updatedtags
+      logger.debug(_("Updating tags in %{repo_path}") % {repo_path: @repo.path})
+      @repo.fetch
     else
       logger.debug(_("%{repo_path} is already at Git ref %{ref}") % {repo_path: @repo.path, ref: ref })
       updated = false
@@ -94,6 +99,8 @@ class R10K::Git::StatefulRepository
       :outdated
     elsif @cache.ref_type(ref) == :branch && !@cache.synced?
       :outdated
+    elsif @repo.updatedtags?
+      :updatedtags
     else
       :insync
     end

--- a/spec/shared-examples/git/working_repository.rb
+++ b/spec/shared-examples/git/working_repository.rb
@@ -206,4 +206,43 @@ RSpec.shared_examples "a git working repository" do
       end
     end
   end
+
+  shared_examples "unequal tags" do
+    it "reports tags as unequal" do
+      expect(subject.logger).to receive(:debug).with(/found different tags in local and remote in/i)
+      expect(subject.updatedtags?).to be true
+    end
+  end
+
+  describe "checking if tags are different" do
+    let(:tag_090) { subject.git_dir + 'refs' + 'tags' + '0.9.0' }
+    let(:packed_refs) { subject.git_dir + 'packed-refs' }
+
+    before(:each) do
+      subject.clone(remote)
+    end
+
+    context "with equal tags local and remote" do
+      it "reports tags as equal" do
+        expect(subject.updatedtags?).to be false
+      end
+    end
+
+    context "with missing local tag" do
+      before do
+        tag_090.delete if tag_090.exist?
+        packed_refs.delete if packed_refs.exist?
+      end
+
+      it_behaves_like "unequal tags"
+    end
+
+    context "with additional local tag" do
+      before(:each) do
+        File.open(File.join(subject.git_dir, 'packed-refs'), 'a') { |f| f.write('157011a4eaa27f1202a9d94335ee4876b26d377e refs/tags/1.0.2') }
+      end
+
+      it_behaves_like "unequal tags"
+    end
+  end
 end


### PR DESCRIPTION
We have the use case, that r10k is pulling modules from our own Git and some modules are applied via `puppet apply` based on a tag in the Git repository. Therefore it's needed, that the git tags are also updated in the deployed modules by r10k.

This PR adds updating the tags, when they differ local and remote.
This is running currently in our production and is working fine.