### PR TITLE
(PE-44135) Update minimum version of jwt to resolve CVE-2026-45363

### DIFF
--- a/CHANGELOG.mkd
+++ b/CHANGELOG.mkd
@@ -4,6 +4,8 @@ CHANGELOG
 Unreleased
 ----------
 
+- Update minimum version of jwt to 2.10.3 to resolve CVE-2026-45363 [PE-44135](https://perforce.atlassian.net/browse/PE-44135)
+
 5.0.3
 -----
 

--- a/r10k.gemspec
+++ b/r10k.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json', '~> 1.10'
   s.add_dependency 'puppet_forge', '>= 6.1.0', '< 7'
   s.add_dependency 'gettext-setup', '>=0.24', '<2.0'
-  s.add_dependency 'jwt', '>= 2.2.3', '< 3'
+  s.add_dependency 'jwt', '>= 2.10.3', '< 3'
   s.add_dependency 'minitar', '>= 0.9', '< 2'
 
   s.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
Updates the minimum version of jwt to 2.10.3 to resolve CVE-2026-45363

Please add all notable changes to the "Unreleased" section of the CHANGELOG in the format:
```
- (JIRA ticket) Summary of changes. [Issue or PR #](link to issue or PR)
```
