### PR TITLE
Require Ruby 3.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,10 +22,10 @@ jobs:
         with: # This doesn't seem to work unless we point directly to the secrets
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 3.1
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 3.1
       - run: gem install bundler
       - uses: actions/checkout@v3
       - name: Set up QEMU

--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -12,14 +12,10 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-latest, ruby: 2.6}
-          - {os: ubuntu-latest, ruby: 2.7}
           - {os: ubuntu-latest, ruby: 3.1}
           - {os: ubuntu-latest, ruby: 3.2}
           - {os: ubuntu-latest, ruby: 3.3}
-          - {os: ubuntu-latest, ruby: jruby-9.3}
           - {os: ubuntu-latest, ruby: jruby-9.4}
-          - {os: windows-latest, ruby: 2.6}
           - {os: windows-latest, ruby: 3.2}
           - {os: windows-latest, ruby: 3.3}
 

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Add Ruby 3.3 to CI [#1403](https://github.com/puppetlabs/r10k/pull/1403)
+- Require Ruby 3.1 [#1402](https://github.com/puppetlabs/r10k/pull/1402)
 
 4.1.0
 -----

--- a/lib/r10k/tarball.rb
+++ b/lib/r10k/tarball.rb
@@ -173,7 +173,7 @@ module R10K
     def each_tarball_entry(&block)
       File.open(cache_path, 'rb') do |file|
         Zlib::GzipReader.wrap(file) do |reader|
-          Archive::Tar::Minitar::Input.each_entry(reader) do |entry|
+          Minitar::Input.each_entry(reader) do |entry|
             yield entry
           end
         end

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -18,22 +18,22 @@ Gem::Specification.new do |s|
     dynamic environments.
   DESCRIPTION
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 3.1.0'
 
   s.license  = 'Apache-2.0'
 
-  s.add_dependency 'colored2',   '3.1.2'
+  s.add_dependency 'colored2', '~> 4.0'
   s.add_dependency 'cri', '>= 2.15.10'
 
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
 
-  s.add_dependency 'puppet_forge', '>= 4.1', '< 6'
+  s.add_dependency 'puppet_forge', '~> 6.0'
 
   s.add_dependency 'gettext-setup', '>=0.24', '<2.0'
 
   s.add_dependency 'jwt', '>= 2.2.3', '< 3'
-  s.add_dependency 'minitar', '~> 0.9'
+  s.add_dependency 'minitar', '~> 1.0', '>= 1.0.2'
 
   s.add_development_dependency 'rspec', '~> 3.1'
 

--- a/spec/shared-contexts/git-fixtures.rb
+++ b/spec/shared-contexts/git-fixtures.rb
@@ -1,4 +1,4 @@
-require 'archive/tar/minitar'
+require 'minitar'
 require 'tmpdir'
 
 shared_context "Git integration" do
@@ -26,7 +26,7 @@ shared_context "Git integration" do
   end
 
   def populate_remote_path
-    Archive::Tar::Minitar.unpack(File.join(fixture_path, 'puppet-boolean-bare.tar'), remote_path)
+    Minitar.unpack(File.join(fixture_path, 'puppet-boolean-bare.tar'), remote_path)
   end
 
   def clear_remote_path


### PR DESCRIPTION
This allows us to use the latest minitar and forge_ruby dependencies.

Replaces:
* https://github.com/puppetlabs/r10k/pull/1401
* https://github.com/puppetlabs/r10k/pull/1397