### PR TITLE
Relax colored2 dependency

### DIFF
--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.license  = 'Apache-2.0'
 
-  s.add_dependency 'colored2', '~> 4.0'
+  s.add_dependency 'colored2', '>= 3.1.2', '< 5'
   s.add_dependency 'cri', '>= 2.15.10'
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'


### PR DESCRIPTION
It was bumped to ~> 4.0, but version 3.1.2 is still usable, so better
set the old version as lower bound and future major version as upper
bound.
