### PR TITLE
(maint) Adjust jwt spec to be more relaxed

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'gettext-setup', '>=0.24', '<2.0'
 
-  s.add_dependency 'jwt', '>= 2.2.3', '< 2.8.0'
+  s.add_dependency 'jwt', '>= 2.2.3', '< 3'
   s.add_dependency 'minitar', '~> 0.9'
 
   s.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
This commit updates the r10k gemspec to allow any jwt rubygem version in the 2 series after 2.2.3. The minimum version is 2.2.3, but the only requirement on the upper bound is < 3. Note that the 3 series does not exist in jwt, this upper bounds just protects against an open ended major version.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
