### PR TITLE
Revert "Limit Rugged Control Repo refspec"

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 ----------
 
+- Revert "Limit Rugged Control Repo refspec to only clone refs/heads" [#1422](https://github.com/puppetlabs/r10k/pull/1422)
 
 5.0.1
 -----

--- a/lib/r10k/git/rugged/bare_repository.rb
+++ b/lib/r10k/git/rugged/bare_repository.rb
@@ -36,7 +36,7 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     @_rugged_repo = ::Rugged::Repository.init_at(@path.to_s, true).tap do |repo|
       config = repo.config
       config['remote.origin.url']    = remote
-      config['remote.origin.fetch']  = '+refs/heads/*:refs/heads/*'
+      config['remote.origin.fetch']  = '+refs/*:refs/*'
       config['remote.origin.mirror'] = 'true'
     end
 
@@ -59,8 +59,8 @@ class R10K::Git::Rugged::BareRepository < R10K::Git::Rugged::BaseRepository
     remote = remotes[remote_name]
     proxy = R10K::Git.get_proxy_for_remote(remote)
 
-    options = {:credentials => credentials, :prune => true, :proxy_url => proxy, :download_tags => true}
-    refspecs = ['+refs/heads/*:refs/heads/*', '+refs/tags/*:refs/tags/*']
+    options = {:credentials => credentials, :prune => true, :proxy_url => proxy}
+    refspecs = ['+refs/*:refs/*']
 
     results = nil
 


### PR DESCRIPTION
This reverts commit c582010a1f4f7f40a3888b26e8c8360589219350 and the subsequent tweak commit 9f9432b779e3ab769a2b65fb4d33f222c351669c, which prevented fetching refs such as `refs/pull/*`, which may be used in a `Puppetfile` for testing pull requests of modules. The commit message of c582010a1f4f7f40a3888b26e8c8360589219350 makes it sound like the change only applies to control repos, but it in fact applies to any git repository used in a `Puppetfile`.