### PR TITLE
(PE-45753) Disable puppet agent service in r10k pre-suite to fix lock-race flakes

### DIFF
--- a/integration/pre-suite/20_pe_r10k.rb
+++ b/integration/pre-suite/20_pe_r10k.rb
@@ -53,3 +53,12 @@ restart_puppet_server(master)
 
 step 'Run Puppet Agent on All Nodes'
 on(agents, puppet('agent', '--test', '--environment production'))
+
+# The production run above applies the PE agent profile, which re-enables and
+# restarts Service[puppet]. Its daemonized periodic runs then race the explicit
+# `puppet agent --test` invocations in the test suite and intermittently fail
+# them with "Run of Puppet configuration client already in progress; skipping
+# (agent_catalog_run.lock exists)". The test environments are custom (no PE
+# profile), so nothing re-enables the service once it is disabled here.
+step 'Stop and disable the puppet agent service to avoid catalog-run lock races'
+on(hosts, puppet('resource', 'service', 'puppet', 'ensure=stopped', 'enable=false'))


### PR DESCRIPTION
## Problem

The PE `pe-r10k-vanagon` `pkg-int-sys-testing` acceptance gates (main / 2025.12.x / 2023.8.x) are chronically red — but from a **flaky harness race, not an r10k regression**. A *different random cell and a different test file* fail each build, always with:

```
puppet agent --test  ->  exited 1
Notice: Run of Puppet configuration client already in progress; skipping
        (/opt/puppetlabs/puppet/cache/state/agent_catalog_run.lock exists)
```

Observed across 6 distinct cells / 6 distinct test files (`multi_env_remove_re-add`, `multi_env_unamanaged`, `multi_env_1000_branches`, `i18n/deploy_module_with_unicode_in_file_name`, `single_env_non-existent_base_dir`, `multi_env_add_change_remove`).

## Root cause

1. `pre-suite/00_pe_install.rb` stops the agent service (`ensure=stopped`) — but does **not** disable it.
2. `pre-suite/20_pe_r10k.rb`'s final step runs `puppet agent --test --environment production` on all nodes; that PE production catalog re-enables and **restarts** `Service[puppet]`.
3. During the tests, the daemonized agent's periodic background run holds `agent_catalog_run.lock` when a test fires its own `puppet agent --test` — puppet correctly refuses to run two catalog applies at once, and the test errors on the unexpected exit code.

This is a genuine concurrent (live) lock, not a stale one — so removing the source of the background run is the fix.

## Fix

After the pre-suite production run, stop **and disable** the agent service so only the suite's explicit foreground `puppet agent --test` calls run. The test environments are custom (`helloworld`, no PE profile), so nothing re-enables the service for the remainder of the suite.

```ruby
step 'Stop and disable the puppet agent service to avoid catalog-run lock races'
on(hosts, puppet('resource', 'service', 'puppet', 'ensure=stopped', 'enable=false'))
```

(No manual lockfile deletion — puppet removes its own run lock on normal completion; the fix is simply to remove the competing background run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)