### PR TITLE
(maint) Support beaker 6

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -12,7 +12,7 @@ end
 
 gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 6')
 gem 'beaker-pe', '~> 3.6'
-gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1.1')
+gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 2')
 gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 1.0')
-gem 'rototiller', '= 1.0'
+gem 'rototiller', '~> 1'
 gem 'beaker-qa-i18n'

--- a/integration/pre-suite/10_git_config.rb
+++ b/integration/pre-suite/10_git_config.rb
@@ -34,7 +34,7 @@ on(master, puppet("module install  puppetlabs-git --modulepath #{@module_path}")
 
 step 'Install and Configure Git'
 on(master, puppet('apply'), :stdin => git_manifest, :acceptable_exit_codes => [0,2]) do |result|
-  assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+  refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
 end
 on(master, 'git config --system --add safe.directory "*"')
 

--- a/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_with_ssh.rb
@@ -103,7 +103,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
+++ b/integration/tests/basic_functionality/rugged_git_provider_without_ssh.rb
@@ -102,7 +102,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/git_source/git_source_git.rb
+++ b/integration/tests/git_source/git_source_git.rb
@@ -119,7 +119,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/git_source/git_source_ssh.rb
+++ b/integration/tests/git_source/git_source_ssh.rb
@@ -81,7 +81,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/git_source/git_source_submodule.rb
+++ b/integration/tests/git_source/git_source_submodule.rb
@@ -63,7 +63,7 @@ agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 1) do |result|
     expect_failure('Expected to fail due to RK-30') do
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
     end
   end

--- a/integration/tests/i18n/deploy_module_with_unicode_in_file_name.rb
+++ b/integration/tests/i18n/deploy_module_with_unicode_in_file_name.rb
@@ -57,7 +57,7 @@ test_i18n_strings(10, [:syntax, :white_space]) do |test_string|
   agents.each do |agent|
     step "Run Puppet Agent"
     on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
     end
   end

