### PR TITLE
r10k::module::git: expose remote as getter

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- r10k::module::git: expose remote as getter  [#1379](https://github.com/puppetlabs/r10k/pull/1379)
 
 3.16.1
 ------

--- a/lib/r10k/module/git.rb
+++ b/lib/r10k/module/git.rb
@@ -46,6 +46,11 @@ class R10K::Module::Git < R10K::Module::Base
   #   @return [String]
   attr_reader :default_override_ref
 
+  # @!attribute[r] remote
+  #   @api private
+  #   @return [String]
+  attr_reader :remote
+
   include R10K::Util::Setopts
 
   def initialize(title, dirname, opts, environment=nil)


### PR DESCRIPTION
This allows us to access the remote property to figure out the git URI for a module:

```
$ bundle exec irb
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
irb(main):001:0> require 'json'
=> true
irb(main):002:0> require 'r10k/module_loader/puppetfile'
=> true
irb(main):003:0> puppetfile = R10K::ModuleLoader::Puppetfile.new(basedir: '/home/bastelfreak/code/controlrepo/').load
=>
{:modules=>
...
irb(main):004:0> mod = puppetfile[:modules].map {|mod| mod if mod.class == R10K::Module::Git}.compact.first
=>
...
irb(main):005:0> mod.remote
=> "https://github.com/voxpupuli/puppet-borg"
irb(main):006:0>
```

cherry-picked 22da06bd1411bc9bed339ecc5a1b6262f6093a8b from https://github.com/puppetlabs/r10k/pull/1379