### PR TITLE
(PE-34196, PE-34917) Make loading metadata in `--incremental` deploys more robust

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -3,6 +3,7 @@ CHANGELOG
 
 Unreleased
 ----------
+- Make metadata loading during incremental deploys more robust [PE-34917](https://perforce.atlassian.net/browse/PE-34917)
 
 
 3.16.0

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -104,7 +104,7 @@ module R10K
         @existing_module_versions_by_name = @existing_module_metadata.map {|mod| [ mod.name, mod.version ] }.to_h
         empty_load_output.merge(modules: @existing_module_metadata)
 
-      rescue SyntaxError, LoadError, ArgumentError, NameError, RuntimeError, R10K::Error => e
+      rescue ScriptError, StandardError => e
         logger.warn _("Unable to preload Puppetfile because of %{msg}" % { msg: e.message })
 
         @existing_module_metadata = []

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -104,7 +104,7 @@ module R10K
         @existing_module_versions_by_name = @existing_module_metadata.map {|mod| [ mod.name, mod.version ] }.to_h
         empty_load_output.merge(modules: @existing_module_metadata)
 
-      rescue SyntaxError, LoadError, ArgumentError, NameError => e
+      rescue SyntaxError, LoadError, ArgumentError, NameError, RuntimeError => e
         logger.warn _("Unable to preload Puppetfile because of %{msg}" % { msg: e.message })
       end
 

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -104,7 +104,7 @@ module R10K
         @existing_module_versions_by_name = @existing_module_metadata.map {|mod| [ mod.name, mod.version ] }.to_h
         empty_load_output.merge(modules: @existing_module_metadata)
 
-      rescue SyntaxError, LoadError, ArgumentError, NameError, RuntimeError => e
+      rescue SyntaxError, LoadError, ArgumentError, NameError, RuntimeError, R10K::Error => e
         logger.warn _("Unable to preload Puppetfile because of %{msg}" % { msg: e.message })
       end
 

--- a/lib/r10k/module_loader/puppetfile.rb
+++ b/lib/r10k/module_loader/puppetfile.rb
@@ -106,6 +106,9 @@ module R10K
 
       rescue SyntaxError, LoadError, ArgumentError, NameError, RuntimeError, R10K::Error => e
         logger.warn _("Unable to preload Puppetfile because of %{msg}" % { msg: e.message })
+
+        @existing_module_metadata = []
+        @existing_module_versions_by_name = {}
       end
 
       def add_module_metadata(name, info)


### PR DESCRIPTION
Previously, if loading module metadata raised an uncaught exception a user with automation that always used `--incremental` (like the PE default configuration) could not recover from a failed deployment.

This PR addresses two different tickets that call out specific exceptions that can be raised during metadata parsing. It then goes slightly farther in making metadata loading more robust to avoid further whack-a-mole exception handling.