--- a/integration/tests/user_scenario/basic_workflow/multi_env_1000_branches.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_1000_branches.rb
@@ -59,7 +59,7 @@ env_names.sample(3).each do |env|
   agents.each do |agent|
     step "Run Puppet Agent Against \"#{env}\" Environment"
     on(agent, puppet('agent', '--test', "--environment #{env}"), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(/I am in the #{env} environment/, result.stdout, 'Expected message not found!')
     end
   end

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module.rb
@@ -96,7 +96,7 @@ env_names.each do |env|
   agents.each do |agent|
     step "Run Puppet Agent Against \"#{env}\" Environment"
     on(agent, puppet('agent', '--test', "--environment #{env}"), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(/I am in the #{env} environment/, result.stdout, 'Expected message not found!')
       assert_match(stdlib_notify_message_regex, result.stdout, 'Expected message not found!')
     end

--- a/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_custom_forge_git_module_static.rb
@@ -102,7 +102,7 @@ env_names.each do |env|
   agents.each do |agent|
     step "Run Puppet Agent Against \"#{env}\" Environment"
     on(agent, puppet('agent', '--test', "--environment #{env}"), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(/I am in the #{env} environment/, result.stdout, 'Expected message not found!')
       assert_match(stdlib_notify_message_regex, result.stdout, 'Expected message not found!')
     end

--- a/integration/tests/user_scenario/basic_workflow/multi_env_hiera.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_hiera.rb
@@ -93,7 +93,7 @@ env_names.each do |env|
   agents.each do |agent|
     step "Run Puppet Agent Against \"#{env}\" Environment"
     on(agent, puppet('agent', '--test', "--environment #{env}"), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(/I am in the #{env} environment/, result.stdout, 'Expected message not found!')
     end
   end

--- a/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_env_multi_source.rb
@@ -125,7 +125,7 @@ sources.sample(3).each do |source|
     agents.each do |agent|
       step "Run Puppet Agent Against \"#{env_name}\" Environment"
       on(agent, puppet('agent', '--test', "--environment #{env_name}"), :acceptable_exit_codes => 2) do |result|
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+        refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         assert_match(/I am in the #{env_name} environment/, result.stdout, 'Expected message not found!')
       end
     end

--- a/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/multi_source_custom_forge_git_module.rb
@@ -140,7 +140,7 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step 'Run Puppet Agent Against "production" Environment'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(/I am in the production environment/, result.stdout, 'Expected message not found!')
   end
 
@@ -151,7 +151,7 @@ agents.each do |agent|
 
   step 'Run Puppet Agent Against "stage" Environment'
   on(agent, puppet('agent', '--test', '--environment stage'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(/I am in the stage environment/, result.stdout, 'Expected message not found!')
     assert_match(stdlib_notify_message_regex, result.stdout, 'Expected message not found!')
   end

--- a/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/negative/neg_bad_git_module.rb
@@ -41,5 +41,5 @@ git_add_commit_push(master, 'production', 'Update Puppetfile.', git_environments
 #Tests
 step 'Attempt to Deploy via r10k'
 on(master, "#{r10k_fqp} deploy environment -v -p", :acceptable_exit_codes => 1) do |result|
-  assert_no_match(error_message_regex, result.stderr, 'Expected message not found!')
+  refute_match(error_message_regex, result.stderr, 'Expected message not found!')
 end

--- a/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_10000_files.rb
@@ -69,7 +69,7 @@ on(master, "cd #{prod_env_test_files_path};md5sum -c #{prod_env_checksum_file_pa
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_git_module.rb
@@ -86,7 +86,7 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_forge_module.rb
@@ -67,7 +67,7 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 

--- a/integration/tests/user_scenario/basic_workflow/single_env_custom_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_custom_module.rb
@@ -43,7 +43,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_large_files.rb
@@ -69,7 +69,7 @@ on(master, "cd #{prod_env_test_files_path};md5sum -c #{prod_env_checksum_file_pa
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/user_scenario/basic_workflow/single_env_module_already_installed.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_module_already_installed.rb
@@ -69,7 +69,7 @@ on(master, "#{r10k_fqp} deploy environment -p -v")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify Contents of MOTD Module'

--- a/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_non-existent_base_dir.rb
@@ -88,7 +88,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step "Run Puppet Agent"
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_purge_unmanaged_modules.rb
@@ -65,7 +65,7 @@ on(master, puppet("module install puppetlabs-motd --modulepath #{moduledir}"))
 agents.each do |agent|
   step 'Run Puppet Agent Against "production" Environment'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step "Verify MOTD Contents"

--- a/integration/tests/user_scenario/basic_workflow/single_env_switch_forge_git_module.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_switch_forge_git_module.rb
@@ -80,7 +80,7 @@ on(master, "chmod 644 #{motd_template_path}")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify MOTD Contents for Forge Version of Module'
@@ -104,7 +104,7 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify MOTD Contents for Git Version of Module'

--- a/integration/tests/user_scenario/basic_workflow/single_env_upgrade_forge_mod_revert_change.rb
+++ b/integration/tests/user_scenario/basic_workflow/single_env_upgrade_forge_mod_revert_change.rb
@@ -83,7 +83,7 @@ on(master, "chmod 644 #{motd_template_path}")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify MOTD Contents for Forge Version of Module'
@@ -115,7 +115,7 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify MOTD Contents for New Version of Module'
@@ -148,7 +148,7 @@ on(master, "chmod 644 #{motd_template_path}")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify MOTD Contents for Old Version of Module'

--- a/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_add_change_remove.rb
@@ -97,7 +97,7 @@ initial_env_names.each do |env|
   agents.each do |agent|
     step "Run Puppet Agent Against \"#{env}\" Environment"
     on(agent, puppet('agent', '--test', "--environment #{env}"), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(/I am in the #{env} environment/, result.stdout, 'Expected message not found!')
     end
   end
@@ -132,13 +132,13 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step 'Run Puppet Agent Against "production" Environment'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(prod_env_notify_message_regex, result.stdout, 'Expected message not found!')
   end
 
   step 'Run Puppet Agent Against "temp" Environment'
   on(agent, puppet('agent', '--test', '--environment temp'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(test_env_notify_message_regex, result.stdout, 'Expected message not found!')
   end
 
@@ -149,7 +149,7 @@ agents.each do |agent|
 
   step 'Run Puppet Agent Against "stage" Environment'
   on(agent, puppet('agent', '--test', '--environment stage'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(stage_env_notify_message_regex, result.stdout, 'Expected message not found!')
   end
 

--- a/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_remove_re-add.rb
@@ -59,7 +59,7 @@ initial_env_names.each do |env|
   agents.each do |agent|
     step "Run Puppet Agent Against \"#{env}\" Environment"
     on(agent, puppet('agent', '--test', "--environment #{env}"), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(/I am in the #{env} environment/, result.stdout, 'Expected message not found!')
     end
   end
@@ -78,7 +78,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step 'Run Puppet Agent Against "production" Environment'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_regex, result.stdout, 'Expected message not found!')
   end
 
@@ -104,7 +104,7 @@ initial_env_names.each do |env|
   agents.each do |agent|
     step "Run Puppet Agent Against \"#{env}\" Environment"
     on(agent, puppet('agent', '--test', "--environment #{env}"), :acceptable_exit_codes => 2) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       assert_match(/I am in the #{env} environment/, result.stdout, 'Expected message not found!')
     end
   end

--- a/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
+++ b/integration/tests/user_scenario/complex_workflow/multi_env_unamanaged.rb
@@ -49,7 +49,7 @@ on(master, "#{r10k_fqp} deploy environment -v")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_prod_env_regex, result.stdout, 'Expected message not found!')
   end
 end
@@ -60,7 +60,7 @@ on(master, "cp -r #{environment_path}/production #{environment_path}/test")
 agents.each do |agent|
   step 'Run Puppet Agent Against "test" Environment'
   on(agent, puppet('agent', '--test', '--environment test'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_message_test_env_regex, result.stdout, 'Expected message not found!')
   end
 end

--- a/integration/tests/user_scenario/complex_workflow/single_env_git_module_update.rb
+++ b/integration/tests/user_scenario/complex_workflow/single_env_git_module_update.rb
@@ -78,7 +78,7 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_original_message_regex, result.stdout, 'Expected message not found!')
   end
 end
@@ -94,7 +94,7 @@ on(master, "#{r10k_fqp} deploy environment -v -p")
 agents.each do |agent|
   step 'Run Puppet Agent'
   on(agent, puppet('agent', '--test', '--environment production'), :acceptable_exit_codes => 2) do |result|
-    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    refute_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     assert_match(notify_updated_message_regex, result.stdout, 'Expected message not found!')
   end
 end


### PR DESCRIPTION
We previously updated to Beaker 6 but doing so requires additional dependency updates and updates for changes to the assert DSL.

We update beaker-hostgenerator because beaker has a direct dependnecy on it. The newer Rubies that beaker 6 enables require a newer rake which rototiller didn't like. Upgrading beaker-hostgenerator to 2.x and rototiller to 1.0.1+ allowed running beaker 6 on ruby 3.2.

The only test changes were the transition from assert_no_match -> refute_match.

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
