### PR TITLE
Replace deprecated action: actions/setup-ruby->ruby/setup-ruby

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Set up Ruby 3.1
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1
       - run: gem install bundler

--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -6,6 +6,7 @@ Unreleased
 
 - Add Ruby 3.3 to CI [#1403](https://github.com/puppetlabs/r10k/pull/1403)
 - Require Ruby 3.1 [#1402](https://github.com/puppetlabs/r10k/pull/1402)
+- Replace deprecated action: actions/setup-ruby->ruby/setup-ruby [#1406](https://github.com/puppetlabs/r10k/pull/1406)
 
 4.1.0
 -----


### PR DESCRIPTION
https://github.com/actions/setup-ruby is deprecated, https://github.com/ruby/setup-ruby is the successor.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
