### PR TITLE
Limit Rugged Control Repo refspec

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -8,6 +8,7 @@ Unreleased
 - Require Ruby 3.1 [#1402](https://github.com/puppetlabs/r10k/pull/1402)
 - Replace deprecated action: actions/setup-ruby->ruby/setup-ruby [#1406](https://github.com/puppetlabs/r10k/pull/1406)
 - Ensure git repositories are pruned on fetch [#1410](https://github.com/puppetlabs/r10k/pull/1410)
+- Limit Rugged Control Repo refspec to only clone refs/heads [#1412](https://github.com/puppetlabs/r10k/pull/1412)
 
 4.1.0
 -----

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -36,7 +36,7 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     @_rugged_repo = ::Rugged::Repository.init_at(@path.to_s, true).tap do |repo|
       config = repo.config
       config['remote.origin.url']    = remote
-      config['remote.origin.fetch']  = '+refs/*:refs/*'
+      config['remote.origin.fetch']  = '+refs/heads/*:refs/heads/*'
       config['remote.origin.mirror'] = 'true'
     end
 
@@ -60,7 +60,7 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     proxy = R10K::Git.get_proxy_for_remote(remote)
 
     options = {:credentials => credentials, :prune => true, :proxy_url => proxy}
-    refspecs = ['+refs/*:refs/*']
+    refspecs = ['+refs/heads/*:refs/heads/*']
 
     results = nil
 


### PR DESCRIPTION
Some Git platforms (e.g. GitLab) store additional references beyond the ones typically found in refs/heads for various tracking/historical reference purposes. For Control Repos which have been around a long time these additional refs can number in the tens of thousands. Refs that numerous seem to cause issues with some versions of Rugged being unable to properly clone and reference the Control Repo.

This patch limits Control Repo reference fetching to refs/heads, which is all R10K should need anyways.

See https://docs.gitlab.com/ee/development/gitaly.html#gitlab-specific-references for details on some of these additional references.
