### PR TITLE
(maint) Fix location_for to parse SSH-style git URLs in integration Gemfile

### DIFF
--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
 
 def location_for(place, fake_version = nil)
-  if place =~ /^(git:[^#]*)#(.*)/
+  if place =~ /^(git[:@][^#]*)#(.*)/
     [fake_version, { :git => $1, :branch => $2, :require => false }].compact
   elsif place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]


### PR DESCRIPTION
## Summary

The `location_for` helper in `integration/Gemfile` only matched `git:` scheme URLs (`/^(git:[^#]*)#(.*)/`). An SSH shorthand value like `git@github.com:puppetlabs/beaker-hostgenerator-private.git#master` — passed via env vars such as `BEAKER_HOSTGENERATOR_VERSION` — did not match, fell through to the `else` branch, and was handed to Bundler as a version requirement, failing with:

```
[!] There was an error parsing `Gemfile`: Illformed requirement
["git@github.com:puppetlabs/beaker-hostgenerator-private.git#master"]. Bundler cannot continue.
```

This broke the `pe-r10k-vanagon` integration/acceptance suite at the `suite-prepare-matrix` stage (`bundle install` in `integration/`).

## Fix

Broaden the regex character class to `[:@]` so both `git:` and `git@` forms are recognized and split into `git`/`branch` options.

```ruby
-  if place =~ /^(git:[^#]*)#(.*)/
+  if place =~ /^(git[:@][^#]*)#(.*)/
```

## Verification

- `ruby -c integration/Gemfile` → Syntax OK
- `git@github.com:puppetlabs/beaker-hostgenerator-private.git#master` → `{git: "git@…", branch: "master"}`
- `~> 2` (plain version) → `["~> 2", {require: false}]` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)