### PR TITLE
Support more minitar versions & prep for r10k 5.0 #major

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,8 +4,12 @@ CHANGELOG
 Unreleased
 ----------
 
+5.0.0
+-----
+
 - Add Ruby 3.3 to CI [#1403](https://github.com/puppetlabs/r10k/pull/1403)
 - Require Ruby 3.1 [#1402](https://github.com/puppetlabs/r10k/pull/1402)
+- Support minitar gem > 1.0. [#1407](https://github.com/puppetlabs/r10k/pull/1407)
 
 4.1.0
 -----

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '4.1.0'
+  VERSION = '5.0.0'
 end

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -24,21 +24,15 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'colored2', '~> 4.0'
   s.add_dependency 'cri', '>= 2.15.10'
-
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
-
-  s.add_dependency 'puppet_forge', '~> 6.0'
-
+  s.add_dependency 'puppet_forge', '>= 4.1.0'
   s.add_dependency 'gettext-setup', '>=0.24', '<2.0'
-
   s.add_dependency 'jwt', '>= 2.2.3', '< 3'
-  s.add_dependency 'minitar', '~> 1.0', '>= 1.0.2'
+  s.add_dependency 'minitar', '>= 0.9'
 
   s.add_development_dependency 'rspec', '~> 3.1'
-
   s.add_development_dependency 'rake'
-
   s.add_development_dependency 'yard', '~> 0.9.11'
 
   s.files        = %x[git ls-files].split($/).reject { |f| f.match(%r{^spec}) }

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cri', '>= 2.15.10'
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
-  s.add_dependency 'puppet_forge', '>= 4.1.0'
+  s.add_dependency 'puppet_forge', '>= 4.1.0', '< 7'
   s.add_dependency 'gettext-setup', '>=0.24', '<2.0'
   s.add_dependency 'jwt', '>= 2.2.3', '< 3'
   s.add_dependency 'minitar', '>= 0.9', '< 2'

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet_forge', '>= 4.1.0'
   s.add_dependency 'gettext-setup', '>=0.24', '<2.0'
   s.add_dependency 'jwt', '>= 2.2.3', '< 3'
-  s.add_dependency 'minitar', '>= 0.9'
+  s.add_dependency 'minitar', '>= 0.9', '< 2'
 
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
I would consider moving from requiring Ruby 2.6 to Ruby 3.1 to be a major breaking change. One we should totally do, but one I think requires a major version bump. We should see what else in the PR backlog we want to get in for such a release.

Also, this allows us to support minitar version > 0.9, to smooth transitions for people who require both r10k and puppet in their Gemfiles/gemspecs.