### PR TITLE
(maint) Fix invalid r10k yaml integration test for Ruby 3.4+ error wording

### DIFF
--- a/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
+++ b/integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb
@@ -28,7 +28,18 @@ CONF
 if get_puppet_version(master) < 4.0
   error_message_regex = /ERROR.*can\'t\ convert\ nil\ into\ String/
 else
-  error_message_regex = /ERROR.* -> no implicit conversion of nil into String/
+  # The wording of the TypeError raised when a nil is passed to Pathname.new
+  # depends on the Ruby that puppet-agent bundles (which r10k runs under), not
+  # the Puppet version. Ruby 3.4+ (shipped as of Puppet 9 / PE 2026) raises
+  # "Pathname.new requires a String, #to_path or #to_str"; older Ruby raised
+  # "no implicit conversion of nil into String".
+  ruby_fqp = File.join(File.dirname(r10k_fqp), 'ruby')
+  ruby_version = on(master, "#{ruby_fqp} -e 'print RUBY_VERSION'").stdout.strip
+  if Gem::Version.new(ruby_version) >= Gem::Version.new('3.4.0')
+    error_message_regex = /ERROR.* -> Pathname\.new requires a String/
+  else
+    error_message_regex = /ERROR.* -> no implicit conversion of nil into String/
+  end
 end
 
 #Teardown


### PR DESCRIPTION
## Problem

The beaker integration test `integration/tests/basic_functionality/negative/neg_deploy_with_invalid_r10k_yaml.rb` is failing on `main` in Jenkins runs using Ruby 4 ([example](https://jenkins-enterprise.delivery.puppetlabs.net/view/r10k/view/main/job/enterprise_pe-r10k-vanagon_pkg-int-sys-testing_main/64/)).

This is a negative test: it feeds r10k an invalid config and asserts r10k errors out. r10k **still errors correctly** (exits 1) — the test failed purely because the assertion regex was pinned to an old Ruby error string:

```
Expected /ERROR.* -> no implicit conversion of nil into String/ to match
"ERROR\t -> Pathname.new requires a String, #to_path or #to_str\n".
```

## Root cause

The `TypeError` message Ruby raises when a `nil` is passed to `Pathname.new` changed in Ruby 3.4+, which ships with puppet-agent as of Puppet 9 / PE 2026:

- **Older Ruby:** `no implicit conversion of nil into String`
- **Ruby 3.4+:** `Pathname.new requires a String, #to_path or #to_str`

Note the test branches on `get_puppet_version`, but this message is driven by the bundled **Ruby** version, not Puppet itself.

## Fix

Broaden the `>= 4.0` assertion regex to accept both wordings so the test passes on both older Ruby and Ruby 4. Verified the regex matches both exact strings.