### PR TITLE
(PE-43589) Bump puppet_forge dependency >= 6.1.0

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,11 @@ CHANGELOG
 Unreleased
 ----------
 
+5.0.3
+-----
+
+- Require puppet_forge >= 6.1.0 to pull in Windows long path fix [PE-43589](https://perforce.atlassian.net/browse/PE-43589)
+
 5.0.2
 -----
 

--- a/lib/r10k/version.rb
+++ b/lib/r10k/version.rb
@@ -2,5 +2,5 @@ module R10K
   # When updating to a new major (X) or minor (Y) version, include `#major` or
   # `#minor` (respectively) in your commit message to trigger the appropriate
   # release. Otherwise, a new patch (Z) version will be released.
-  VERSION = '5.0.2'
+  VERSION = '5.0.3'
 end

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cri', '>= 2.15.10'
   s.add_dependency 'log4r',     '1.1.10'
   s.add_dependency 'multi_json', '~> 1.10'
-  s.add_dependency 'puppet_forge', '>= 4.1.0', '< 7'
+  s.add_dependency 'puppet_forge', '>= 6.1.0', '< 7'
   s.add_dependency 'gettext-setup', '>=0.24', '<2.0'
   s.add_dependency 'jwt', '>= 2.2.3', '< 3'
   s.add_dependency 'minitar', '>= 0.9', '< 2'


### PR DESCRIPTION
# Summary

Bumps the `puppet_forge` gem dependency floor to `>= 6.1.0` and releases r10k `5.0.3` to propagate the Windows long path fix downstream to consumers like `bolt`.

# Detailed Description

* `r10k.gemspec`
  * Raised the `puppet_forge` lower bound from `>= 4.1.0` to `>= 6.1.0`. The `puppet_forge` 6.1.0 release replaced `Dir[]` with `Find.find`, fixing a Windows long path error encountered when `bolt` installs modules with deeply nested folder structures.
* `lib/r10k/version.rb`
  * Bumped version from `5.0.2` to `5.0.3` (patch release) to cut a new gem that carries the updated dependency constraint.
* `CHANGELOG.mkd`
  * Added `5.0.3` entry.